### PR TITLE
Fixed false positive for freelance.habr

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -560,6 +560,7 @@
     "username_unclaimed": "noonewouldeverusethis"
   },
   "Freelance.habr": {
+    "regexCheck": "^((?!\\.).)*$",
     "errorMsg": "<div class=\"icon_user_locked\"></div>",
     "errorType": "message",
     "url": "https://freelance.habr.com/freelancers/{}",


### PR DESCRIPTION
Usernames with dots led to false positives for freelance.habr. Changes in this PR add a regex check to prevent the issue from occurring.