### PR TITLE
Added notes for Anaconda users

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ python3 sherlock.py user1 user2 user3
 
 Accounts found will be stored in an individual text file with the corresponding username (e.g ```user123.txt```).
 
+## Anaconda (Windows) Notes
+If you are using Anaconda in Windows, using 'python3' might not work. Use 'python' instead.
+
 ## Docker Notes
 If docker is installed you can build an image and run this as a container.
 


### PR DESCRIPTION
When I used Anaconda on Windows, using 'python3' did not work. Only 'python' worked in those cases. My change will be useful for Windows users.