### PR TITLE
Adding facility to support multiple errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report a bug in Sherlock's functionality
+title: ''
+labels: bug 
+assignees: ''
+
+---
+
+<!--
+
+######################################################################
+  WARNING!
+  IGNORING THE FOLLOWING TEMPLATE WILL RESULT IN ISSUE CLOSED AS INCOMPLETE
+######################################################################
+
+-->
+
+
+## Checklist
+<!--
+Put x into all boxes (like this [x]) once you have completed what they say.
+Make sure complete everything in the checklist.
+-->
+
+- [ ] I'm reporting a bug in Sherlock's functionality
+- [ ] The bug I'm reporting is not a false positive or a false negative
+- [ ] I've verified that I'm running the latest version of Sherlock
+- [ ] I've checked for similar bug reports including closed ones
+- [ ] I've checked for pull requests that attempt to fix this bug
+
+## Description
+<!--
+Provide a detailed description of the bug that you have found in Sherlock.
+Provide the version of Sherlock you are running.
+-->
+
+WRITE DESCRIPTION HERE

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Request a new functionality for Sherlock
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+<!--
+
+######################################################################
+  WARNING!
+  IGNORING THE FOLLOWING TEMPLATE WILL RESULT IN ISSUE CLOSED AS INCOMPLETE
+######################################################################
+
+-->
+
+## Checklist
+<!--
+Put x into all boxes (like this [x]) once you have completed what they say.
+Make sure complete everything in the checklist.
+-->
+- [ ] I'm reporting a feature request
+- [ ] I've checked for similar feature requests including closed ones
+
+## Description
+<!-- 
+Provide a detailed description of the feature you would like Sherlock to have
+-->
+
+WRITE DESCRIPTION HERE

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,33 @@
+---
+name: Question
+about: Ask us a question
+title: ''
+labels: question
+assignees: ''
+
+---
+
+<!--
+
+######################################################################
+  WARNING!
+  IGNORING THE FOLLOWING TEMPLATE WILL RESULT IN ISSUE CLOSED AS INCOMPLETE.
+######################################################################
+
+-->
+
+## Checklist
+<!--
+Put x into all boxes (like this [x]) once you have completed what they say.
+Make sure complete everything in the checklist.
+-->
+- [ ] I'm asking a question regarding Sherlock
+- [ ] My question is not a tech support question.
+
+**We are not your tech support**. 
+If you have questions related to `pip`, `git`, or something that is not related to Sherlock, please ask them on [StackOverflow](https://stackoverflow.com/) or [r/learnpython](https://www.reddit.com/r/learnpython/)
+
+
+## Question
+
+ASK YOUR QUESTION HERE

--- a/.github/ISSUE_TEMPLATE/reporting-false-negative.md
+++ b/.github/ISSUE_TEMPLATE/reporting-false-negative.md
@@ -1,0 +1,34 @@
+---
+name: Reporting false negative
+about: Reporting a site that is returning false positives
+title: ''
+labels: false negative 
+assignees: ''
+
+---
+
+<!--
+
+######################################################################
+  WARNING!
+  IGNORING THE FOLLOWING TEMPLATE WILL RESULT IN ISSUE CLOSED AS INCOMPLETE
+######################################################################
+
+-->
+
+## Checklist
+<!--
+Put x into all boxes (like this [x]) once you have completed what they say.
+Make sure complete everything in the checklist.
+-->
+- [ ] I'm reporting a website that is returning **false negative** results
+- [ ] I've checked for similar site support requests including closed ones
+- [ ] I've checked for pull requests attempting to fix this false negative
+- [ ] I'm only reporting **one** site (create a seperate issue for each site)
+
+## Description
+<!--
+Provide the username that is causing Sherlock to return a false negative, along with any other information that might help us fix this false negative.
+-->
+
+WRITE DESCRIPTION HERE

--- a/.github/ISSUE_TEMPLATE/reporting-false-positive.md
+++ b/.github/ISSUE_TEMPLATE/reporting-false-positive.md
@@ -1,0 +1,34 @@
+---
+name: Reporting false positive
+about: Reporting a site that is returning false positives
+title: ''
+labels: false positive 
+assignees: ''
+
+---
+
+<!--
+
+######################################################################
+  WARNING!
+  IGNORING THE FOLLOWING TEMPLATE WILL RESULT IN ISSUE CLOSED AS INCOMPLETE
+######################################################################
+
+-->
+
+## Checklist
+<!--
+Put x into all boxes (like this [x]) once you have completed what they say.
+Make sure complete everything in the checklist.
+-->
+- [ ] I'm reporting a website that is returning **false positive** results
+- [ ] I've checked for similar site support requests including closed ones
+- [ ] I've checked for pull requests attempting to fix this false positive
+- [ ] I'm only reporting **one** site (create a seperate issue for each site)
+
+## Description
+<!--
+Provide the username that is causing Sherlock to return a false positive, along with any other information that might help us fix this false positive.
+-->
+
+WRITE DESCRIPTION HERE

--- a/.github/ISSUE_TEMPLATE/site-support-request.md
+++ b/.github/ISSUE_TEMPLATE/site-support-request.md
@@ -1,0 +1,37 @@
+---
+name: Site support request
+about: Request support for a new site
+title: ''
+labels: site support request
+assignees: ''
+
+---
+
+<!--
+
+######################################################################
+  WARNING!
+  IGNORING THE FOLLOWING TEMPLATE WILL RESULT IN ISSUE CLOSED AS INCOMPLETE
+######################################################################
+
+-->
+
+## Checklist
+<!--
+Put x into all boxes (like this [x]) once you have completed what they say.
+Make sure complete everything in the checklist.
+-->
+
+- [ ] I'm requesting support for a new site
+- [ ] I've checked for similar site support requests including closed ones
+- [ ] I've checked that the site I am requesting has not been removed in the past and is not documented in [removed_sites.md](https://github.com/sherlock-project/sherlock/blob/master/removed_sites.md)
+- [ ] The site I am requesting support for is not a pornographic website
+- [ ] I'm only requesting support of **one** website (create a seperate issue for each site)
+
+## Description
+<!--
+Provide the url to the website and the name of the website.
+If there is anything else you want to mention regarding the site support request include that in this section.
+-->
+
+URL:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ the site may be removed from the list.  The
 file contains sites that were included at one time in Sherlock, but had to be removed for
 one reason or another.
 
-In regards to adult sites (e.g. PornHub), we have agreed to not include them in Sherlock.  
+In regards to adult sites (e.g. Pornhub), we have agreed to not include them in Sherlock.  
 However, we do understand that some users desire this support.  The data.json file is easy to add to, 
 so users will be able to maintain their own forks to have this support. This is not ideal.  
 Maybe there could be another repo with an adult data.json? That would avoid forks getting out of date.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ file contains sites that were included at one time in Sherlock, but had to be re
 one reason or another.
 
 In regards to adult sites (e.g. PornHub), we have agreed to not include them in Sherlock.  
-However, we do understand that some users desires this support.  The data.json file is easy to add to, 
+However, we do understand that some users desire this support.  The data.json file is easy to add to, 
 so users will be able to maintain their own forks to have this support. This is not ideal.  
 Maybe there could be another repo with an adult data.json? That would avoid forks getting out of date.
 

--- a/removed_sites.json
+++ b/removed_sites.json
@@ -497,6 +497,13 @@
     "urlMain": "http://www.pokerstrategy.net",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
+  },
+  "Filmogs": {
+    "errorType": "status_code",
+    "url": "https://www.filmo.gs/users/{}",
+    "urlMain": "https://www.filmo.gs/",
+    "username_claimed": "cupparober",
+    "username_unclaimed": "noonewouldeverusethis7"
   }
 }
 

--- a/removed_sites.json
+++ b/removed_sites.json
@@ -372,14 +372,14 @@
     "username_claimed": "deepigoyal",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "mixer.com": { 
-    "errorType": "status_code", 
-    "rank": 1544, 
-    "url": "https://mixer.com/{}", 
-    "urlMain": "https://mixer.com/", 
-    "urlProbe": "https://mixer.com/api/v1/channels/{}", 
-    "username_claimed": "blue", 
-    "username_unclaimed": "noonewouldeverusethis7" 
+  "mixer.com": {
+    "errorType": "status_code",
+    "rank": 1544,
+    "url": "https://mixer.com/{}",
+    "urlMain": "https://mixer.com/",
+    "urlProbe": "https://mixer.com/api/v1/channels/{}",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
   },
   "KanoWorld": {
     "errorType": "status_code",
@@ -521,14 +521,6 @@
     "urlMain": "http://www.pokerstrategy.net",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
-  },
-  "Instagram": {
-    "errorType": "status_code",
-    "request_head_only": false,
-    "url": "https://www.instagram.com/{}",
-    "urlMain": "https://www.instagram.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
+  }
 }
 

--- a/removed_sites.json
+++ b/removed_sites.json
@@ -113,14 +113,6 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "Imgur": {
-    "errorType": "status_code",
-    "rank": 74,
-    "url": "https://imgur.com/user/{}",
-    "urlMain": "https://imgur.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
   "Investing.com": {
     "errorType": "status_code",
     "rank": 196,

--- a/removed_sites.json
+++ b/removed_sites.json
@@ -48,14 +48,6 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "ColourLovers": {
-    "errorType": "status_code",
-    "rank": 21271,
-    "url": "https://www.colourlovers.com/lover/{}",
-    "urlMain": "https://www.colourlovers.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
   "EVE Online": {
     "errorType": "response_url",
     "errorUrl": "https://eveonline.com",

--- a/removed_sites.json
+++ b/removed_sites.json
@@ -48,14 +48,6 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "Codepen": {
-    "errorType": "status_code",
-    "rank": 1359,
-    "url": "https://codepen.io/{}",
-    "urlMain": "https://codepen.io/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
   "ColourLovers": {
     "errorType": "status_code",
     "rank": 21271,

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -991,3 +991,20 @@ As of 2020-10-21, PokerStrategy returns false positives. This was reported in #7
     "username_unclaimed": "noonewouldeverusethis7"
   },
 ```
+
+## Filmogs
+
+Filmogs has closed down.
+
+> **Filmogs is closed**
+> **31-Aug 2020** - We are preparing the last data export and collection of images. It will be published here by 19-Oct 2020. If you have requested an export of your data it will also be emailed to you by 19-Oct 2020.
+
+```
+  "Filmogs": {
+    "errorType": "status_code",
+    "url": "https://www.filmo.gs/users/{}",
+    "urlMain": "https://www.filmo.gs/",
+    "username_claimed": "cupparober",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
+```

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -355,21 +355,6 @@ Usernames that exist are not detected. Forbidden Request 403 Error.
   },
 ```
 
-## Codepen
-
-Usernames that exist are not detected.
-
-```
-  "Codepen": {
-    "errorType": "status_code",
-    "rank": 1359,
-    "url": "https://codepen.io/{}",
-    "urlMain": "https://codepen.io/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
-```
-
 ## PowerShell Gallery
 
 Accidentally merged even though the original pull request showed that all

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -370,22 +370,6 @@ Usernames that exist are not detected.
   },
 ```
 
-## Imgur
-
-Looks like they made some changes to the site.  Sherlock says that all
-usernames are available.
-
-```
-  "Imgur": {
-    "errorType": "status_code",
-    "rank": 74,
-    "url": "https://imgur.com/user/{}",
-    "urlMain": "https://imgur.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
-```
-
 ## PowerShell Gallery
 
 Accidentally merged even though the original pull request showed that all

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -61,24 +61,6 @@ required login before access.
     "username_unclaimed": "noonewouldeverusethis7"
   },
 ```
-## ColourLovers
-
-As of 2020-05-24, all usernames are reported as claimed.
-
-There is an API available (https://www.colourlovers.com/api/), but when
-there is no match it returns an empty file.  So, changes would have to
-happen before the lack of a response could be used to detect.
-
-```
-  "ColourLovers": {
-    "errorType": "status_code",
-    "rank": 21271,
-    "url": "https://www.colourlovers.com/lover/{}",
-    "urlMain": "https://www.colourlovers.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
-```
 
 ## AdobeForums
 

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1036,16 +1036,3 @@ As of 2020-10-21, PokerStrategy returns false positives. This was reported in #7
     "username_unclaimed": "noonewouldeverusethis7"
   },
 ```
-
-## Instagram
-As of 2020-10-21, Instagram return false positives. This was reported in #764
-```
-  "Instagram": {
-    "errorType": "status_code",
-    "request_head_only": false,
-    "url": "https://www.instagram.com/{}",
-    "urlMain": "https://www.instagram.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
-```

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -277,7 +277,11 @@ HTTP Status.
 
 ## Foursquare
 
-Usernames that exist are not detected.
+When usage of automated tool is detected. Whole IP is banned from future requests.
+There is an error message:
+
+> Please verify you are a human
+> Access to this page has been denied because we believe you are using automation tools to browse the website.
 
 ```
   "Foursquare": {

--- a/sherlock/__main__.py
+++ b/sherlock/__main__.py
@@ -22,10 +22,7 @@ if __name__ == "__main__":
 
     python_version = str(sys.version_info[0])+"."+str(sys.version_info[1])+"."+str(sys.version_info[2])
 
-    if major != 3:
-        print("Sherlock requires Python 3.6+\nYou are using Python %s, which is not supported by Sherlock" % (python_version))
-        sys.exit(1)
-    if minor < 6:
+    if major != 3 or major == 3 and minor < 6:
         print("Sherlock requires Python 3.6+\nYou are using Python %s, which is not supported by Sherlock" % (python_version))
         sys.exit(1)
 

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -913,8 +913,10 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Medium": {
-    "errorType": "status_code",
+    "errorType": "message",
+    "errorMsg": "<body",
     "url": "https://medium.com/@{}",
+    "urlProbe": "https://medium.com/feed/@{}",
     "urlMain": "https://medium.com/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2231,5 +2231,13 @@
     "urlMain": "https://uid.me/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
+  },
+  "Imgur": {
+    "errorType": "status_code",
+    "urlProbe": "https://api.imgur.com/account/v1/accounts/{}?client_id=546c25a59c58ad7",
+    "url": "https://imgur.com/user/{}",
+    "urlMain": "https://imgur.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
   }
 }

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -500,6 +500,7 @@
   },
   "Facenama": {
     "errorType": "response_url",
+    "regexCheck": "^[-a-zA-Z0-9_]+$",
     "errorUrl": "https://facenama.com/404.html",
     "url": "https://facenama.com/{}",
     "urlMain": "https://facenama.com/",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -560,6 +560,7 @@
     "username_unclaimed": "noonewouldeverusethis"
   },
   "Freelance.habr": {
+    "regexCheck": "^((?!\\.).)*$",
     "errorMsg": "<div class=\"icon_user_locked\"></div>",
     "errorType": "message",
     "url": "https://freelance.habr.com/freelancers/{}",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -476,8 +476,7 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "EyeEm": {
-    "errorMsg": "<title>Not Found (404) | EyeEm</title>",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://www.eyeem.com/u/{}",
     "urlMain": "https://www.eyeem.com/",
     "username_claimed": "blue",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2241,5 +2241,12 @@
     "urlMain": "https://imgur.com/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
+  },
+  "Codepen": {
+    "errorType": "status_code",
+    "url": "https://codepen.io/{}",
+    "urlMain": "https://codepen.io/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
   }
 }

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1050,7 +1050,7 @@
     "errorType": "status_code",
     "url": "https://community.oracle.com/people/{}",
     "urlMain": "https://community.oracle.com",
-    "username_claimed": "blue",
+    "username_claimed": "dev",
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Otzovik": {

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -514,13 +514,6 @@
     "username_claimed": "Jungypoo",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "Filmogs": {
-    "errorType": "status_code",
-    "url": "https://www.filmo.gs/users/{}",
-    "urlMain": "https://www.filmo.gs/",
-    "username_claimed": "cupparober",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
   "Flickr": {
     "errorType": "status_code",
     "url": "https://www.flickr.com/people/{}",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2138,7 +2138,7 @@
   "opennet": {
     "errorMsg": "\u0418\u043c\u044f \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e",
     "errorType": "message",
-    "regexCheck": "^[^_]*$",
+    "regexCheck": "^[^-]*$",
     "url": "https://www.opennet.ru/~{}",
     "urlMain": "https://www.opennet.ru/",
     "username_claimed": "anonismus",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -764,19 +764,7 @@
     "url": "https://www.instagram.com/{}",
     "urlMain": "https://www.instagram.com/",
     "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7",
-    "headers": {
-      "authority": "www.instagram.com",
-      "pragma": "no-cache",
-      "cache-control": "no-cache",
-      "upgrade-insecure-requests": "1",
-      "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-      "sec-fetch-site": "same-origin",
-      "sec-fetch-mode": "navigate",
-      "sec-fetch-user": "?1",
-      "sec-fetch-dest": "document",
-      "accept-language": "en-US,en;q=0.9,pt-BR;q=0.8,pt;q=0.7"
-    }
+    "username_unclaimed": "noonewouldeverusethis7"
   },
   "Instructables": {
     "errorMsg": "404: We're sorry, things break sometimes",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -780,7 +780,7 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "jbzd.com.p": {
+  "jbzd.com.pl": {
     "errorType": "status_code",
     "url": "https://jbzd.com.pl/uzytkownik/{}",
     "urlMain": "https://jbzd.com.pl/",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1638,6 +1638,7 @@
   },
   "Vero": {
     "errorType": "status_code",
+    "request_head_only": false,
     "url": "https://vero.co/{}",
     "urlMain": "https://vero.co/",
     "username_claimed": "blue",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1246,8 +1246,7 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Repl.it": {
-    "errorMsg": "404",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://repl.it/@{}",
     "urlMain": "https://repl.it/",
     "username_claimed": "blue",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1491,7 +1491,8 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Tinder": {
-    "errorMsg": "<title data-react-helmet=\"true\">Tinder | Match. Chat. Date.</title>",
+    "errorMsg": ["<title data-react-helmet=\"true\">Tinder | Dating, Make Friends &amp; Meet New People</title>",
+    "<title data-react-helmet=\"true\">Tinder | Match. Chat. Date.</title>"],
     "errorType": "message",
     "url": "https://www.gotinder.com/@{}",
     "urlMain": "https://tinder.com/",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2248,5 +2248,12 @@
     "urlMain": "https://codepen.io/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
+  },
+  "ColourLovers": {
+    "errorType": "status_code",
+    "url": "https://www.colourlovers.com/lover/{}",
+    "urlMain": "https://www.colourlovers.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
   }
 }

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1676,9 +1676,9 @@
     "username_unclaimed": "noonewouldeverusethis77777"
   },
   "Wattpad": {
-    "errorMsg": "userError-404",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://www.wattpad.com/user/{}",
+    "urlProbe": "https://www.wattpad.com/api/v3/users/{}/",
     "urlMain": "https://www.wattpad.com/",
     "username_claimed": "Dogstho7951",
     "username_unclaimed": "noonewouldeverusethis7"

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -780,6 +780,13 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "jbzd.com.p": {
+    "errorType": "status_code",
+    "url": "https://jbzd.com.pl/uzytkownik/{}",
+    "urlMain": "https://jbzd.com.pl/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Jimdo": {
     "errorType": "status_code",
     "noPeriod": "True",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -758,6 +758,26 @@
     "username_claimed": "adam",
     "username_unclaimed": "noonewouldeverusethis"
   },
+  "Instagram": {
+    "errorType": "message",
+    "errorMsg": "href=\"/static/bundles/metro/HttpErrorPage.js/",
+    "url": "https://www.instagram.com/{}",
+    "urlMain": "https://www.instagram.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7",
+    "headers": {
+      "authority": "www.instagram.com",
+      "pragma": "no-cache",
+      "cache-control": "no-cache",
+      "upgrade-insecure-requests": "1",
+      "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+      "sec-fetch-site": "same-origin",
+      "sec-fetch-mode": "navigate",
+      "sec-fetch-user": "?1",
+      "sec-fetch-dest": "document",
+      "accept-language": "en-US,en;q=0.9,pt-BR;q=0.8,pt;q=0.7"
+    }
+  },
   "Instructables": {
     "errorMsg": "404: We're sorry, things break sometimes",
     "errorType": "message",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1660,10 +1660,11 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "VirusTotal": {
-    "errorMsg": "not found",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://www.virustotal.com/ui/users/{}/trusted_users",
+    "urlProbe": "https://www.virustotal.com/ui/users/{}/avatar",
     "urlMain": "https://www.virustotal.com/",
+    "request_head_only": false,
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -25,7 +25,7 @@ from notify import QueryNotifyPrint
 from sites  import SitesInformation
 
 module_name = "Sherlock: Find Usernames Across Social Networks"
-__version__ = "0.12.9"
+__version__ = "0.13.0"
 
 
 

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -326,9 +326,27 @@ def sherlock(username, site_data, query_notify,
                                  query_time=response_time,
                                  context=error_text)
         elif error_type == "message":
-            error = net_info.get("errorMsg")
-            # Checks if the error message is in the HTML
-            if not error in r.text:
+            # error_flag True denotes no error found in the HTML
+            # error_flag False denotes error found in the HTML
+            error_flag = True
+            errors=net_info.get("errorMsg")
+            # errors will hold the error message
+            # it can be string or list
+            # by insinstance method we can detect that
+            # and handle the case for strings as normal procedure
+            # and if its list we can iterate the errors
+            if isinstance(errors,str):
+                # Checks if the error message is in the HTML
+                # if error is present we will set flag to False
+                if errors in r.text:
+                    error_flag = False
+            else:
+                # If it's list, it will iterate all the error message
+                for error in errors:
+                    if error in r.text:
+                        error_flag = False
+                        break
+            if error_flag:
                 result = QueryResult(username,
                                      social_network,
                                      url,


### PR DESCRIPTION
As of now, Sherlock supports only a single instance for error messages. I have added the functionality which can handle the list/array of error messages.
Taking an example of Tinder, it provides multiple kinds of error. So, I have added those error messages in the data.json file.
Now the core module sherlock.py only supports one error message in form of string. So I have modified that file and handled the case so that it can support a list/array of messages.
As a result, Tinder which was reporting False-Positives is handled, and now it returns correct results.
Also, this can be helpful in the future, in order to support multiple error messages for different sites.