### PR TITLE
Clean out unused imports

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -8,16 +8,12 @@ networks.
 """
 
 import csv
-import json
 import os
 import platform
 import re
 import sys
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from time import monotonic
-from concurrent.futures import ThreadPoolExecutor
-from time import time
-import webbrowser
 
 import requests
 
@@ -25,7 +21,6 @@ from requests_futures.sessions import FuturesSession
 from torrequest import TorRequest
 from result import QueryStatus
 from result import QueryResult
-from notify import QueryNotify
 from notify import QueryNotifyPrint
 from sites  import SitesInformation
 

--- a/sherlock/sites.py
+++ b/sherlock/sites.py
@@ -3,7 +3,6 @@
 This module supports storing information about web sites.
 This is the raw data that will be used to search for usernames.
 """
-import logging
 import os
 import json
 import operator

--- a/sherlock/tests/base.py
+++ b/sherlock/tests/base.py
@@ -2,7 +2,6 @@
 
 This module contains various utilities for running tests.
 """
-import json
 import os
 import os.path
 import unittest


### PR DESCRIPTION
I used the "importchecker" pip plugin for this

```
pip install importchecker
importchecker .
```

Keeping unittest since that seems important.

Note: I ran unit tests, and 5 things failed, but they seemed to be failing before (and all assertion errors, nothing from a missing import)