### PR TITLE
Changed Error Message Search to Lower Case

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -327,7 +327,7 @@ def sherlock(username, site_data, query_notify,
         elif error_type == "message":
             error = net_info.get("errorMsg")
             # Checks if the error message is in the HTML
-            if not error in r.text:
+            if not error.lower() in r.text.lower():
                 result = QueryResult(username,
                                      social_network,
                                      url,


### PR DESCRIPTION
I noticed that case sensitivity seems to be an issue when using Sherlock, so I changed both the HTML and the error message to both be lower case, so that's a non issue.