### PR TITLE
add nairaland.com

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2331,6 +2331,14 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "nairaland.com": {
+    "errorType": "status_code",
+    "rank": 808,
+    "url": "https://www.nairaland.com/{}",
+    "urlMain": "https://www.nairaland.com/",
+    "username_claimed": "red",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "nightbot": {
     "errorType": "status_code",
     "rank": 10776,


### PR DESCRIPTION
An online forum-like community targeted towards Nigerians.

- Alexa rank: 808
- 6th site in Nigeria
- nearly 2.5mln user accounts
- exists since 2005

Sources:
https://www.alexa.com/siteinfo/nairaland.com
https://en.wikipedia.org/wiki/Nairaland