### PR TITLE
Added support for custom headers

### DIFF
--- a/sherlock.py
+++ b/sherlock.py
@@ -164,13 +164,6 @@ def sherlock(username, site_data, verbose=False, tor=False, unique_tor=False, pr
 
     print_info("Checking username", username)
 
-    # A user agent is needed because some sites don't
-    # return the correct information since they think that
-    # we are bots
-    headers = {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0'
-    }
-
     # Allow 1 thread for each external service, so `len(site_data)` threads total
     executor = ThreadPoolExecutor(max_workers=len(site_data))
 
@@ -196,6 +189,14 @@ def sherlock(username, site_data, verbose=False, tor=False, unique_tor=False, pr
 
         # Record URL of main site
         results_site['url_main'] = net_info.get("urlMain")
+        
+        # A user agent is needed because some sites don't return the correct information since they think that
+        # we are bots
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0',
+        }
+        if "headers" in net_info:
+            headers.update(net_info["headers"])
 
         # Don't make request if username is invalid for the site
         regex_check = net_info.get("regexCheck")


### PR DESCRIPTION
I've added support for custom headers in the `data.json` file for each site. If no headers are declared, which is the case for all current sites, it will use the same User-Agent in the header as before. To declare custom headers  add a dictionary to a site in `data.json` called "headers" as demonstrated below.

```
  "Zomato": {
    "errorType": "status_code",
    "url": "https://www.zomato.com/{}/foodjourney",
    "urlMain": "https://www.zomato.com/",
    "username_claimed": "deepigoyal",
    "username_unclaimed": "noonewouldeverusethis7",
    "headers": {
      "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0",
      "Origin": "https://www.zomato.com/"
    }
```
This was made in response to #256. 