### PR TITLE
fixed false positive for Ko-fi

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2514,7 +2514,8 @@
     "username_unclaimed": "noonewouldeverusethis77777"
   },
   "kofi": {
-    "errorType": "status_code",
+    "errorType": "response_url",
+    "errorUrl": "https://ko-fi.com/art?=redirect",
     "rank": 89891,
     "url": "https://ko-fi.com/{}",
     "urlMain": "https://ko-fi.com",


### PR DESCRIPTION
I found out that when a username that does not exist is used, we get redirected to `https://ko-fi.com/art?=redirect`