### PR TITLE
Fix Pinterest

### DIFF
--- a/data.json
+++ b/data.json
@@ -781,8 +781,7 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Pinterest": {
-    "errorType": "response_url",
-    "errorUrl": "https://www.pinterest.com/?show_error=true",
+    "errorType": "status_code",
     "rank": 73,
     "url": "https://www.pinterest.com/{}/",
     "urlMain": "https://www.pinterest.com/",


### PR DESCRIPTION
Currently, the system is not working for Pinterest because the site will always return a status code of 301 no matter the username exists or not.
I changed it to use status_code. Pinterest will eventually return a status code of 404 if the username does not exist.