### PR TITLE
Fix MixCloud false positive.

### DIFF
--- a/data.json
+++ b/data.json
@@ -705,10 +705,10 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "MixCloud": {
-    "errorMsg": "Page Not Found",
-    "errorType": "message",
+    "errorType": "status_code",
     "rank": 2436,
-    "url": "https://www.mixcloud.com/{}",
+    "url": "https://www.mixcloud.com/{}/",
+    "urlProbe": "https://api.mixcloud.com/{}/",
     "urlMain": "https://www.mixcloud.com/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"


### PR DESCRIPTION
It appears that they have changed their website. Before, they rendered their "Page Not Found" error message in HTML. Now, they must be creating that text with javascript.

Lucky, they do have an unauthenticated API available.  So, change the detection to use that.

See #258 