### PR TITLE
Added --local argument for local data.json use

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -492,8 +492,8 @@ def main():
                         help="Browse to all results on default browser.")
     
     parser.add_argument("--local", "-l",
-                        action="store_true", default=None,
-                        help="Forces the use of the local data.json file.")
+                        action="store_true", default=False,
+                        help="Force the use of the local data.json file.")
 
     args = parser.parse_args()
 

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -490,6 +490,10 @@ def main():
     parser.add_argument("--browse", "-b",
                         action="store_true", dest="browse", default=False,
                         help="Browse to all results on default browser.")
+    
+    parser.add_argument("--local", "-l",
+                        action='store_true', default=None,
+                        help="Forces the use of the local data.json file.")
 
     args = parser.parse_args()
 
@@ -535,7 +539,10 @@ def main():
 
     #Create object with all information about sites we are aware of.
     try:
-        sites = SitesInformation(args.json_file)
+        if args.local:
+            sites = SitesInformation(os.path.join(os.path.dirname(__file__), 'resources/data.json'))
+        else:
+            sites = SitesInformation(args.json_file)
     except Exception as error:
         print(f"ERROR:  {error}")
         sys.exit(1)

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -25,7 +25,7 @@ from notify import QueryNotifyPrint
 from sites  import SitesInformation
 
 module_name = "Sherlock: Find Usernames Across Social Networks"
-__version__ = "0.12.5"
+__version__ = "0.12.7"
 
 
 

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -492,7 +492,7 @@ def main():
                         help="Browse to all results on default browser.")
     
     parser.add_argument("--local", "-l",
-                        action='store_true', default=None,
+                        action="store_true", default=None,
                         help="Forces the use of the local data.json file.")
 
     args = parser.parse_args()


### PR DESCRIPTION
Having to use ```--json sherlock/resources/data.json``` to use the local data.json seems a bit cumbersome, so I've added a simple "--local" or "-l" argument to force it's use.