### PR TITLE
Adds a link to let github visitors test Sherlock from their browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ $ cd sherlock
 $ pip3 install -r requirements.txt
 ```
 
+## Demonstration
+
+You can use this link to test Sherlock directly in your browser:
+https://elody.com/scenario/plan/16/
+
 ## Usage
 
 ```bash
@@ -85,7 +90,7 @@ For example to search for user:
 ```
 python3 sherlock.py user123
 
-``` 
+```
 All of the accounts found will be stored in a text file with the username (e.g ```user123.txt```).
 
 To search for more that user:


### PR DESCRIPTION
I have added a link to the README.md that will allow anyone to test Sherlock directly in the browser.

Just try it out and you will see what I mean: [https://elody.com/scenario/plan/16/](url)

Is this useful for you?

I am building a website that can let anyone make their code available to endusers without download or installation.

I used Sherlock as a test case, because it was recently trending on github and it seemed like a good fit.

My goal is that developers will upload their existing github projects to elody.com and put the link to it on their github page, to make showcasing the projects more convenient. Elody can also do a whole lot more than that, but it's a good way to get started.

Do you like it?

Is there anything else you would like to see to make this more useful?

I would really appreciate any feedback!