### PR TITLE
Label the Docker image with some VCS repository information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,9 @@ RUN pip3 install -r requirements.txt -f /wheels \
   && rm -rf /wheels \
   && rm -rf /root/.cache/pip/*
 
+ARG VCS_REF
+ARG VCS_URL="https://github.com/sherlock-project/sherlock"
+LABEL org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL
+
 ENTRYPOINT ["python", "sherlock.py"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 <a target="_blank" href="https://travis-ci.com/TheYahya/sherlock/" title="Build Status"><img src="https://travis-ci.com/TheYahya/sherlock.svg?branch=master"></a>
 <a target="_blank" href="https://twitter.com/intent/tweet?text=%F0%9F%94%8E%20Find%20usernames%20across%20social%20networks%20&url=https://github.com/TheYahya/sherlock&hashtags=hacking,%20osint,%20bugbounty,%20reconnaissance" title="Share on Tweeter"><img src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social"></a>
 <a target="_blank" href="http://sherlock-project.github.io/"><img alt="Website" src="https://img.shields.io/website-up-down-green-red/http/sherlock-project.github.io/..svg"></a>
+<a target="_blank" href="https://microbadger.com/images/theyahya/sherlock"><img alt="docker image" src="https://images.microbadger.com/badges/version/theyahya/sherlock.svg"></a>
 </p>
 <p align="center">
 <a href="https://asciinema.org/a/223115">


### PR DESCRIPTION
Heya, 

To link the of the image published on Docker Hub with the git revision I've introduced some labels in the image. This should help identifying  mismatches between container and repository versions faster like in the case of #175.

### What has been done:
- Added build-args that will be transformed into labels
- Added a badge to the readme where you can [view details of the latest docker image](https://microbadger.com/images/theyahya/sherlock).

### How to test:
- Build image with `docker build -t mysherlock-image . --build-arg VCS_REF=$(git rev-parse HEAD)`
- Acknowledge that `docker image inspect mysherlock-image` will show the labels
- Build the image without the build-arg, notice that it does not break the build.

Let me know if you want anything changed. Thank you for the awesome project 😄 