### PR TITLE
Fix Broken Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ usage: sherlock.py [-h] [--version] [--verbose] [--rank]
                    [--proxy PROXY_URL] [--json JSON_FILE]
                    USERNAMES [USERNAMES ...]
 
-Sherlock: Find Usernames Across Social Networks (Version 0.6.2)
+Sherlock: Find Usernames Across Social Networks (Version 0.6.3)
 
 positional arguments:
   USERNAMES             One or more usernames to check with social networks.

--- a/data.json
+++ b/data.json
@@ -792,8 +792,7 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Reddit": {
-    "errorMsg": "page not found",
-    "errorType": "message",
+    "errorType": "status_code",
     "rank": 24,
     "url": "https://www.reddit.com/user/{}",
     "urlMain": "https://www.reddit.com/",

--- a/data.json
+++ b/data.json
@@ -372,8 +372,7 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Flipboard": {
-    "errorMsg": "loading...",
-    "errorType": "message",
+    "errorType": "status_code",
     "rank": 3859,
     "regexCheck": "^([a-zA-Z0-9_]){1,15}$",
     "url": "https://flipboard.com/@{}",

--- a/data.json
+++ b/data.json
@@ -2,7 +2,7 @@
   "500px": {
     "errorMsg": "Oops! This page doesn\u2019t exist.",
     "errorType": "message",
-    "rank": 3219,
+    "rank": 3235,
     "url": "https://500px.com/{}",
     "urlMain": "https://500px.com/",
     "username_claimed": "blue",
@@ -10,7 +10,7 @@
   },
   "9GAG": {
     "errorType": "status_code",
-    "rank": 319,
+    "rank": 315,
     "url": "https://9gag.com/u/{}",
     "urlMain": "https://9gag.com/",
     "username_claimed": "blue",
@@ -18,7 +18,7 @@
   },
   "About.me": {
     "errorType": "status_code",
-    "rank": 13992,
+    "rank": 14071,
     "url": "https://about.me/{}",
     "urlMain": "https://about.me/",
     "username_claimed": "blue",
@@ -26,7 +26,7 @@
   },
   "Academia.edu": {
     "errorType": "status_code",
-    "rank": 169,
+    "rank": 170,
     "url": "https://independent.academia.edu/{}",
     "urlMain": "https://www.academia.edu/",
     "username_claimed": "blue",
@@ -34,7 +34,7 @@
   },
   "AngelList": {
     "errorType": "status_code",
-    "rank": 3414,
+    "rank": 3379,
     "url": "https://angel.co/{}",
     "urlMain": "https://angel.co/",
     "username_claimed": "blue",
@@ -42,7 +42,7 @@
   },
   "Aptoide": {
     "errorType": "status_code",
-    "rank": 5265,
+    "rank": 5219,
     "url": "https://{}.en.aptoide.com/",
     "urlMain": "https://en.aptoide.com/",
     "username_claimed": "blue",
@@ -50,7 +50,7 @@
   },
   "AskFM": {
     "errorType": "status_code",
-    "rank": 1099,
+    "rank": 1118,
     "url": "https://ask.fm/{}",
     "urlMain": "https://ask.fm/",
     "username_claimed": "blue",
@@ -58,7 +58,7 @@
   },
   "BLIP.fm": {
     "errorType": "status_code",
-    "rank": 410341,
+    "rank": 393052,
     "url": "https://blip.fm/{}",
     "urlMain": "https://blip.fm/",
     "username_claimed": "blue",
@@ -66,7 +66,7 @@
   },
   "Badoo": {
     "errorType": "status_code",
-    "rank": 1237,
+    "rank": 1249,
     "url": "https://badoo.com/profile/{}",
     "urlMain": "https://badoo.com/",
     "username_claimed": "blue",
@@ -74,7 +74,7 @@
   },
   "Bandcamp": {
     "errorType": "status_code",
-    "rank": 585,
+    "rank": 592,
     "url": "https://www.bandcamp.com/{}",
     "urlMain": "https://www.bandcamp.com/",
     "username_claimed": "blue",
@@ -83,7 +83,7 @@
   "Basecamp": {
     "errorMsg": "The account you were looking for doesn't exist",
     "errorType": "message",
-    "rank": 1825,
+    "rank": 1827,
     "url": "https://{}.basecamphq.com",
     "urlMain": "https://basecamp.com/",
     "username_claimed": "blue",
@@ -91,7 +91,7 @@
   },
   "Behance": {
     "errorType": "status_code",
-    "rank": 398,
+    "rank": 394,
     "url": "https://www.behance.net/{}",
     "urlMain": "https://www.behance.net/",
     "username_claimed": "blue",
@@ -99,7 +99,7 @@
   },
   "BitBucket": {
     "errorType": "status_code",
-    "rank": 988,
+    "rank": 992,
     "url": "https://bitbucket.org/{}/",
     "urlMain": "https://bitbucket.org/",
     "username_claimed": "blue",
@@ -108,7 +108,7 @@
   "BitCoinForum": {
     "errorMsg": "The user whose profile you are trying to view does not exist.",
     "errorType": "message",
-    "rank": 407308,
+    "rank": 421587,
     "url": "https://bitcoinforum.com/profile/{}",
     "urlMain": "https://bitcoinforum.com",
     "username_claimed": "bitcoinforum.com",
@@ -116,7 +116,7 @@
   },
   "Blogger": {
     "errorType": "status_code",
-    "rank": 220,
+    "rank": 217,
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://{}.blogspot.com",
     "urlMain": "https://www.blogger.com/",
@@ -125,7 +125,7 @@
   },
   "BuzzFeed": {
     "errorType": "status_code",
-    "rank": 281,
+    "rank": 279,
     "url": "https://buzzfeed.com/{}",
     "urlMain": "https://buzzfeed.com/",
     "username_claimed": "blue",
@@ -134,7 +134,7 @@
   "Canva": {
     "errorType": "response_url",
     "errorUrl": "https://www.canva.com/{}",
-    "rank": 186,
+    "rank": 184,
     "url": "https://www.canva.com/{}",
     "urlMain": "https://www.canva.com/",
     "username_claimed": "blue",
@@ -143,7 +143,7 @@
   "Carbonmade": {
     "errorType": "response_url",
     "errorUrl": "https://carbonmade.com/fourohfour?domain={}.carbonmade.com",
-    "rank": 29773,
+    "rank": 29687,
     "url": "https://{}.carbonmade.com",
     "urlMain": "https://carbonmade.com/",
     "username_claimed": "jenny",
@@ -151,7 +151,7 @@
   },
   "CashMe": {
     "errorType": "status_code",
-    "rank": 86432,
+    "rank": 109883,
     "url": "https://cash.me/{}",
     "urlMain": "https://cash.me/",
     "username_claimed": "jenny",
@@ -159,7 +159,7 @@
   },
   "Cloob": {
     "errorType": "status_code",
-    "rank": 9716,
+    "rank": 9822,
     "url": "https://www.cloob.com/name/{}",
     "urlMain": "https://www.cloob.com/",
     "username_claimed": "blue",
@@ -167,7 +167,7 @@
   },
   "Codecademy": {
     "errorType": "status_code",
-    "rank": 2815,
+    "rank": 2857,
     "url": "https://www.codecademy.com/{}",
     "urlMain": "https://www.codecademy.com/",
     "username_claimed": "blue",
@@ -175,7 +175,7 @@
   },
   "Codementor": {
     "errorType": "status_code",
-    "rank": 8412,
+    "rank": 8538,
     "url": "https://www.codementor.io/{}",
     "urlMain": "https://www.codementor.io/",
     "username_claimed": "blue",
@@ -183,7 +183,7 @@
   },
   "Codepen": {
     "errorType": "status_code",
-    "rank": 810,
+    "rank": 821,
     "url": "https://codepen.io/{}",
     "urlMain": "https://codepen.io/",
     "username_claimed": "blue",
@@ -192,7 +192,7 @@
   "Coderwall": {
     "errorMsg": "404! Our feels when that url is used",
     "errorType": "message",
-    "rank": 10302,
+    "rank": 10269,
     "url": "https://coderwall.com/{}",
     "urlMain": "https://coderwall.com/",
     "username_claimed": "jenny",
@@ -200,7 +200,7 @@
   },
   "ColourLovers": {
     "errorType": "status_code",
-    "rank": 30649,
+    "rank": 31343,
     "url": "https://www.colourlovers.com/lover/{}",
     "urlMain": "https://www.colourlovers.com/",
     "username_claimed": "blue",
@@ -209,7 +209,7 @@
   "Contently": {
     "errorMsg": "We can't find that page!",
     "errorType": "message",
-    "rank": 62423,
+    "rank": 62376,
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://{}.contently.com/",
     "urlMain": "https://contently.com/",
@@ -218,7 +218,7 @@
   },
   "Coroflot": {
     "errorType": "status_code",
-    "rank": 38865,
+    "rank": 39167,
     "url": "https://www.coroflot.com/{}",
     "urlMain": "https://coroflot.com/",
     "username_claimed": "blue",
@@ -227,7 +227,7 @@
   "CreativeMarket": {
     "errorType": "response_url",
     "errorUrl": "https://www.creativemarket.com/",
-    "rank": 2108,
+    "rank": 2115,
     "url": "https://creativemarket.com/{}",
     "urlMain": "https://creativemarket.com/",
     "username_claimed": "blue",
@@ -235,7 +235,7 @@
   },
   "Crevado": {
     "errorType": "status_code",
-    "rank": 194039,
+    "rank": 197752,
     "url": "https://{}.crevado.com",
     "urlMain": "https://crevado.com/",
     "username_claimed": "blue",
@@ -243,7 +243,7 @@
   },
   "Crunchyroll": {
     "errorType": "status_code",
-    "rank": 420,
+    "rank": 407,
     "url": "https://www.crunchyroll.com/user/{}",
     "urlMain": "https://www.crunchyroll.com/",
     "username_claimed": "blue",
@@ -251,7 +251,7 @@
   },
   "DEV Community": {
     "errorType": "status_code",
-    "rank": 5838,
+    "rank": 5671,
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://dev.to/{}",
     "urlMain": "https://dev.to/",
@@ -260,7 +260,7 @@
   },
   "DailyMotion": {
     "errorType": "status_code",
-    "rank": 118,
+    "rank": 120,
     "url": "https://www.dailymotion.com/{}",
     "urlMain": "https://www.dailymotion.com/",
     "username_claimed": "blue",
@@ -268,7 +268,7 @@
   },
   "Designspiration": {
     "errorType": "status_code",
-    "rank": 24522,
+    "rank": 24721,
     "url": "https://www.designspiration.net/{}/",
     "urlMain": "https://www.designspiration.net/",
     "username_claimed": "blue",
@@ -276,7 +276,7 @@
   },
   "DeviantART": {
     "errorType": "status_code",
-    "rank": 234,
+    "rank": 231,
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://{}.deviantart.com",
     "urlMain": "https://deviantart.com",
@@ -285,7 +285,7 @@
   },
   "Disqus": {
     "errorType": "status_code",
-    "rank": 1336,
+    "rank": 1346,
     "url": "https://disqus.com/{}",
     "urlMain": "https://disqus.com/",
     "username_claimed": "blue",
@@ -303,7 +303,7 @@
   "Dribbble": {
     "errorMsg": "Whoops, that page is gone.",
     "errorType": "message",
-    "rank": 955,
+    "rank": 973,
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://dribbble.com/{}",
     "urlMain": "https://dribbble.com/",
@@ -313,7 +313,7 @@
   "EVE Online": {
     "errorType": "response_url",
     "errorUrl": "https://eveonline.com",
-    "rank": 12442,
+    "rank": 12014,
     "url": "https://evewho.com/pilot/{}/",
     "urlMain": "https://eveonline.com",
     "username_claimed": "blue",
@@ -322,7 +322,7 @@
   "Ebay": {
     "errorMsg": "The User ID you entered was not found",
     "errorType": "message",
-    "rank": 50,
+    "rank": 51,
     "url": "https://www.ebay.com/usr/{}",
     "urlMain": "https://www.ebay.com/",
     "username_claimed": "blue",
@@ -331,7 +331,7 @@
   "Ello": {
     "errorMsg": "We couldn't find the page you're looking for",
     "errorType": "message",
-    "rank": 35296,
+    "rank": 36427,
     "url": "https://ello.co/{}",
     "urlMain": "https://ello.co/",
     "username_claimed": "blue",
@@ -339,7 +339,7 @@
   },
   "Etsy": {
     "errorType": "status_code",
-    "rank": 176,
+    "rank": 174,
     "url": "https://www.etsy.com/shop/{}",
     "urlMain": "https://www.etsy.com/",
     "username_claimed": "JennyKrafts",
@@ -348,7 +348,7 @@
   "EyeEm": {
     "errorType": "response_url",
     "errorUrl": "https://www.eyeem.com/",
-    "rank": 29927,
+    "rank": 30451,
     "url": "https://www.eyeem.com/u/{}",
     "urlMain": "https://www.eyeem.com/",
     "username_claimed": "blue",
@@ -363,9 +363,17 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Fandom": {
+    "errorType": "status_code",
+    "rank": 61,
+    "url": "https://www.fandom.com/u/{}",
+    "urlMain": "https://www.fandom.com/",
+    "username_claimed": "Jungypoo",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Flickr": {
     "errorType": "status_code",
-    "rank": 444,
+    "rank": 445,
     "url": "https://www.flickr.com/people/{}",
     "urlMain": "https://www.flickr.com/",
     "username_claimed": "blue",
@@ -373,7 +381,7 @@
   },
   "Flipboard": {
     "errorType": "status_code",
-    "rank": 3859,
+    "rank": 3691,
     "regexCheck": "^([a-zA-Z0-9_]){1,15}$",
     "url": "https://flipboard.com/@{}",
     "urlMain": "https://flipboard.com/",
@@ -382,7 +390,7 @@
   },
   "Foursquare": {
     "errorType": "status_code",
-    "rank": 2093,
+    "rank": 2121,
     "url": "https://foursquare.com/{}",
     "urlMain": "https://foursquare.com/",
     "username_claimed": "dens",
@@ -390,7 +398,7 @@
   },
   "Giphy": {
     "errorType": "status_code",
-    "rank": 529,
+    "rank": 517,
     "url": "https://giphy.com/{}",
     "urlMain": "https://giphy.com/",
     "username_claimed": "blue",
@@ -398,7 +406,7 @@
   },
   "GitHub": {
     "errorType": "status_code",
-    "rank": 48,
+    "rank": 50,
     "regexCheck": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$",
     "url": "https://www.github.com/{}",
     "urlMain": "https://www.github.com/",
@@ -408,7 +416,7 @@
   "GitLab": {
     "errorMsg": "You need to sign in or sign up before continuing.",
     "errorType": "message",
-    "rank": 1875,
+    "rank": 1846,
     "url": "https://gitlab.com/{}",
     "urlMain": "https://gitlab.com/",
     "username_claimed": "blue",
@@ -416,7 +424,7 @@
   },
   "Gitee": {
     "errorType": "status_code",
-    "rank": 2960,
+    "rank": 2946,
     "url": "https://gitee.com/{}",
     "urlMain": "https://gitee.com/",
     "username_claimed": "blue",
@@ -424,7 +432,7 @@
   },
   "GoodReads": {
     "errorType": "status_code",
-    "rank": 396,
+    "rank": 395,
     "url": "https://www.goodreads.com/{}",
     "urlMain": "https://www.goodreads.com/",
     "username_claimed": "blue",
@@ -432,7 +440,7 @@
   },
   "Gravatar": {
     "errorType": "status_code",
-    "rank": 5751,
+    "rank": 5815,
     "url": "http://en.gravatar.com/{}",
     "urlMain": "http://en.gravatar.com/",
     "username_claimed": "blue",
@@ -441,7 +449,7 @@
   "Gumroad": {
     "errorMsg": "Page not found.",
     "errorType": "message",
-    "rank": 3206,
+    "rank": 3172,
     "url": "https://www.gumroad.com/{}",
     "urlMain": "https://www.gumroad.com/",
     "username_claimed": "blue",
@@ -450,7 +458,7 @@
   "HackerNews": {
     "errorMsg": "No such user.",
     "errorType": "message",
-    "rank": 2474,
+    "rank": 2440,
     "url": "https://news.ycombinator.com/user?id={}",
     "urlMain": "https://news.ycombinator.com/",
     "username_claimed": "blue",
@@ -459,7 +467,7 @@
   "HackerOne": {
     "errorMsg": "Page not found",
     "errorType": "message",
-    "rank": 40421,
+    "rank": 41592,
     "url": "https://hackerone.com/{}",
     "urlMain": "https://hackerone.com/",
     "username_claimed": "blue",
@@ -468,7 +476,7 @@
   "House-Mixes.com": {
     "errorMsg": "Profile Not Found",
     "errorType": "message",
-    "rank": 256985,
+    "rank": 277271,
     "url": "https://www.house-mixes.com/profile/{}",
     "urlMain": "https://www.house-mixes.com/",
     "username_claimed": "blue",
@@ -477,7 +485,7 @@
   "Houzz": {
     "errorMsg": "The page you requested was not found.",
     "errorType": "message",
-    "rank": 2534,
+    "rank": 2500,
     "url": "https://houzz.com/user/{}",
     "urlMain": "https://houzz.com/",
     "username_claimed": "blue",
@@ -485,7 +493,7 @@
   },
   "HubPages": {
     "errorType": "status_code",
-    "rank": 9432,
+    "rank": 9609,
     "url": "https://hubpages.com/@{}",
     "urlMain": "https://hubpages.com/",
     "username_claimed": "blue",
@@ -494,7 +502,7 @@
   "IFTTT": {
     "errorMsg": "The requested page or file does not exist",
     "errorType": "message",
-    "rank": 6340,
+    "rank": 6264,
     "url": "https://www.ifttt.com/p/{}",
     "urlMain": "https://www.ifttt.com/",
     "username_claimed": "blue",
@@ -503,7 +511,7 @@
   "ImageShack": {
     "errorType": "response_url",
     "errorUrl": "https://imageshack.us/",
-    "rank": 55786,
+    "rank": 57211,
     "url": "https://imageshack.us/user/{}",
     "urlMain": "https://imageshack.us/",
     "username_claimed": "blue",
@@ -520,7 +528,7 @@
   "Instagram": {
     "errorMsg": "The link you followed may be broken",
     "errorType": "message",
-    "rank": 16,
+    "rank": 15,
     "url": "https://www.instagram.com/{}",
     "urlMain": "https://www.instagram.com/",
     "username_claimed": "blue",
@@ -529,7 +537,7 @@
   "Instructables": {
     "errorMsg": "404: We're sorry, things break sometimes",
     "errorType": "message",
-    "rank": 812,
+    "rank": 820,
     "url": "https://www.instructables.com/member/{}",
     "urlMain": "https://www.instructables.com/",
     "username_claimed": "blue",
@@ -537,7 +545,7 @@
   },
   "Investing.com": {
     "errorType": "status_code",
-    "rank": 487,
+    "rank": 480,
     "url": "https://www.investing.com/traders/{}",
     "urlMain": "https://www.investing.com/",
     "username_claimed": "jenny",
@@ -545,7 +553,7 @@
   },
   "Issuu": {
     "errorType": "status_code",
-    "rank": 627,
+    "rank": 611,
     "url": "https://issuu.com/{}",
     "urlMain": "https://issuu.com/",
     "username_claimed": "jenny",
@@ -553,7 +561,7 @@
   },
   "Itch.io": {
     "errorType": "status_code",
-    "rank": 2048,
+    "rank": 2039,
     "url": "https://{}.itch.io/",
     "urlMain": "https://itch.io/",
     "username_claimed": "blue",
@@ -562,7 +570,7 @@
   "Jimdo": {
     "errorType": "status_code",
     "noPeriod": "True",
-    "rank": 59977,
+    "rank": 58471,
     "url": "https://{}.jimdosite.com",
     "urlMain": "https://jimdosite.com/",
     "username_claimed": "jenny",
@@ -570,7 +578,7 @@
   },
   "Kaggle": {
     "errorType": "status_code",
-    "rank": 2762,
+    "rank": 2794,
     "url": "https://www.kaggle.com/{}",
     "urlMain": "https://www.kaggle.com/",
     "username_claimed": "dansbecker",
@@ -578,7 +586,7 @@
   },
   "KanoWorld": {
     "errorType": "status_code",
-    "rank": 176108,
+    "rank": 178111,
     "url": "https://api.kano.me/progress/user/{}",
     "urlMain": "https://world.kano.me/",
     "username_claimed": "blue",
@@ -586,7 +594,7 @@
   },
   "Keybase": {
     "errorType": "status_code",
-    "rank": 76454,
+    "rank": 75731,
     "url": "https://keybase.io/{}",
     "urlMain": "https://keybase.io/",
     "username_claimed": "blue",
@@ -595,7 +603,7 @@
   "Kik": {
     "errorMsg": "The page you requested was not found",
     "errorType": "message",
-    "rank": 317395,
+    "rank": 318390,
     "url": "https://ws2.kik.com/user/{}",
     "urlMain": "http://kik.me/",
     "username_claimed": "blue",
@@ -604,7 +612,7 @@
   "Kongregate": {
     "errorMsg": "Sorry, no account with that name was found.",
     "errorType": "message",
-    "rank": 2021,
+    "rank": 2040,
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://www.kongregate.com/accounts/{}",
     "urlMain": "https://www.kongregate.com/",
@@ -613,7 +621,7 @@
   },
   "Launchpad": {
     "errorType": "status_code",
-    "rank": 7041,
+    "rank": 7146,
     "url": "https://launchpad.net/~{}",
     "urlMain": "https://launchpad.net/",
     "username_claimed": "blue",
@@ -622,7 +630,7 @@
   "Letterboxd": {
     "errorMsg": "Sorry, we can\u2019t find the page you\u2019ve requested.",
     "errorType": "message",
-    "rank": 3723,
+    "rank": 3717,
     "url": "https://letterboxd.com/{}",
     "urlMain": "https://letterboxd.com/",
     "username_claimed": "blue",
@@ -630,7 +638,7 @@
   },
   "LiveJournal": {
     "errorType": "status_code",
-    "rank": 217,
+    "rank": 218,
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://{}.livejournal.com",
     "urlMain": "https://www.livejournal.com/",
@@ -639,7 +647,7 @@
   },
   "Mastodon": {
     "errorType": "status_code",
-    "rank": 1239916,
+    "rank": 1249864,
     "url": "https://mstdn.io/@{}",
     "urlMain": "https://mstdn.io/",
     "username_claimed": "blue",
@@ -656,7 +664,7 @@
   "MeetMe": {
     "errorType": "response_url",
     "errorUrl": "https://www.meetme.com/",
-    "rank": 18871,
+    "rank": 18888,
     "url": "https://www.meetme.com/{}",
     "urlMain": "https://www.meetme.com/",
     "username_claimed": "blue",
@@ -665,7 +673,7 @@
   "MixCloud": {
     "errorMsg": "Page Not Found",
     "errorType": "message",
-    "rank": 2445,
+    "rank": 2452,
     "url": "https://www.mixcloud.com/{}",
     "urlMain": "https://www.mixcloud.com/",
     "username_claimed": "blue",
@@ -673,7 +681,7 @@
   },
   "MyAnimeList": {
     "errorType": "status_code",
-    "rank": 489,
+    "rank": 487,
     "url": "https://myanimelist.net/profile/{}",
     "urlMain": "https://myanimelist.net/",
     "username_claimed": "blue",
@@ -681,7 +689,7 @@
   },
   "Myspace": {
     "errorType": "status_code",
-    "rank": 4531,
+    "rank": 4576,
     "url": "https://myspace.com/{}",
     "urlMain": "https://myspace.com/",
     "username_claimed": "blue",
@@ -690,7 +698,7 @@
   "NameMC (Minecraft.net skins)": {
     "errorMsg": "Profiles: 0 results",
     "errorType": "message",
-    "rank": 6904,
+    "rank": 6662,
     "url": "https://namemc.com/profile/{}",
     "urlMain": "https://namemc.com/",
     "username_claimed": "blue",
@@ -698,7 +706,7 @@
   },
   "Newgrounds": {
     "errorType": "status_code",
-    "rank": 3392,
+    "rank": 3399,
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://{}.newgrounds.com",
     "urlMain": "https://newgrounds.com",
@@ -708,7 +716,7 @@
   "Pastebin": {
     "errorType": "response_url",
     "errorUrl": "https://pastebin.com/index",
-    "rank": 917,
+    "rank": 927,
     "url": "https://pastebin.com/u/{}",
     "urlMain": "https://pastebin.com/",
     "username_claimed": "blue",
@@ -716,7 +724,7 @@
   },
   "Patreon": {
     "errorType": "status_code",
-    "rank": 266,
+    "rank": 265,
     "url": "https://www.patreon.com/{}",
     "urlMain": "https://www.patreon.com/",
     "username_claimed": "blue",
@@ -725,7 +733,7 @@
   "Pexels": {
     "errorMsg": "Ouch, something went wrong!",
     "errorType": "message",
-    "rank": 662,
+    "rank": 660,
     "url": "https://www.pexels.com/@{}",
     "urlMain": "https://www.pexels.com/",
     "username_claimed": "rawpixel",
@@ -733,7 +741,7 @@
   },
   "Photobucket": {
     "errorType": "status_code",
-    "rank": 3930,
+    "rank": 4004,
     "url": "https://photobucket.com/user/{}/library",
     "urlMain": "https://photobucket.com/",
     "username_claimed": "blue",
@@ -742,7 +750,7 @@
   "Pinterest": {
     "errorType": "response_url",
     "errorUrl": "https://www.pinterest.com/?show_error=true",
-    "rank": 69,
+    "rank": 70,
     "url": "https://www.pinterest.com/{}/",
     "urlMain": "https://www.pinterest.com/",
     "username_claimed": "blue",
@@ -750,7 +758,7 @@
   },
   "Pixabay": {
     "errorType": "status_code",
-    "rank": 428,
+    "rank": 420,
     "url": "https://pixabay.com/en/users/{}",
     "urlMain": "https://pixabay.com/",
     "username_claimed": "blue",
@@ -758,7 +766,7 @@
   },
   "Plug.DJ": {
     "errorType": "status_code",
-    "rank": 30760,
+    "rank": 30428,
     "url": "https://plug.dj/@/{}",
     "urlMain": "https://plug.dj/",
     "username_claimed": "plug-dj-rock",
@@ -767,7 +775,7 @@
   "ProductHunt": {
     "errorMsg": "Product Hunt is a curation of the best new products",
     "errorType": "message",
-    "rank": 3283,
+    "rank": 3217,
     "url": "https://www.producthunt.com/@{}",
     "urlMain": "https://www.producthunt.com/",
     "username_claimed": "jenny",
@@ -776,7 +784,7 @@
   "Quora": {
     "errorType": "response_url",
     "errorUrl": "https://www.quora.com/profile/{}",
-    "rank": 64,
+    "rank": 65,
     "url": "https://www.quora.com/profile/{}",
     "urlMain": "https://www.quora.com/",
     "username_claimed": "Matt-Riggsby",
@@ -785,7 +793,7 @@
   "Rajce.net": {
     "errorMsg": "410",
     "errorType": "message",
-    "rank": 1493,
+    "rank": 1488,
     "url": "https://{}.rajce.idnes.cz/",
     "urlMain": "https://www.rajce.idnes.cz/",
     "username_claimed": "blue",
@@ -802,7 +810,7 @@
   "Repl.it": {
     "errorMsg": "404",
     "errorType": "message",
-    "rank": 6726,
+    "rank": 6744,
     "url": "https://repl.it/@{}",
     "urlMain": "https://repl.it/",
     "username_claimed": "blue",
@@ -811,7 +819,7 @@
   "ReverbNation": {
     "errorMsg": "Sorry, we couldn't find that page",
     "errorType": "message",
-    "rank": 11377,
+    "rank": 11320,
     "url": "https://www.reverbnation.com/{}",
     "urlMain": "https://www.reverbnation.com/",
     "username_claimed": "blue",
@@ -820,7 +828,7 @@
   "Roblox": {
     "errorMsg": "Page cannot be found or no longer exists",
     "errorType": "message",
-    "rank": 117,
+    "rank": 118,
     "url": "https://www.roblox.com/user.aspx?username={}",
     "urlMain": "https://www.roblox.com/",
     "username_claimed": "bluewolfekiller",
@@ -829,7 +837,7 @@
   "Scribd": {
     "errorMsg": "Page not found",
     "errorType": "message",
-    "rank": 150,
+    "rank": 153,
     "url": "https://www.scribd.com/{}",
     "urlMain": "https://www.scribd.com/",
     "username_claimed": "blue",
@@ -838,7 +846,7 @@
   "Signal": {
     "errorMsg": "Oops! That page doesn\u2019t exist or is private.",
     "errorType": "message",
-    "rank": 1171212,
+    "rank": 1248625,
     "url": "https://community.signalusers.org/u/{}",
     "urlMain": "https://community.signalusers.org",
     "username_claimed": "jlund",
@@ -846,7 +854,7 @@
   },
   "Slack": {
     "errorType": "status_code",
-    "rank": 199,
+    "rank": 191,
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://{}.slack.com",
     "urlMain": "https://slack.com",
@@ -855,7 +863,7 @@
   },
   "SlideShare": {
     "errorType": "status_code",
-    "rank": 119,
+    "rank": 121,
     "url": "https://slideshare.net/{}",
     "urlMain": "https://slideshare.net/",
     "username_claimed": "blue",
@@ -863,7 +871,7 @@
   },
   "Smashcast": {
     "errorType": "status_code",
-    "rank": 117577,
+    "rank": 115310,
     "url": "https://www.smashcast.tv/api/media/live/{}",
     "urlMain": "https://www.smashcast.tv/",
     "username_claimed": "hello",
@@ -871,7 +879,7 @@
   },
   "SoundCloud": {
     "errorType": "status_code",
-    "rank": 88,
+    "rank": 87,
     "url": "https://soundcloud.com/{}",
     "urlMain": "https://soundcloud.com/",
     "username_claimed": "blue",
@@ -879,7 +887,7 @@
   },
   "SourceForge": {
     "errorType": "status_code",
-    "rank": 357,
+    "rank": 360,
     "url": "https://sourceforge.net/u/{}",
     "urlMain": "https://sourceforge.net/",
     "username_claimed": "blue",
@@ -887,7 +895,7 @@
   },
   "Spotify": {
     "errorType": "status_code",
-    "rank": 105,
+    "rank": 107,
     "url": "https://open.spotify.com/user/{}",
     "urlMain": "https://open.spotify.com/",
     "username_claimed": "blue",
@@ -895,7 +903,7 @@
   },
   "Star Citizen": {
     "errorType": "status_code",
-    "rank": 7478,
+    "rank": 7497,
     "url": "https://robertsspaceindustries.com/citizens/{}",
     "urlMain": "https://robertsspaceindustries.com/",
     "username_claimed": "blue",
@@ -921,7 +929,7 @@
   },
   "Taringa": {
     "errorType": "status_code",
-    "rank": 956,
+    "rank": 952,
     "url": "https://www.taringa.net/{}",
     "urlMain": "https://taringa.net/",
     "username_claimed": "blue",
@@ -930,7 +938,7 @@
   "Telegram": {
     "errorMsg": "<meta property=\"twitter:title\" content=\"Telegram: Contact",
     "errorType": "message",
-    "rank": 679,
+    "rank": 667,
     "url": "https://t.me/{}",
     "urlMain": "https://t.me/",
     "username_claimed": "saman",
@@ -939,7 +947,7 @@
   "Tinder": {
     "errorMsg": "Looking for Someone?",
     "errorType": "message",
-    "rank": 1744,
+    "rank": 1772,
     "url": "https://www.gotinder.com/@{}",
     "urlMain": "https://tinder.com/",
     "username_claimed": "blue",
@@ -947,7 +955,7 @@
   },
   "TradingView": {
     "errorType": "status_code",
-    "rank": 608,
+    "rank": 581,
     "url": "https://www.tradingview.com/u/{}/",
     "urlMain": "https://www.tradingview.com/",
     "username_claimed": "blue",
@@ -955,7 +963,7 @@
   },
   "Trakt": {
     "errorType": "status_code",
-    "rank": 4776,
+    "rank": 4727,
     "url": "https://www.trakt.tv/users/{}",
     "urlMain": "https://www.trakt.tv/",
     "username_claimed": "blue",
@@ -964,7 +972,7 @@
   "Trip": {
     "errorMsg": "Page not found",
     "errorType": "message",
-    "rank": 3353,
+    "rank": 3308,
     "url": "https://www.trip.skyscanner.com/user/{}",
     "urlMain": "https://www.trip.skyscanner.com/",
     "username_claimed": "blue",
@@ -973,7 +981,7 @@
   "TripAdvisor": {
     "errorMsg": "This page is on vacation\u2026",
     "errorType": "message",
-    "rank": 253,
+    "rank": 251,
     "url": "https://tripadvisor.com/members/{}",
     "urlMain": "https://tripadvisor.com/",
     "username_claimed": "blue",
@@ -998,7 +1006,7 @@
   },
   "Unsplash": {
     "errorType": "status_code",
-    "rank": 551,
+    "rank": 546,
     "url": "https://unsplash.com/@{}",
     "urlMain": "https://unsplash.com/",
     "username_claimed": "jenny",
@@ -1015,7 +1023,7 @@
   },
   "VSCO": {
     "errorType": "status_code",
-    "rank": 3530,
+    "rank": 3473,
     "url": "https://vsco.co/{}",
     "urlMain": "https://vsco.co/",
     "username_claimed": "blue",
@@ -1023,7 +1031,7 @@
   },
   "Venmo": {
     "errorType": "status_code",
-    "rank": 5354,
+    "rank": 5300,
     "url": "https://venmo.com/{}",
     "urlMain": "https://venmo.com/",
     "username_claimed": "jenny",
@@ -1031,7 +1039,7 @@
   },
   "Vimeo": {
     "errorType": "status_code",
-    "rank": 128,
+    "rank": 126,
     "url": "https://vimeo.com/{}",
     "urlMain": "https://vimeo.com/",
     "username_claimed": "blue",
@@ -1040,7 +1048,7 @@
   "VirusTotal": {
     "errorMsg": "not found",
     "errorType": "message",
-    "rank": 3879,
+    "rank": 3901,
     "url": "https://www.virustotal.com/ui/users/{}/trusted_users",
     "urlMain": "https://www.virustotal.com/",
     "username_claimed": "blue",
@@ -1049,7 +1057,7 @@
   "Wattpad": {
     "errorMsg": "This page seems to be missing...",
     "errorType": "message",
-    "rank": 525,
+    "rank": 522,
     "url": "https://www.wattpad.com/user/{}",
     "urlMain": "https://www.wattpad.com/",
     "username_claimed": "Dogstho7951",
@@ -1058,7 +1066,7 @@
   "We Heart It": {
     "errorMsg": "Oops! You've landed on a moving target!",
     "errorType": "message",
-    "rank": 4018,
+    "rank": 4000,
     "url": "https://weheartit.com/{}",
     "urlMain": "https://weheartit.com/",
     "username_claimed": "ventivogue",
@@ -1066,18 +1074,10 @@
   },
   "WebNode": {
     "errorType": "status_code",
-    "rank": 16210,
+    "rank": 16426,
     "url": "https://{}.webnode.cz/",
     "urlMain": "https://www.webnode.cz/",
     "username_claimed": "radkabalcarova",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
-  "Fandom": {
-    "errorType": "status_code",
-    "rank": 6540,
-    "url": "https://www.fandom.com/u/{}",
-    "urlMain": "https://www.fandom.com/",
-    "username_claimed": "Jungypoo",
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Wikipedia": {
@@ -1091,7 +1091,7 @@
   },
   "Wix": {
     "errorType": "status_code",
-    "rank": 423,
+    "rank": 419,
     "url": "https://{}.wix.com",
     "urlMain": "https://wix.com/",
     "username_claimed": "support",
@@ -1100,7 +1100,7 @@
   "WordPress": {
     "errorType": "response_url",
     "errorUrl": "wordpress.com/typo/?subdomain=",
-    "rank": 44,
+    "rank": 45,
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://{}.wordpress.com/",
     "urlMain": "https://wordpress.com",
@@ -1110,7 +1110,7 @@
   "YouNow": {
     "errorMsg": "No users found",
     "errorType": "message",
-    "rank": 18039,
+    "rank": 18128,
     "url": "https://www.younow.com/{}/",
     "urlMain": "https://www.younow.com/",
     "urlProbe": "https://api.younow.com/php/api/broadcast/info/user={}/",
@@ -1119,7 +1119,7 @@
   },
   "YouPic": {
     "errorType": "status_code",
-    "rank": 46663,
+    "rank": 45817,
     "url": "https://youpic.com/photographer/{}/",
     "urlMain": "https://youpic.com/",
     "username_claimed": "blue",
@@ -1137,7 +1137,7 @@
   "Zhihu": {
     "errorType": "response_url",
     "errorUrl": "https://www.zhihu.com/people/{}",
-    "rank": 87,
+    "rank": 81,
     "url": "https://www.zhihu.com/people/{}",
     "urlMain": "https://www.zhihu.com/",
     "username_claimed": "blue",
@@ -1146,7 +1146,7 @@
   "devRant": {
     "errorType": "response_url",
     "errorUrl": "https://devrant.com/",
-    "rank": 147125,
+    "rank": 148820,
     "url": "https://devrant.com/users/{}",
     "urlMain": "https://devrant.com/",
     "username_claimed": "blue",
@@ -1155,7 +1155,7 @@
   "iMGSRC.RU": {
     "errorType": "response_url",
     "errorUrl": "https://imgsrc.ru/",
-    "rank": 8323,
+    "rank": 8377,
     "url": "https://imgsrc.ru/main/user.php?user={}",
     "urlMain": "https://imgsrc.ru/",
     "username_claimed": "blue",
@@ -1163,7 +1163,7 @@
   },
   "last.fm": {
     "errorType": "status_code",
-    "rank": 1168,
+    "rank": 1197,
     "url": "https://last.fm/user/{}",
     "urlMain": "https://last.fm/",
     "username_claimed": "blue",

--- a/data.json
+++ b/data.json
@@ -1073,13 +1073,12 @@
     "username_claimed": "radkabalcarova",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "Wikia": {
-    "errorMsg": "does not exist",
-    "errorType": "message",
+  "Fandom": {
+    "errorType": "status_code",
     "rank": 6540,
-    "url": "https://wikia.com/wiki/User:{}",
-    "urlMain": "http://www.wikia.com/",
-    "username_claimed": "KP_Blue",
+    "url": "https://www.fandom.com/u/{}",
+    "urlMain": "https://www.fandom.com/",
+    "username_claimed": "Jungypoo",
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Wikipedia": {

--- a/sherlock.py
+++ b/sherlock.py
@@ -26,7 +26,7 @@ from torrequest import TorRequest
 from load_proxies import load_proxies_from_csv, check_proxy_list
 
 module_name = "Sherlock: Find Usernames Across Social Networks"
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 amount = 0
 
 BANNER = r'''

--- a/sites.md
+++ b/sites.md
@@ -125,7 +125,7 @@
 124. [Wattpad](https://www.wattpad.com/)
 125. [We Heart It](https://weheartit.com/)
 126. [WebNode](https://www.webnode.cz/)
-127. [Wikia](http://www.wikia.com/)
+127. [Fandom](https://www.fandom.com/)
 128. [Wikipedia](https://www.wikipedia.org/)
 129. [Wix](https://wix.com/)
 130. [WordPress](https://wordpress.com)
@@ -137,4 +137,4 @@
 136. [iMGSRC.RU](https://imgsrc.ru/)
 137. [last.fm](https://last.fm/)
 
-Alexa.com rank data fetched at (2019-05-28 12:24:44.944984 UTC)
+Alexa.com rank data fetched at (2019-06-08 14:24:33.626484 UTC)


### PR DESCRIPTION
Convert Flipboard to use more reliable HTTP Status detection method.  The site gives a clean 404 error.  They changed their site response, so we were getting false positives.

Wikia has been renamed to Fandom.  The old http://www.wikia.com/ site redirects to https://www.fandom.com/, so the detection was not working.

Convert Reddit to use more reliable HTTP Status detection method.  The site gives a clean 404 error.