### PR TITLE
use errorMsg for Quora

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1229,8 +1229,8 @@
     "username_unclaimed": "noonewouldeverusethis"
   },
   "Quora": {
-    "errorType": "response_url",
-    "errorUrl": "https://www.quora.com/profile/{}",
+    "errorType": "message",
+    "errorMsg": "Page Not Found",
     "url": "https://www.quora.com/profile/{}",
     "urlMain": "https://www.quora.com/",
     "username_claimed": "Matt-Riggsby",


### PR DESCRIPTION
Use `errorMsg` instead of `errorUrl` as it is more reliable.