### PR TITLE
query sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ python3 -m pip install -r requirements.txt
 ```bash
 $ python3 sherlock --help
 usage: sherlock [-h] [--version] [--verbose] [--folderoutput FOLDEROUTPUT] [--output OUTPUT]
-                [--tor] [--unique-tor] [--csv] [--site SITE_NAME] [--proxy PROXY_URL]
+                [--tor] [--unique-tor] [--csv] [--site SITE_NAME] [--search SEARCH] [--proxy PROXY_URL]
                 [--json JSON_FILE] [--timeout TIMEOUT] [--print-found] [--no-color] [--browse]
                 USERNAMES [USERNAMES ...]
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ optional arguments:
   --csv                 Create Comma-Separated Values (CSV) File.
   --site SITE_NAME      Limit analysis to just the listed sites. Add multiple options to specify
                         more than one site.
+  --search SEARCH       Limit analysis to just the sites that contains the specified text. 
+                        Add multiple options to specify more than one query.
   --proxy PROXY_URL, -p PROXY_URL
                         Make requests over a proxy. e.g. socks5://127.0.0.1:1080
   --json JSON_FILE, -j JSON_FILE

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -429,9 +429,11 @@ def get_specified_sites(sites_all, sites_desired, matcher, error_message):
             if matcher(site, existing_site):  #check if user's desired site matches iterated sites from file
                 site_data[existing_site] = sites_all[existing_site]
                 counter += 1
+
         if counter == 0:
             # Build up list of sites not supported for future error message.
             site_missing.append(f"'{site}'")
+
     if site_missing:
         print(f"Error: {error_message}: {', '.join(site_missing)}.")
     return site_data
@@ -573,14 +575,14 @@ def main():
         # desired to select by site name
         if args.site_list:
             result = get_specified_sites(site_data_all, args.site_list,
-                                        lambda specified_site, site: specified_site.lower() == site.lower(),
+                                        lambda specified_site, site: specified_site.lower() == site.lower(), # checks if user's site IS EXACTLY as the site from file
                                         "Desired sites not found")
             site_data.update(result)
 
         # desired to search by site name
         if args.search:
             result = get_specified_sites(site_data_all, args.search,
-                                        lambda specified_site, site: specified_site.lower() in site.lower(),
+                                        lambda specified_site, site: specified_site.lower() in site.lower(), # checks if user's site MATCHES the site from file
                                         "Desired queries not found")
             site_data.update(result)
     else:

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -478,7 +478,7 @@ def main():
                         )
     parser.add_argument("--search", metavar="SEARCH",
                         action="append", dest="search", default=None,
-                        help="Limit analysis to just the sites that contains the specified text"
+                        help="Limit analysis to just the sites that contains the specified text. Add multiple options to specify more than one query."
                         )
     parser.add_argument("--proxy", "-p", metavar='PROXY_URL',
                         action="store", dest="proxy", default=None,


### PR DESCRIPTION
Hello, my pull request contains a new functionality -> searching. It allows to search sites with specified text.
Example:``` python sherlock username --search twit ``` will check if username is available on **twit**ter and on **twit**ch.

Except that, I had to perform some refactoring to make it more readable together with --site option. Code is now more friendly for future features, like searching sites with e.g search engine.

I also found a small bug:
```
site_data = {}
site_missing = []
for site in args.site_list:
    for existing_site in site_data_all:
        if site.lower() == existing_site.lower():
            site_data[existing_site] = site_data_all[existing_site]
    if not site_data:
        # Build up list of sites not supported for future error message.
        site_missing.append(f"'{site}'")
```
site_missing won't be appended if site_data has any item, like ```python sherlock username --site facebook --site facebuk```
won't print an error about **facebuk**, because site_data has **facebook** item. I fixed it with a counter variable.

Please inform me if You have any considerations about that. :+1: 