### PR TITLE
Fixed CapFriendly Check

### DIFF
--- a/data_bad_site.json
+++ b/data_bad_site.json
@@ -39,15 +39,6 @@
     "url": "http://blackplanet.com/{}",
     "urlMain": "http://blackplanet.com/"
   },
-  "CapFriendly": {
-    "errorMsg": "No User Found",
-    "errorType": "message",
-    "rank": 64100,
-    "url": "https://www.capfriendly.com/users/{}",
-    "urlMain": "https://www.capfriendly.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis"
-  },
   "Canva": {
     "errorType": "response_url",
     "errorUrl": "https://www.canva.com/{}",

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -514,22 +514,6 @@ Good-bye [Google Plus](https://en.wikipedia.org/wiki/Google%2B)...
   },
 ```
 
-## CapFriendly
-
-As of 2020-02-17, CapFriendly returns fake profile pages for non-existing users, what seems to distinguish between the pages is the Sign-up date, for non-existing users, the web application returns a date before 2000-01-01.
-
-```
-  "CapFriendly": {
-    "errorMsg": "No User Found",
-    "errorType": "message",
-    "rank": 64100,
-    "url": "https://www.capfriendly.com/users/{}",
-    "urlMain": "https://www.capfriendly.com/",
-    "username_claimed": "user",
-    "username_unclaimed": "noonewouldeverusethis"
-  },
-```
-
 
 ## Furaffinity
 

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -282,6 +282,15 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis"
   },
+  "CapFriendly": {
+    "errorMsg": "<div class=\"err show p5\">No results found</div>",
+    "errorType": "message",
+    "rank": 64100,
+    "url": "https://www.capfriendly.com/users/{}",
+    "urlMain": "https://www.capfriendly.com/",
+    "username_claimed": "thisactuallyexists",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Carbonmade": {
     "errorType": "response_url",
     "errorUrl": "https://carbonmade.com/fourohfour?domain={}.carbonmade.com",


### PR DESCRIPTION
CapFriendly returns Fake Profiles that seem indistinguishable.
Found a cheeky difference that appeared in Faked Profiles but did not in Actual Profiles.
`<div class="err show p5">No results found</div>`
Matching Error Message against this tells us if the user exists or not.