### PR TITLE
9Gag Works! Weird.

### DIFF
--- a/data_bad_site.json
+++ b/data_bad_site.json
@@ -1,12 +1,4 @@
 {
-  "9GAG": {
-    "errorType": "status_code",
-    "rank": 389,
-    "url": "https://9gag.com/u/{}",
-    "urlMain": "https://9gag.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
   "AdobeForums": {
     "errorType": "status_code",
     "rank": 59,

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -41,20 +41,7 @@ turned on.
     "username_unclaimed": "noonewouldeverusethis7"
   },
 ```
-## 9GAG
 
-As of 2020-05-25, all usernames are reported as available.
-
-```
-  "9GAG": {
-    "errorType": "status_code",
-    "rank": 389,
-    "url": "https://9gag.com/u/{}",
-    "urlMain": "https://9gag.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
-```
 
 ## Investing.com
 

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -66,7 +66,7 @@
   "9GAG": {
     "errorType": "status_code",
     "rank": 389,
-    "url": "https://9gag.com/u/{}",
+    "url": "https://www.9gag.com/u/{}",
     "urlMain": "https://www.9gag.com/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -66,8 +66,8 @@
   "9GAG": {
     "errorType": "status_code",
     "rank": 389,
-    "url": "https://www.9gag.com/u/{}",
-    "urlMain": "https://9gag.com/",
+    "url": "https://9gag.com/u/{}",
+    "urlMain": "https://www.9gag.com/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -63,6 +63,14 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "9GAG": {
+    "errorType": "status_code",
+    "rank": 389,
+    "url": "https://www.9gag.com/u/{}",
+    "urlMain": "https://9gag.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "About.me": {
     "errorType": "status_code",
     "rank": 11447,


### PR DESCRIPTION
9Gag was marked as reporting all usernames as valid.
Going through today (06.08.2020) I found that the site returned different pages when called as:

> https://9gag.com/ 

     -- Returned a 403 Error on POSTMAN with some HTML on Cloudfare Error.
and

> https://www.9gag.com/

      -- Returned the correct HTML page.
Weird and I am not sure why.
But testing usernames after adding www, it works magically!