### PR TITLE
Adds Fiverr check and implements feature to no follow redirects

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -383,14 +383,6 @@
     "username_claimed": "blue",
     "username_unclaimed": "noneownsthisusername7"
   },
-  "Fiverr": {
-    "errorType": "response_url",
-    "errorUrl": "https://www.fiverr.com/",
-    "url": "https://www.fiverr.com/{}",
-    "urlMain": "https://www.fiverr.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis"
-  },
   "ImageShack": {
     "errorType": "response_url",
     "errorUrl": "https://imageshack.us/",

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -763,21 +763,6 @@ future once we find a better error detecting method.
   },
 ```
 
-## Fiverr
-
-As of 2020-08-24, Fiverr now returns false positives, which was found when running the tests, but will most likley be added again in the near
-future once we find a better error detecting method.
-```
-  "Fiverr": {
-    "errorType": "response_url",
-    "errorUrl": "https://www.fiverr.com/",
-    "url": "https://www.fiverr.com/{}",
-    "urlMain": "https://www.fiverr.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis"
-  },
-```
-
 ## ImageShack
 
 As of 2020-08-24, ImageShack now returns false positives, which was found when running the tests, but will most likley be added again in the near future once we find a better error detecting method.

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -536,6 +536,17 @@
     "username_claimed": "Jungypoo",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Fiverr": {
+    "errorType": "status_code",
+    "request_no_follow_redirects": true,
+    "url": "https://www.fiverr.com/{}",
+    "urlMain": "https://www.fiverr.com/",
+    "username_claimed": "blue",
+    "headers": {
+      "authority": "fiverr.com"
+    },
+    "username_unclaimed": "noonewouldeverusethis"
+  },
   "Flickr": {
     "errorType": "status_code",
     "url": "https://www.flickr.com/people/{}",

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -250,6 +250,8 @@ def sherlock(username, site_data, query_notify,
                 # found.  Disallow the redirect so we can capture the
                 # http status from the original URL request.
                 allow_redirects = False
+            elif net_info.get("request_no_follow_redirects", True) == True:
+                allow_redirects = False
             else:
                 # Allow whatever redirect that the site wants to do.
                 # The final result of the request will be what is available.


### PR DESCRIPTION
Working on Fiverr, I discovered that the destination only redirects if the user is invalid, so I needed to check the status code without request redirection, so I implemented the option `request_no_follow_redirects` to not follow redirects when this value is true.