### PR TITLE
Add PlayStore

### DIFF
--- a/data.json
+++ b/data.json
@@ -867,6 +867,13 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "PlayStore": {
+    "errorType": "status_code",
+    "url": "https://play.google.com/store/apps/developer?id={}",
+    "urlMain": "https://play.google.com/store",
+    "username_claimed": "Facebook",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Plug.DJ": {
     "errorType": "status_code",
     "rank": 32278,


### PR DESCRIPTION
Please note: Google PlayStore dev ids are case-sensitive. So for example, If `Facebook` is registered and you search for `facebook`, then it'll return `404`.

There is no way out as of now.