### PR TITLE
Check Python version before executing the main function of Sherlock

### DIFF
--- a/sherlock/__main__.py
+++ b/sherlock/__main__.py
@@ -7,8 +7,27 @@ This module contains the main logic to search for usernames at social
 networks.
 """
 
-import sherlock
+import sys
 
 
 if __name__ == "__main__":
+    # Checking if the user is using the correct version of Python
+    # Reference:
+    #  If Python version is 3.6.5
+    #               major --^
+    #               minor ----^
+    #               micro ------^
+    major = sys.version_info[0]
+    minor = sys.version_info[1]
+
+    python_version = str(sys.version_info[0])+"."+str(sys.version_info[1])+"."+str(sys.version_info[2])
+
+    if major != 3:
+        print("Sherlock requires Python 3.6+\nYou are using Python %s, which is not supported by Sherlock" % (python_version))
+        sys.exit(1)
+    if minor < 6:
+        print("Sherlock requires Python 3.6+\nYou are using Python %s, which is not supported by Sherlock" % (python_version))
+        sys.exit(1)
+
+    import sherlock
     sherlock.main()


### PR DESCRIPTION
This will hopefully prevent people from opening issues where the problem is that the user
is using a version of Python which is lower than 3.6. Sherlock only supports 3.6+
This hack was taken from h8mail created by @khast3x
Source: https://github.com/khast3x/h8mail/blob/master/h8mail/__main__.py