### PR TITLE
Update CreativeMarket to their new url

### DIFF
--- a/data.json
+++ b/data.json
@@ -459,7 +459,7 @@
     "errorType": "response_url",
     "errorUrl": "https://www.creativemarket.com/",
     "rank": 1763,
-    "url": "https://creativemarket.com/{}",
+    "url": "https://creativemarket.com/users/{}",
     "urlMain": "https://creativemarket.com/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"


### PR DESCRIPTION
CreativeMarket changed their user URL from `https://creativemarket.com/blue` to `https://creativemarket.com/users/blue`.