### PR TITLE
Add FlightMemory

### DIFF
--- a/data.json
+++ b/data.json
@@ -429,6 +429,14 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "FlightMemory": {
+    "errorType": "response_url",
+    "errorUrl": "https://www.flightmemory.com/",
+    "url": "https://my.flightmemory.com/{}",
+    "urlMain": "https://www.flightmemory.com/",
+    "username_claimed": "N751PR",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Flipboard": {
     "errorType": "status_code",
     "rank": 3728,


### PR DESCRIPTION
Note: Profiles that are private would also cause false positive and there's no other way to verify this.