### PR TITLE
removed forum.redsun.tf

### DIFF
--- a/removed_sites.md
+++ b/removed_sites.md
@@ -664,3 +664,19 @@ downforeveryoneorjustme.com that the website is down.
   },
 ```
 
+## Redsun.tf
+
+As of 2020-06-20, Redsun.tf seems to be adding random digits to the end of the usernames which makes it pretty much impossible
+for Sherlock to check for usernames on this particular website.
+
+```
+  "Redsun.tf": {
+    "errorMsg": "The specified member cannot be found",
+    "errorType": "message",
+    "rank": 3796657,
+    "url": "https://forum.redsun.tf/members/?username={}",
+    "urlMain": "https://redsun.tf/",
+    "username_claimed": "dan",
+    "username_unclaimed": "noonewouldeverusethis"
+  },
+```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1408,15 +1408,6 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "Redsun.tf": {
-    "errorMsg": "The specified member cannot be found",
-    "errorType": "message",
-    "rank": 3796657,
-    "url": "https://forum.redsun.tf/members/?username={}",
-    "urlMain": "https://redsun.tf/",
-    "username_claimed": "dan",
-    "username_unclaimed": "noonewouldeverusethis"
-  },
   "Repl.it": {
     "errorMsg": "404",
     "errorType": "message",


### PR DESCRIPTION
Like mentioned in #647 forum.redsun.tf seems to be giving false positives. In this PR, this site will be removed because of the way the site uses usernames, Sherlock is not able to check the usernames.