### PR TITLE
added a --print-all flag

### DIFF
--- a/sherlock/notify.py
+++ b/sherlock/notify.py
@@ -110,7 +110,7 @@ class QueryNotifyPrint(QueryNotify):
 
     Query notify class that prints results.
     """
-    def __init__(self, result=None, verbose=False, color=True):
+    def __init__(self, result=None, verbose=False, color=True, print_all=False):
         """Create Query Notify Print Object.
 
         Contains information about a specific method of notifying the results
@@ -121,6 +121,7 @@ class QueryNotifyPrint(QueryNotify):
         result                 -- Object of type QueryResult() containing
                                   results for this query.
         verbose                -- Boolean indicating whether to give verbose output.
+        print_all              -- Boolean indicating whether to only print all sites, including not found.
         color                  -- Boolean indicating whether to color terminal output
 
         Return Value:
@@ -132,6 +133,7 @@ class QueryNotifyPrint(QueryNotify):
 
         super().__init__(result)
         self.verbose = verbose
+        self.print_all = print_all
         self.color = color
 
         return
@@ -197,7 +199,7 @@ class QueryNotifyPrint(QueryNotify):
                 print(f"[+]{response_time_text} {self.result.site_name}: {self.result.site_url_user}")
 
         elif result.status == QueryStatus.AVAILABLE:
-            if self.verbose:
+            if self.print_all:
                 if self.color:
                     print((Style.BRIGHT + Fore.WHITE + "[" +
                         Fore.RED + "-" +
@@ -209,7 +211,7 @@ class QueryNotifyPrint(QueryNotify):
                     print(f"[-]{response_time_text} {self.result.site_name}: Not Found!")
 
         elif result.status == QueryStatus.UNKNOWN:
-            if self.verbose:
+            if self.print_all:
                 if self.color:
                     print(Style.BRIGHT + Fore.WHITE + "[" +
                           Fore.RED + "-" +
@@ -221,7 +223,7 @@ class QueryNotifyPrint(QueryNotify):
                     print(f"[-] {self.result.site_name}: {self.result.context} ")
 
         elif result.status == QueryStatus.ILLEGAL:
-            if self.verbose:
+            if self.print_all:
                 msg = "Illegal Username Format For This Site!"
                 if self.color:
                     print((Style.BRIGHT + Fore.WHITE + "[" +

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -25,7 +25,7 @@ from notify import QueryNotifyPrint
 from sites  import SitesInformation
 
 module_name = "Sherlock: Find Usernames Across Social Networks"
-__version__ = "0.12.7"
+__version__ = "0.12.8"
 
 
 
@@ -475,6 +475,10 @@ def main():
                              "A longer timeout will be more likely to get results from slow sites."
                              "On the other hand, this may cause a long delay to gather all results."
                         )
+    parser.add_argument("--print-all",
+                        action="store_true", dest="print_all", default=False,
+                        help="Output sites where the username was not found."
+                        )
     parser.add_argument("--no-color",
                         action="store_true", dest="no_color", default=False,
                         help="Don't color terminal output"
@@ -495,7 +499,6 @@ def main():
     args = parser.parse_args()
 
     # Check for newer version of Sherlock. If it exists, let the user know about it
-
     try:
         r = requests.get("https://raw.githubusercontent.com/sherlock-project/sherlock/master/sherlock/sherlock.py")
 
@@ -579,6 +582,7 @@ def main():
     #Create notify object for query results.
     query_notify = QueryNotifyPrint(result=None,
                                     verbose=args.verbose,
+                                    print_all=args.print_all,
                                     color=not args.no_color)
 
     # Run report on all specified users.


### PR DESCRIPTION
This flag will output all the sites regardless the QueryStatus.
As mentioned by @hoadlck, this flag is more appropriate than using
--verbose, which is the flag I set to serve the same purpose as
--print-all in the previous commit. More of the discussion about this
flag can been viewed in #747