### PR TITLE
Fixed KeyError (Issue #205)

### DIFF
--- a/sherlock.py
+++ b/sherlock.py
@@ -84,7 +84,7 @@ def print_error(err, errstr, var, verbose=False):
           Fore.RED + "-" +
           Fore.WHITE + "]" +
           Fore.RED + f" {errstr}" +
-          Fore.WHITE + f" {var}")
+          Fore.WHITE + f" {err if verbose else var}")
 
 
 def format_response_time(response_time, verbose):

--- a/sherlock.py
+++ b/sherlock.py
@@ -84,7 +84,7 @@ def print_error(err, errstr, var, verbose=False):
           Fore.RED + "-" +
           Fore.WHITE + "]" +
           Fore.RED + f" {errstr}" +
-          Fore.WHITE + f" {err if verbose else var}")
+          Fore.YELLOW + f" {err if verbose else var}")
 
 
 def format_response_time(response_time, verbose):

--- a/sherlock.py
+++ b/sherlock.py
@@ -83,8 +83,8 @@ def print_error(err, errstr, var, verbose=False):
     print(Style.BRIGHT + Fore.WHITE + "[" +
           Fore.RED + "-" +
           Fore.WHITE + "]" +
-          Fore.RED + " {errstr}" +
-          Fore.YELLOW + " {err if verbose else var}")
+          Fore.RED + f" {errstr}" +
+          Fore.WHITE + f" {var}")
 
 
 def format_response_time(response_time, verbose):
@@ -111,8 +111,8 @@ def print_invalid(social_network, msg):
     print((Style.BRIGHT + Fore.WHITE + "[" +
            Fore.RED + "-" +
            Fore.WHITE + "]" +
-           Fore.GREEN + " {}:" +
-           Fore.YELLOW + " {msg}").format(social_network))
+           Fore.GREEN + f" {social_network}:" +
+           Fore.YELLOW + f" {msg}"))
 
 
 def get_response(request_future, error_type, social_network, verbose=False, retry_no=None):


### PR DESCRIPTION
Fixed `KeyError 'msg'` by using formatted strings in the **print_error** function additionally providing  better readability. <br/>
Furthermore changed **print_invalid** function to display the error and affected social network ( e.g. ``[-] Error Connecting: Instagram`` ) network instead of just showing `[-] {errstr} {err if verbose else var}`. If ``--verbose`` argument is parsed the **print_invalid** function prints the complete error.

Disclaimer:
This is my first pull request so hopefully I did everything correctly :)