### PR TITLE
Script now supports Debian/Ubuntu, Arch, Fedora, CentOS/RHEL and OpenSUSE based distos

### DIFF
--- a/install_packages.sh
+++ b/install_packages.sh
@@ -31,8 +31,21 @@ else
     exit 1
 fi
 
-
+    
 # install the all the necessery packages and requirements
-sudo pip3 install --upgrade setuptools
-sudo pip3 install -r requirements.txt
+echo ''
+echo ''
+while true; do
+    echo 'Do you want dependencies to be installed globally (or locally) [Y/n]?'
+    read ans
+    if [[ ${#ans} -eq 0 || $ans = "Y" || $ans = "y" ]]; then
+        sudo pip3 install --upgrade setuptools
+        sudo pip3 install -r requirements.txt
+    elif [[ $ans = "N" || $ans = "n" ]]; then
+        sudo pip3 install --user --upgrade setuptools
+        sudo pip3 install --user -r requirements.txt
+    fi
+
+    [[ ${#ans} -eq 0 || $ans = "Y" || $ans = "y" || $ans = "N" || $ans = "n" ]] && break;
+done
 


### PR DESCRIPTION
As requested on #87, now the script know which package manager the system uses.
I checked it on Debian/Ubuntu. Please, let me know if something is wrong on other distos.