### PR TITLE
GitHub Action to run our unit tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,13 @@
+name: run_tests
+on: [push, pull_request]
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+      - run: pip install flake8 -r requirements.txt
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: python -m unittest tests.all.SherlockSiteCoverageTests --buffer --verbose
+      - run: python -m unittest tests.all.SherlockDetectTests --buffer --verbose || true
+      


### PR DESCRIPTION
Replace Travis CI with a GitHub Action. @TheYahya @sdushantha Can one of you please enable GitHub Actions at https://github.com/sherlock-project/sherlock/actions/new or Travis CI at https://travis-ci.com/sherlock-project ?  Both are free to open source projects like this one.