### PR TITLE
Fixed eBay False Positive on Other Languages

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -468,7 +468,7 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Ebay": {
-    "errorMsg": "The User ID you entered was not found",
+    "errorMsg": "<title>eBay Profile - error</title>",
     "errorType": "message",
     "url": "https://www.ebay.com/usr/{}",
     "urlMain": "https://www.ebay.com/",


### PR DESCRIPTION
eBay uses the same title for non-existent profiles irrespective of the language, which we now use as ErrorMsg.