### PR TITLE
Fix Trip False Positive

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ usage: sherlock.py [-h] [--version] [--verbose] [--rank]
                    [--print-found]
                    USERNAMES [USERNAMES ...]
 
-Sherlock: Find Usernames Across Social Networks (Version 0.8.6)
+Sherlock: Find Usernames Across Social Networks (Version 0.8.7)
 
 positional arguments:
   USERNAMES             One or more usernames to check with social networks.

--- a/data.json
+++ b/data.json
@@ -1254,8 +1254,7 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Trip": {
-    "errorMsg": "Page not found",
-    "errorType": "message",
+    "errorType": "status_code",
     "rank": 2558,
     "url": "https://www.trip.skyscanner.com/user/{}",
     "urlMain": "https://www.trip.skyscanner.com/",

--- a/sherlock.py
+++ b/sherlock.py
@@ -26,7 +26,7 @@ from torrequest import TorRequest
 from load_proxies import load_proxies_from_csv, check_proxy_list
 
 module_name = "Sherlock: Find Usernames Across Social Networks"
-__version__ = "0.8.6"
+__version__ = "0.8.7"
 amount = 0
 
 


### PR DESCRIPTION
Convert Trip to use more reliable HTTP Status detection method.  The site gives a clean 410 error.  They changed their site response, so we were getting false positives.

This has been noticed in issues #325 and #326.