### PR TITLE
Add Trello

### DIFF
--- a/data.json
+++ b/data.json
@@ -1144,6 +1144,15 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Trello": {
+    "errorType": "message",
+    "errorMsg": "model not found",
+    "url": "https://trello.com/{}",
+    "urlProbe": "https://trello.com/1/Members/{}",
+    "urlMain": "https://trello.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Trip": {
     "errorMsg": "Page not found",
     "errorType": "message",


### PR DESCRIPTION
Status code algo for some reason isn't working with Sherlock for this site (but works if I do a cURL request or from any other tool). So I had to go with message algo which does the job but I'd prefer status code if possible.