### PR TITLE
MetaCritic Regex & False Positive Fix

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2137,7 +2137,7 @@
   "metacritic": {
     "errorMsg": "User not found",
     "errorType": "message",
-    "regexCheck": "^(?![-_])[A-Za-z0-9-_]{3,15}$",
+    "regexCheck": "^(?![-_].)[A-Za-z0-9-_]{3,15}$",
     "url": "https://www.metacritic.com/user/{}",
     "urlMain": "https://www.metacritic.com/",
     "username_claimed": "blue",


### PR DESCRIPTION
Metacritic does not allow . in its username which was the one causing issues with Sherlock.