### PR TITLE
Update Command Line Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,14 @@ $ python3 -m pip install -r requirements.txt
 
 ```console
 $ python3 sherlock --help
-usage: sherlock [-h] [--version] [--verbose] [--folderoutput FOLDEROUTPUT] [--output OUTPUT]
-                [--tor] [--unique-tor] [--csv] [--site SITE_NAME] [--proxy PROXY_URL]
-                [--json JSON_FILE] [--timeout TIMEOUT] [--no-color] [--browse]
+usage: sherlock [-h] [--version] [--verbose] [--folderoutput FOLDEROUTPUT]
+                [--output OUTPUT] [--tor] [--unique-tor] [--csv]
+                [--site SITE_NAME] [--proxy PROXY_URL] [--json JSON_FILE]
+                [--timeout TIMEOUT] [--print-all] [--print-found] [--no-color]
+                [--browse] [--local]
                 USERNAMES [USERNAMES ...]
 
-Sherlock: Find Usernames Across Social Networks (Version 0.12.8)
+Sherlock: Find Usernames Across Social Networks (Version 0.12.9)
 
 positional arguments:
   USERNAMES             One or more usernames to check with social networks.
@@ -67,26 +69,32 @@ optional arguments:
   --verbose, -v, -d, --debug
                         Display extra debugging information and metrics.
   --folderoutput FOLDEROUTPUT, -fo FOLDEROUTPUT
-                        If using multiple usernames, the output of the results will be saved to
-                        this folder.
+                        If using multiple usernames, the output of the results
+                        will be saved to this folder.
   --output OUTPUT, -o OUTPUT
-                        If using single username, the output of the result will be saved to this
-                        file.
-  --tor, -t             Make requests over Tor; increases runtime; requires Tor to be installed and
-                        in system path.
-  --unique-tor, -u      Make requests over Tor with new Tor circuit after each request; increases
-                        runtime; requires Tor to be installed and in system path.
+                        If using single username, the output of the result
+                        will be saved to this file.
+  --tor, -t             Make requests over Tor; increases runtime; requires
+                        Tor to be installed and in system path.
+  --unique-tor, -u      Make requests over Tor with new Tor circuit after each
+                        request; increases runtime; requires Tor to be
+                        installed and in system path.
   --csv                 Create Comma-Separated Values (CSV) File.
-  --site SITE_NAME      Limit analysis to just the listed sites. Add multiple options to specify
-                        more than one site.
+  --site SITE_NAME      Limit analysis to just the listed sites. Add multiple
+                        options to specify more than one site.
   --proxy PROXY_URL, -p PROXY_URL
-                        Make requests over a proxy. e.g. socks5://127.0.0.1:1080
+                        Make requests over a proxy. e.g.
+                        socks5://127.0.0.1:1080
   --json JSON_FILE, -j JSON_FILE
-                        Load data from a JSON file or an online, valid, JSON file.
-  --timeout TIMEOUT     Time (in seconds) to wait for response to requests. Default timeout of
-                        60.0s.A longer timeout will be more likely to get results from slow
-                        sites.On the other hand, this may cause a long delay to gather all results.
+                        Load data from a JSON file or an online, valid, JSON
+                        file.
+  --timeout TIMEOUT     Time (in seconds) to wait for response to requests.
+                        Default timeout is infinity. A longer timeout will be
+                        more likely to get results from slow sites. On the
+                        other hand, this may cause a long delay to gather all
+                        results.
   --print-all           Output sites where the username was not found.
+  --print-found         Output sites where the username was found.
   --no-color            Don't color terminal output
   --browse, -b          Browse to all results on default browser.
   --local, -l           Force the use of the local data.json file.

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -233,7 +233,7 @@ def sherlock(username, site_data, query_notify,
                 # from where the user profile normally can be found.
                 url_probe = url_probe.format(username)
 
-            if (net_info["errorType"] == 'status_code' and 
+            if (net_info["errorType"] == 'status_code' and
                 net_info.get("request_head_only", True) == True):
                 #In most cases when we are detecting by status code,
                 #it is not necessary to get the entire body:  we can
@@ -476,9 +476,13 @@ def main():
                              "On the other hand, this may cause a long delay to gather all results."
                         )
     parser.add_argument("--print-all",
-                        action="store_true", dest="print_all", default=False,
+                        action="store_true", dest="print_all",
                         help="Output sites where the username was not found."
-                        )
+                       )
+    parser.add_argument("--print-found",
+                        action="store_false", dest="print_all", default=False,
+                        help="Output sites where the username was found."
+                       )
     parser.add_argument("--no-color",
                         action="store_true", dest="no_color", default=False,
                         help="Don't color terminal output"
@@ -491,7 +495,7 @@ def main():
     parser.add_argument("--browse", "-b",
                         action="store_true", dest="browse", default=False,
                         help="Browse to all results on default browser.")
-    
+
     parser.add_argument("--local", "-l",
                         action="store_true", default=False,
                         help="Force the use of the local data.json file.")
@@ -508,7 +512,7 @@ def main():
         if remote_version != local_version:
             print("Update Available!\n" +
                   f"You are running version {local_version}. Version {remote_version} is available at https://git.io/sherlock")
-    
+
     except Exception as error:
         print(f"A problem occured while checking for an update: {error}")
 

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -471,10 +471,10 @@ def main():
                         action="store", metavar='TIMEOUT',
                         dest="timeout", type=timeout_check, default=None,
                         help="Time (in seconds) to wait for response to requests. "
-                             "Default timeout of 60.0s."
-                             "A longer timeout will be more likely to get results from slow sites."
+                             "Default timeout is infinity. "
+                             "A longer timeout will be more likely to get results from slow sites. "
                              "On the other hand, this may cause a long delay to gather all results."
-                        )
+                       )
     parser.add_argument("--print-all",
                         action="store_true", dest="print_all",
                         help="Output sites where the username was not found."

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -25,7 +25,7 @@ from notify import QueryNotifyPrint
 from sites  import SitesInformation
 
 module_name = "Sherlock: Find Usernames Across Social Networks"
-__version__ = "0.12.8"
+__version__ = "0.12.9"
 
 
 


### PR DESCRIPTION
Restore --print-found option.

Now --print-all and --print-found complement each other.  The default remains that only the found are reported.

Update documentation on timeout command line option.