### PR TITLE
CashMe Fix

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -263,7 +263,8 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "CashMe": {
-    "errorType": "status_code",
+    "errorMsg": "ss\"",
+    "errorType": "message",
     "url": "https://cash.me/${}",
     "urlMain": "https://cash.me/",
     "username_claimed": "Jenny",


### PR DESCRIPTION
Quirky.

In places CashMe operates, Usernames that do not exist give,

```javascript
{
    "success": false,
    "message": {
        "message": "",
        "already_localized": true
    },
    "debug_info": ""
}
```

In places CashMe does not operate, we get the following,

```html
<html lang="en">
<head>
  <meta charset="UTF-8" />
  <title>Cash App</title>
  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
  <link rel="stylesheet" type="text/css"
...
```

*ss"* is a match on the Non-Existing Usernames in places CashMe operates through the standard JSON response and also on countries that do not have CashMe through the standard HTML response. 
This cannot be found on the HTML response for Existing Usernames in places CashMe operate.