### PR TITLE
Add support for ChessKid

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -285,6 +285,14 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "ChessKid": {
+    "errorMsg": "",
+    "errorType": "message",
+    "url": "https://chesskid.com/user/{}/profile"
+    "urlMain": "https://chesskid.com",
+    "username_claimed": "AiryCleanCarrot",
+    "username_unclaimed": "blue",
+  },
   "Cloob": {
     "errorType": "status_code",
     "url": "https://www.cloob.com/name/{}",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -288,7 +288,7 @@
   "ChessKid": {
     "errorMsg": "",
     "errorType": "message",
-    "url": "https://chesskid.com/user/{}/profile"
+    "url": "https://chesskid.com/user/{}/profile",
     "urlMain": "https://chesskid.com",
     "username_claimed": "AiryCleanCarrot",
     "username_unclaimed": "blue",


### PR DESCRIPTION
URLs for unclaimed names return an empty screen, so I put the `errorType` as a message and the `errorMsg` as an empty string.