### PR TITLE
Prevent copying of venv folder in the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .vscode/
 *.txt
 !/requirements.txt
+venv/

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 *.txt
 !/requirements.txt
 venv/
+


### PR DESCRIPTION
After diving into the current image I noticed that the `venv` was copied in there. This PR should prevent that from happing in future builds.

### What has been done:
- added venv folder to the .dockerignore

### Notes:
- I also noticed that the current image on docker hub has a layer for `RUN /sbin/apk add tor`. Is this supposed to be there? Maybe we can rebuild the image to reflect the Dockerfile in the repository. 