### PR TITLE
Fix / Install stem requirement from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ venv/
 # Python
 __pycache__/
 
+# Pip
+src/
+
 # Jupyter Notebook
 .ipynb_checkpoints
 *.ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,7 @@ PySocks>=1.7.0
 requests>=2.22.0
 requests-futures>=1.0.0
 soupsieve>=1.9.2
+# install from git to fix RuntimeError: dictionary keys changed during iteration
+# change to stem>=1.7.2 or greater when available
 -e git+https://git.torproject.org/stem.git@b5aecb7#egg=stem
 torrequest>=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ PySocks>=1.7.0
 requests>=2.22.0
 requests-futures>=1.0.0
 soupsieve>=1.9.2
-stem>=1.7.1
+-e git+https://git.torproject.org/stem.git@b5aecb7#egg=stem
 torrequest>=0.1.0


### PR DESCRIPTION
This intend to fix the _RuntimeError: dictionary keys changed during iteration_ which happens on `stem` package by using the specific commit where the bug was fixed.

Since there is no new release from `stem` since that bugfix, the only solution is to patch de dependency code or install from git (my choice).

Details in the following links:

- https://www.mail-archive.com/tor-bugs@lists.torproject.org/msg186952.html 
- https://gitweb.torproject.org/stem.git/commit/?id=b5aecb7