### PR TITLE
Robustness Update For CI Tests (Part 1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  - python -m unittest tests.all --buffer --verbose || true
+  - python -m unittest tests.all.SherlockDetectTests --buffer --verbose || true
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/tests/all.py
+++ b/tests/all.py
@@ -7,26 +7,30 @@ import unittest
 
 
 class SherlockDetectTests(SherlockBaseTest):
-    def test_detect_true(self):
-        """Test Username Existence Detection.
+    def test_detect_true_via_message(self):
+        """Test Username Does Exist (Via Message).
 
-        This test ensures that the mechanism of ensuring that a Username
-        exists works properly.
+        This test ensures that the "message" detection mechanism of
+        ensuring that a Username does exist works properly.
 
         Keyword Arguments:
         self                   -- This object.
 
         Return Value:
         N/A.
-        Will trigger an assert if Usernames which are known to exist are
-        not detected.
+        Will trigger an assert if detection mechanism did not work as expected.
         """
 
-        self.username_check(['jack'],  ['Twitter'],   exist_check=True)
-        self.username_check(['dfox'],  ['devRant'],   exist_check=True)
-        self.username_check(['blue'],  ['Pinterest'], exist_check=True)
-        self.username_check(['kevin'], ['Instagram'], exist_check=True)
-        self.username_check(['zuck'],  ['Facebook'],  exist_check=True)
+        site = 'Instagram'
+        site_data = self.site_data_all[site]
+
+        #Ensure that the site's detection method has not changed.
+        self.assertEqual("message", site_data["errorType"])
+
+        self.username_check([site_data["username_claimed"]],
+                            [site],
+                            exist_check=True
+                           )
 
         return
 
@@ -44,9 +48,42 @@ class SherlockDetectTests(SherlockBaseTest):
         Will trigger an assert if detection mechanism did not work as expected.
         """
 
-        self.username_check(['jackkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk'],
-                            ['Instagram'],
+        site = 'Instagram'
+        site_data = self.site_data_all[site]
+
+        #Ensure that the site's detection method has not changed.
+        self.assertEqual("message", site_data["errorType"])
+
+        self.username_check([site_data["username_unclaimed"]],
+                            [site],
                             exist_check=False
+                           )
+
+        return
+
+    def test_detect_true_via_status_code(self):
+        """Test Username Does Exist (Via Status Code).
+
+        This test ensures that the "status code" detection mechanism of
+        ensuring that a Username does exist works properly.
+
+        Keyword Arguments:
+        self                   -- This object.
+
+        Return Value:
+        N/A.
+        Will trigger an assert if detection mechanism did not work as expected.
+        """
+
+        site = 'Facebook'
+        site_data = self.site_data_all[site]
+
+        #Ensure that the site's detection method has not changed.
+        self.assertEqual("status_code", site_data["errorType"])
+
+        self.username_check([site_data["username_claimed"]],
+                            [site],
+                            exist_check=True
                            )
 
         return
@@ -65,9 +102,42 @@ class SherlockDetectTests(SherlockBaseTest):
         Will trigger an assert if detection mechanism did not work as expected.
         """
 
-        self.username_check(['jackkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk'],
-                            ['Facebook'],
+        site = 'Facebook'
+        site_data = self.site_data_all[site]
+
+        #Ensure that the site's detection method has not changed.
+        self.assertEqual("status_code", site_data["errorType"])
+
+        self.username_check([site_data["username_unclaimed"]],
+                            [site],
                             exist_check=False
+                           )
+
+        return
+
+    def test_detect_true_via_response_url(self):
+        """Test Username Does Exist (Via Response URL).
+
+        This test ensures that the "response URL" detection mechanism of
+        ensuring that a Username does exist works properly.
+
+        Keyword Arguments:
+        self                   -- This object.
+
+        Return Value:
+        N/A.
+        Will trigger an assert if detection mechanism did not work as expected.
+        """
+
+        site = 'Quora'
+        site_data = self.site_data_all[site]
+
+        #Ensure that the site's detection method has not changed.
+        self.assertEqual("response_url", site_data["errorType"])
+
+        self.username_check([site_data["username_claimed"]],
+                            [site],
+                            exist_check=True
                            )
 
         return
@@ -86,8 +156,14 @@ class SherlockDetectTests(SherlockBaseTest):
         Will trigger an assert if detection mechanism did not work as expected.
         """
 
-        self.username_check(['jackkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk'],
-                            ['Pinterest'],
+        site = 'Quora'
+        site_data = self.site_data_all[site]
+
+        #Ensure that the site's detection method has not changed.
+        self.assertEqual("response_url", site_data["errorType"])
+
+        self.username_check([site_data["username_unclaimed"]],
+                            [site],
                             exist_check=False
                            )
 


### PR DESCRIPTION
This update is in regards to the discussion in #235 .  

There are so many sites that are unreliable, it is pretty uncommon for the tests to run without one or the other failing to respond and causing the tests to fail.  So, this update changes the CI tests to only run against a subset of sites.  These are more popular sites that should be less likely to go down.  The tests will exercise Sherlock so that it will try each of the detection methods.

Part 2 will be to devise a CI test that does the site coverage.