### PR TITLE
Update claimed username for BitBucket.

### DIFF
--- a/data.json
+++ b/data.json
@@ -102,7 +102,7 @@
     "rank": 994,
     "url": "https://bitbucket.org/{}/",
     "urlMain": "https://bitbucket.org/",
-    "username_claimed": "blue",
+    "username_claimed": "white",
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "BitCoinForum": {


### PR DESCRIPTION
username_claimed 'blue' for BitBucket no longer works.

Accordingly, I replaced `blue` with `white`.