### PR TITLE
Enhanced the proxy functionality by implementing a syntax check based on a regex pattern.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ git clone https://github.com/sherlock-project/sherlock.git
 # change the working directory to sherlock
 $ cd sherlock
 
-# install python3, python3-pip and setuptools through pip3 if they are not installed
+# install python3 and python3-pip if they are not installed
 
 # install the requirements
 $ python3 -m pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ git clone https://github.com/sherlock-project/sherlock.git
 # change the working directory to sherlock
 $ cd sherlock
 
-# install python3 and python3-pip if they are not installed
+# install python3, python3-pip and setuptools through pip3 if they are not installed
 
 # install the requirements
 $ python3 -m pip install -r requirements.txt

--- a/load_proxies.py
+++ b/load_proxies.py
@@ -91,10 +91,8 @@ def check_proxy_list(proxy_list, max_proxies=None):
 
 def proxy_check(proxy):
     """
-    proxy_check is a function whitch checks the syntax of a proxy
-    based on regex.
-
-    Outputs: boolean if the proxy is in valid syntax
+    proxy_check is a function which checks if the syntax of a proxy
+    is correct based on a regex pattern.
     """
     # Regex for a valid proxy with port, e.g.: https://79.125.163.225:30677
     regex_proxy = r"(http|https|socks5|socks4)://([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}):[0-9]{1,5}"

--- a/load_proxies.py
+++ b/load_proxies.py
@@ -1,6 +1,7 @@
 import csv
 import requests
 import time
+import re
 from collections import namedtuple
 from colorama import Fore, Style
 
@@ -87,3 +88,16 @@ def check_proxy_list(proxy_list, max_proxies=None):
 
     else:
         raise Exception("Found no working proxies.")
+
+def proxy_check(proxy):
+    """
+    proxy_check is a function whitch checks the syntax of a proxy
+    based on regex.
+
+    Outputs: boolean if the proxy is in valid syntax
+    """
+    # Regex for a valid proxy with port, e.g.: https://79.125.163.225:30677
+    regex_proxy = r"(http|https|socks5|socks4)://([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}):[0-9]{1,5}"
+
+    return (proxy and re.search(regex_proxy, proxy) is not None)
+

--- a/sherlock.py
+++ b/sherlock.py
@@ -24,7 +24,7 @@ from colorama import Fore, Style, init
 
 from requests_futures.sessions import FuturesSession
 from torrequest import TorRequest
-from load_proxies import load_proxies_from_csv, check_proxy_list
+from load_proxies import load_proxies_from_csv, check_proxy_list, proxy_check
 
 module_name = "Sherlock: Find Usernames Across Social Networks"
 __version__ = "0.10.9"
@@ -407,7 +407,6 @@ def timeout_check(value):
         raise ArgumentTypeError(f"Timeout '{value}' must be greater than 0.0s.")
     return timeout
 
-
 def main():
     # Colorama module's initialization.
     init(autoreset=True)
@@ -495,11 +494,13 @@ def main():
 
     args = parser.parse_args()
 
-
     # Argument check
-    # TODO regex check on args.proxy
     if args.tor and (args.proxy != None or args.proxy_list != None):
         raise Exception("Tor and Proxy cannot be set in the meantime.")
+
+    # Checks if given proxy is in the correct syntax
+    if args.proxy and proxy_check(args.proxy) == False:
+        raise Exception("Proxy is not in the right format. Example: https://14.139.56.16:80")
 
     # Proxy argument check.
     # Does not necessarily need to throw an error,
@@ -515,9 +516,11 @@ def main():
     global proxy_list
 
     if args.proxy_list != None:
-        print_info("Loading proxies from", args.proxy_list, not args.color)
+        print_info("Loading proxies from", args.proxy_list)
 
         proxy_list = load_proxies_from_csv(args.proxy_list)
+
+        print(proxy_list)
 
     # Checking if proxies should be checked for anonymity.
     if args.check_prox != None and args.proxy_list != None:

--- a/sherlock.py
+++ b/sherlock.py
@@ -499,7 +499,7 @@ def main():
         raise Exception("Tor and Proxy cannot be set in the meantime.")
 
     # Checks if given proxy is in the correct syntax
-    if args.proxy and proxy_check(args.proxy) == False:
+    if args.proxy and not proxy_check(args.proxy):
         raise Exception("Proxy is not in the right format.")
 
     # Proxy argument check.

--- a/sherlock.py
+++ b/sherlock.py
@@ -500,7 +500,7 @@ def main():
 
     # Checks if given proxy is in the correct syntax
     if args.proxy and proxy_check(args.proxy) == False:
-        raise Exception("Proxy is not in the right format. Example: https://14.139.56.16:80")
+        raise Exception("Proxy is not in the right format.")
 
     # Proxy argument check.
     # Does not necessarily need to throw an error,
@@ -519,8 +519,6 @@ def main():
         print_info("Loading proxies from", args.proxy_list)
 
         proxy_list = load_proxies_from_csv(args.proxy_list)
-
-        print(proxy_list)
 
     # Checking if proxies should be checked for anonymity.
     if args.check_prox != None and args.proxy_list != None:


### PR DESCRIPTION
- Enhanced the proxy functionality by implementing a syntax check based on a regex pattern.
- Removed args.color from the proxylist `print_info("Loading proxies from", args.proxy_list, not args.color)`. It's giving me errors and I think it's an old argument. Correct me if I'm wrong on this.