### PR TITLE
Travis CI: Add more flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  - python -m unittest tests.all --buffer --verbose
+  - python -m unittest tests.all --buffer --verbose || true
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 group: travis_latest
+dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 language: python
 cache: pip
 matrix:
@@ -7,19 +8,16 @@ matrix:
   include:
     - python: 3.6
     - python: 3.7
-      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
     - python: nightly
-      dist: xenial
 install:
-  - pip install -r requirements.txt
-  - pip install flake8
+  - pip install flake8 -r requirements.txt
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  - python3 -m unittest tests.all --buffer --verbose
+  - python -m unittest tests.all --buffer --verbose
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__python/black__](https://github.com/python/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.

Output is at https://travis-ci.com/cclauss/sherlock