### PR TITLE
Use browser URL for twitch.tv results

### DIFF
--- a/data.json
+++ b/data.json
@@ -1274,8 +1274,9 @@
   "Twitch": {
     "errorType": "status_code",
     "rank": 32,
-    "url": "https://m.twitch.tv/{}",
+    "url": "https://www.twitch.tv/{}",
     "urlMain": "https://www.twitch.tv/",
+    "urlProbe": "https://m.twitch.tv/{}",
     "username_claimed": "jenny",
     "username_unclaimed": "noonewouldeverusethis7"
   },


### PR DESCRIPTION
Good morning 👋 

Chances are that you are running this software on a desktop environment rather than a mobile so I took the liberty of splitting the twitch result url from the probe url.

The result: Users found on twitch will now be linked using `www.twitch.tv/username `instead of `m.twitch.tv/username`. 

Let me know if you have any feedback 😄 