### PR TITLE
Add NPM Package & Change NPM to Status Code

### DIFF
--- a/data.json
+++ b/data.json
@@ -764,13 +764,19 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "NPM": {
-    "errorMsg": "Scope not found",
-    "errorType": "message",
+    "errorType": "status_code",
     "rank": 1887,
-    "url": "https://npmjs.com/~{}",
-    "urlMain": "https://npmjs.com/",
+    "url": "https://www.npmjs.com/~{}",
+    "urlMain": "https://www.npmjs.com/",
     "username_claimed": "kennethsweezy",
     "username_unclaimed": "noonewould"
+  },
+  "NPM-Package": {
+    "errorType": "status_code",
+    "url": "https://www.npmjs.com/package/{}",
+    "urlMain": "https://www.npmjs.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
   },
   "NameMC (Minecraft.net skins)": {
     "errorMsg": "Profiles: 0 results",


### PR DESCRIPTION
Addition: NPM Package names are unique and they're sometimes reserved by the devs as many have lost the good names to others because of neglecting and end up having different package names pointing to different GitHub repos (which is often confusing but no choice).

Change with NPM is simply because the status code algo just works fine and no need to rely on an unstable algo (message) and the head request would just be sufficient as well.