### PR TITLE
ISSUE-223 Wattpad site false positive issue

### DIFF
--- a/data.json
+++ b/data.json
@@ -1122,7 +1122,7 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Wattpad": {
-    "errorMsg": "This page seems to be missing...",
+    "errorMsg": "userError-404",
     "errorType": "message",
     "rank": 495,
     "url": "https://www.wattpad.com/user/{}",


### PR DESCRIPTION
Hello,
This is for Issue #223
Wattpad returns HTML message for non-existent users. In that message, the "userError-404" div tag id is used to render the 'User Not found' message. 
So, I am using this tag id to check whether the user not exist and preventing the false positive issue. 

Thanks and Regards,
Sathish K