### PR TITLE
Telegram Works Now | Updated the correct URL for Angel List

### DIFF
--- a/data_bad_site.json
+++ b/data_bad_site.json
@@ -300,15 +300,6 @@
      "username_claimed": "admin",
      "username_unclaimed": "noonewouldeverusethis7"
   },
-  "Telegram": {
-     "errorType": "response_url",
-     "errorUrl": "https://telegram.org",
-     "rank": 385,
-     "url": "https://t.me/{}",
-     "urlMain": "https://t.me/",
-     "username_claimed": "saman",
-     "username_unclaimed": "i_do_not_believe_this_account_exists_at_all"
-  },
   "elwoRU": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",

--- a/data_bad_site.json
+++ b/data_bad_site.json
@@ -18,7 +18,7 @@
   "AngelList": {
     "errorType": "status_code",
     "rank": 5767,
-    "url": "https://angel.co/{}",
+    "url": "https://angel.co/u/{}",
     "urlMain": "https://angel.co/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -615,21 +615,6 @@ As of 2020-04-02, boingboing.net requires a login to check if a user exits or no
    },
 ```
 
-## Telegram
-As of 2020-04-02 Telegram always returns true even though an username is non-existant
-
-´´´
-   "Telegram": {
-     "errorType": "response_url",
-     "errorUrl": "https://telegram.org",
-     "rank": 385,
-     "url": "https://t.me/{}",
-     "urlMain": "https://t.me/",
-     "username_claimed": "saman",
-     "username_unclaimed": "i_do_not_believe_this_account_exists_at_all"
-  },
-´´´
-
 ## elwoRU
 As of 2020-04-04, elwoRu does not exist anymore. I confirmed using
 downforeveryoneorjustme.com that the website is down.

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -373,13 +373,13 @@ Usernames that exist are not detected.
 
 ## AngelList
 
-Usernames that exist are not detected.
+Usernames that exist are not detected. Forbidden Request 403 Error.
 
 ```
   "AngelList": {
     "errorType": "status_code",
     "rank": 5767,
-    "url": "https://angel.co/{}",
+    "url": "https://angel.co/u/{}",
     "urlMain": "https://angel.co/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1648,6 +1648,15 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Telegram": {
+    "errorMsg":"<meta property=\"og:description\" content=\"\">",
+    "errorType": "message",
+    "rank": 385,
+    "url": "https://t.me/{}",
+    "urlMain": "https://t.me/",
+    "username_claimed": "roopeshvs",
+    "username_unclaimed": "noonewouldeverusethis7"
+ },
   "Tellonym.me": {
     "errorType": "status_code",
     "rank": 26963,


### PR DESCRIPTION
The Incorrect URL for Angel List has been updated.
However, it is still not possible to verify usernames in this site as the request generates a Forbidden 403 Error.

Edit:
Telegram Username check is modified and works now.
Changed Error type from status_code to errorMsg.
Thus, removed entry from removed_sites.md