### PR TITLE
Add hub.docker.com

### DIFF
--- a/data.json
+++ b/data.json
@@ -294,8 +294,9 @@
   "Docker Hub": {
     "errorType": "status_code",
     "rank": 1905,
-    "url": "https://hub.docker.com/v2/users/{}/",
+    "url": "https://hub.docker.com/u/{}/",
     "urlMain": "https://hub.docker.com/",
+    "urlProbe": "https://hub.docker.com/v2/users/{}/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },

--- a/data.json
+++ b/data.json
@@ -291,6 +291,14 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Docker Hub": {
+    "errorType": "status_code",
+    "rank": 1905,
+    "url": "https://hub.docker.com/v2/users/{}/",
+    "urlMain": "https://hub.docker.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Dribbble": {
     "errorMsg": "Whoops, that page is gone.",
     "errorType": "message",


### PR DESCRIPTION
Heya,

This PR should add Docker Hub to the searchable websites. Using the hints you provided with a separate `urlProbe`. 

### How to test:
1. Checkout PR branch
1. Run `python3 sherlock.py nstapelbroek --site Docker\ Hub`
1. Acknowledge result

Thanks!