### PR TITLE
Use compound if statement rather than "if and"

### DIFF
--- a/sherlock.py
+++ b/sherlock.py
@@ -320,7 +320,7 @@ def sherlock(username, site_data, verbose=False, tor=False, unique_tor=False, pr
             # match the request.  Instead, we will ensure that the response
             # code indicates that the request was successful (i.e. no 404, or
             # forward to some odd redirect).
-            if (r.status_code >= 200) and (r.status_code < 300):
+            if 200 <= r.status_code < 300:
                 #
                 print_found(social_network, url, response_time, verbose)
                 exists = "yes"


### PR DESCRIPTION
This approach is a bit strange to read the first few time but has advantages in that it is easier to get right and faster to execute.

The interactions between `and`, `or`, `not`, and `()` can get confusing for new coders.  For example, just a few lines above this PR's changes the code line 308 does not match the comment on 307 and I believe that in this case the comment correct and the code is wrong (for values < 200) because it is missing parens.  I believe that __200 <= status_code < 300__ produces the correct results in a readable (semi-)intuitive code.
```
>>> for status_code in (-1, 1, 199, 200, 201, 299, 300, 301, 1000):
...     print(not status_code >= 300 or status_code < 200,
...           not (status_code >= 300 or status_code < 200),
...           200 <= status_code < 300)
...
True False False
True False False
True False False
True True True
True True True
True True True
False False False
False False False
False False False
```