### PR TITLE
Use stem from PyPi insted of Git version, fixes #496 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,5 @@ PySocks>=1.7.0
 requests>=2.22.0
 requests-futures>=1.0.0
 soupsieve>=1.9.2
-# install from git to fix RuntimeError: dictionary keys changed during iteration
-# change to stem>=1.7.2 or greater when available
--e git+https://git.torproject.org/stem.git@b5aecb7#egg=stem
+stem>=1.8.0 
 torrequest>=0.1.0


### PR DESCRIPTION
This should the issues some people have been having with installing the `stem` module.

fixes #496 