### PR TITLE
fixed missing_sites

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -557,16 +557,19 @@ def main():
         site_data = {}
         site_missing = []
         for site in args.site_list:
+            counter = 0
             for existing_site in site_data_all:
                 if site.lower() == existing_site.lower():
                     site_data[existing_site] = site_data_all[existing_site]
-            if not site_data:
+                    counter += 1
+            if counter == 0:
                 # Build up list of sites not supported for future error message.
                 site_missing.append(f"'{site}'")
 
         if site_missing:
-            print(
-                f"Error: Desired sites not found: {', '.join(site_missing)}.")
+            print(f"Error: Desired sites not found: {', '.join(site_missing)}.")
+
+        if not site_data:
             sys.exit(1)
 
     #Create notify object for query results.


### PR DESCRIPTION
Hello

I found a small bug:
```
site_data = {}
site_missing = []
for site in args.site_list:
    for existing_site in site_data_all:
        if site.lower() == existing_site.lower():
            site_data[existing_site] = site_data_all[existing_site]
     if not site_data:
         # Build up list of sites not supported for future error message.
         site_missing.append(f"'{site}'")

f site_missing:
    print(
        f"Error: Desired sites not found: {', '.join(site_missing)}.")
    sys.exit(1)
```
If user inserts multiple sites with ```--site```, and program correctly finds one of the sites, the next ones won't be added to ```site_missing``` even if they are wrong. For example ```python sherlock username --site facebook --site twittter```
won't print out message about wrong twittter site name, because site_data has item (facebook). I solved it with counter variable instead of checking ```if not site_data:```.

Glad to help.