### PR TITLE
Creates an html file with all of the links in the .txt

### DIFF
--- a/sherlock/intohtml.py
+++ b/sherlock/intohtml.py
@@ -38,6 +38,9 @@ def run():
             file.write("\n"+htmlFoot)
             userFine("Action completed!")
         except:
+            if username.endswith(".txt"):
+                userError(f"No file with the name \"{username}\"")
+                return
             userError(f"No file with the name \"{username}.txt\"")
     else:
         if len(sys.argv) > 2:

--- a/sherlock/intohtml.py
+++ b/sherlock/intohtml.py
@@ -10,6 +10,8 @@ def userWarn(str):
     print(f"{Fore.YELLOW}Warning: {str}")
 def userFine(str):
     print(Fore.GREEN+str)
+def userPrompt(str):
+    print(Fore.BLUE+str)
 
 def run():
     if len(sys.argv) != 1 and len(sys.argv) < 3:
@@ -36,7 +38,12 @@ def run():
             for i in range(0, len(lines)):
                 file.write(f"\t<input type=\"checkbox\" /><a href=\"{lines[i]}\" target=\"_blank\">{lines[i]}</a><br /><br />")
             file.write("\n"+htmlFoot)
+            file.close()
             userFine("Action completed!")
+            userPrompt(f"Would you like to open {file.name}? y/n")
+            openFile = input()
+            if openFile == "y":
+                os.system(f'start "" {file.name}')
         except:
             if username.endswith(".txt"):
                 userError(f"No file with the name \"{username}\"")

--- a/sherlock/intohtml.py
+++ b/sherlock/intohtml.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import colorama
+from colorama import Fore, Style
+colorama.init(autoreset=True)
+
+htmlHead = '<!DOCTYPE html>\n<html lang="en">\n<head>\n\t<meta charset="UTF-8">\n\t<meta name="viewport" content="width=device-width, initial-scale=1.0">\n\t<title>Sites From sherlock.py</title>\n</head>\n<body>'
+htmlFoot = "</body>\n</html>"
+
+def userError(str):
+    print(Fore.RED+str)
+def userWarn(str):
+    print(f"{Fore.YELLOW}Warning: {str}")
+def userFine(str):
+    print(Fore.GREEN+str)
+
+def run():
+    if len(sys.argv) != 1 and len(sys.argv) < 3:
+        username = sys.argv[1]
+        linksFile = None
+        try:
+            if username.endswith(".txt"):
+                linksFile = open(username, "r")
+            else:
+                linksFile = open(f"{username}.txt", "r")
+            lines = linksFile.readlines()
+            # removes the line at the end which isnt a link
+            lines = lines[:-1]
+            file = None
+            if username.endswith(".txt"):
+                userFine(f"Creating {username[:-4]}.html file...")
+                file = open(f"{username[:-4]}.html", "w+")
+            else:
+                userFine(f"Creating {username}.html file...")
+                file = open(f"{username}.html", "w+")
+            file.write(htmlHead)
+            for i in range(0, len(lines)):
+                file.write(f"<a href=\"{lines[i]}\" target=\"_blank\">{lines[i]}</a><br><br>")
+            file.write("\n"+htmlFoot)
+            userFine("Action completed!")
+        except:
+            userError(f"No file with the name \"{username}.txt\"")
+    else:
+        if len(sys.argv) > 2:
+            userError("Too many args!\nusage: py intohtml.py [filename(.txt optional)]")
+        else:
+            userError("Not enough args provided!\nusage: py intohtml.py [filename(.txt optional)]")
+
+run()

--- a/sherlock/intohtml.py
+++ b/sherlock/intohtml.py
@@ -4,9 +4,6 @@ import colorama
 from colorama import Fore, Style
 colorama.init(autoreset=True)
 
-htmlHead = '<!DOCTYPE html>\n<html lang="en">\n<head>\n\t<meta charset="UTF-8">\n\t<meta name="viewport" content="width=device-width, initial-scale=1.0">\n\t<title>Sites From sherlock.py</title>\n</head>\n<body>'
-htmlFoot = "</body>\n</html>"
-
 def userError(str):
     print(Fore.RED+str)
 def userWarn(str):
@@ -17,6 +14,8 @@ def userFine(str):
 def run():
     if len(sys.argv) != 1 and len(sys.argv) < 3:
         username = sys.argv[1]
+        htmlHead = f'<!DOCTYPE html>\n<html lang="en">\n<head>\n\t<meta charset="UTF-8">\n\t<meta name="viewport" content="width=device-width, initial-scale=1.0">\n\t<title>{username}</title>\n</head>\n<body>\n'
+        htmlFoot = "</body>\n</html>"
         linksFile = None
         try:
             if username.endswith(".txt"):
@@ -35,7 +34,7 @@ def run():
                 file = open(f"{username}.html", "w+")
             file.write(htmlHead)
             for i in range(0, len(lines)):
-                file.write(f"<input type=\"checkbox\" /><a href=\"{lines[i]}\" target=\"_blank\">{lines[i]}</a><br /><br />")
+                file.write(f"\t<input type=\"checkbox\" /><a href=\"{lines[i]}\" target=\"_blank\">{lines[i]}</a><br /><br />")
             file.write("\n"+htmlFoot)
             userFine("Action completed!")
         except:

--- a/sherlock/intohtml.py
+++ b/sherlock/intohtml.py
@@ -35,7 +35,7 @@ def run():
                 file = open(f"{username}.html", "w+")
             file.write(htmlHead)
             for i in range(0, len(lines)):
-                file.write(f"<a href=\"{lines[i]}\" target=\"_blank\">{lines[i]}</a><br><br>")
+                file.write(f"<input type=\"checkbox\" /><a href=\"{lines[i]}\" target=\"_blank\">{lines[i]}</a><br /><br />")
             file.write("\n"+htmlFoot)
             userFine("Action completed!")
         except:


### PR DESCRIPTION
This addition will create an html file that has a links for every site that had a matching username. It will read through a .txt (ignoring the last line as it is not a url) and create a [username].html file with those urls.

usage:
```python3 intohtml.py [username]```
or
```python3 intohtml.py [username.txt]```
This will find the username.txt file and read the contents of it.

This could be integrated into the main sherlock.py, but I'm not going to study the code and try to do that on my own as it may break something else if I do it wrong