### PR TITLE
Implements error_type content_regex and adds instagram check

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -372,14 +372,14 @@
     "username_claimed": "deepigoyal",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "mixer.com": { 
-    "errorType": "status_code", 
-    "rank": 1544, 
-    "url": "https://mixer.com/{}", 
-    "urlMain": "https://mixer.com/", 
-    "urlProbe": "https://mixer.com/api/v1/channels/{}", 
-    "username_claimed": "blue", 
-    "username_unclaimed": "noonewouldeverusethis7" 
+  "mixer.com": {
+    "errorType": "status_code",
+    "rank": 1544,
+    "url": "https://mixer.com/{}",
+    "urlMain": "https://mixer.com/",
+    "urlProbe": "https://mixer.com/api/v1/channels/{}",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
   },
   "KanoWorld": {
     "errorType": "status_code",
@@ -521,14 +521,6 @@
     "urlMain": "http://www.pokerstrategy.net",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
-  },
-  "Instagram": {
-    "errorType": "status_code",
-    "request_head_only": false,
-    "url": "https://www.instagram.com/{}",
-    "urlMain": "https://www.instagram.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
+  }
 }
 

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1036,16 +1036,3 @@ As of 2020-10-21, PokerStrategy returns false positives. This was reported in #7
     "username_unclaimed": "noonewouldeverusethis7"
   },
 ```
-
-## Instagram
-As of 2020-10-21, Instagram return false positives. This was reported in #764
-```
-  "Instagram": {
-    "errorType": "status_code",
-    "request_head_only": false,
-    "url": "https://www.instagram.com/{}",
-    "urlMain": "https://www.instagram.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
-```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -757,6 +757,14 @@
     "username_claimed": "adam",
     "username_unclaimed": "noonewouldeverusethis"
   },
+  "Instagram": {
+    "errorType": "content_regex",
+    "errorRegex": "<title>[\\r\\n]*Instagram[\\r\\n]*<\\/title>",
+    "url": "https://www.instagram.com/{}",
+    "urlMain": "https://www.instagram.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Instructables": {
     "errorMsg": "404: We're sorry, things break sometimes",
     "errorType": "message",

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -354,6 +354,21 @@ def sherlock(username, site_data, query_notify,
                                      url,
                                      QueryStatus.AVAILABLE,
                                      query_time=response_time)
+        elif error_type == "content_regex":
+            error_regex = net_info['errorRegex']
+
+            if error_regex and re.search(error_regex, r.text) is None:
+                result = QueryResult(username,
+                                     social_network,
+                                     url,
+                                     QueryStatus.CLAIMED,
+                                     query_time=response_time)
+            else:
+                result = QueryResult(username,
+                                     social_network,
+                                     url,
+                                     QueryStatus.AVAILABLE,
+                                     query_time=response_time)
         elif error_type == "response_url":
             # For this detection method, we have turned off the redirect.
             # So, there is no need to check the response URL: it will always


### PR DESCRIPTION
I'm trying to add instagram verification again,  but I understand that the current `error_type` implementations don't have a way to implement this verification, so I create a new `error_type` called `content_regex`, which checks the content with regex, and that way I can implement the instagram verification.