### PR TITLE
Fix Error When csv Is Written When Username Is Illegal For A Site

### DIFF
--- a/sherlock.py
+++ b/sherlock.py
@@ -215,6 +215,10 @@ def sherlock(username, site_data, verbose=False, tor=False, unique_tor=False, pr
             # No need to do the check at the site: this user name is not allowed.
             print_invalid(social_network, "Illegal Username Format For This Site!")
             results_site["exists"] = "illegal"
+            results_site["url_user"] = ""
+            results_site['http_status'] = ""
+            results_site['response_text'] = ""
+            results_site['response_time_ms'] = ""
         else:
             # URL of user on site (if it exists)
             url = net_info["url"].format(username)


### PR DESCRIPTION
This problem happens during the write to the CSV.  There are various results that are gathered during the query for the existence of a given site, and they are always expected to exist in the results dictionary.  However, if a given user name has an illegal format for a given site, then the query is not even attempted.  Which leaves some keys in the dictionary undefined.

The solution is to define these keys even in the case where the username has an illegal format.

See #252 