### PR TITLE
Use retries/back-off for retrying when rate limited.

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1483,7 +1483,7 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Steamid": {
-    "errorMsg": "<div class=\"alert alert-warning\">Profile not found</div>",
+    "errorMsg": ["<div class=\"alert alert-warning\">Profile not found</div>", "Server or Network issue"],
     "errorType": "message",
     "url": "https://steamid.uk/profile/{}",
     "urlMain": "https://steamid.uk/",

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -15,6 +15,7 @@ import sys
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from time import monotonic
 
+from random import randint
 import requests
 
 from requests_futures.sessions import FuturesSession
@@ -23,6 +24,9 @@ from result import QueryStatus
 from result import QueryResult
 from notify import QueryNotifyPrint
 from sites  import SitesInformation
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
 
 module_name = "Sherlock: Find Usernames Across Social Networks"
 __version__ = "0.13.0"
@@ -171,7 +175,15 @@ def sherlock(username, site_data, query_notify,
         #Normal requests
         underlying_session = requests.session()
         underlying_request = requests.Request()
+    retry_strategy = Retry(
+        total=5,
+        backoff_factor=5,
+        status_forcelist=[400, 403, 429, 500, 502, 503, 504],
+        method_whitelist=["HEAD", "GET", "POST", "OPTIONS"]
+    )
 
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+        
     #Limit number of workers to 20.
     #This is probably vastly overkill.
     if len(site_data) >= 20:
@@ -199,7 +211,7 @@ def sherlock(username, site_data, query_notify,
         # A user agent is needed because some sites don't return the correct
         # information since they think that we are bots (Which we actually are...)
         headers = {
-            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0',
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.{1}; rv:{0}.0) Gecko/20100101 Firefox/{0}.0'.format(randint(55,78), randint(12,16)),
         }
 
         if "headers" in net_info:


### PR DESCRIPTION
This adds retries with backoffs to requests, this has lead to now no longer getting false positives when rate limited and fixes a site.

Should this be a new version number?