### PR TITLE
Add support for GitHub Support Communities

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -657,7 +657,7 @@
     "url": "https://github.community/u/{}/summary",
     "urlMain": "https://github.community",
     "username_claimed": "jperl",
-    "username_unclaimed": "blue"
+    "username_unclaimed": "noonewouldusethis298"
   },
   "GitLab": {
     "errorMsg": "[]",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -651,6 +651,14 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "GitHub Support Community": {
+    "errorMsg": "Oops! That page doesn’t exist or is private.",
+    "errorType": "message",
+    "url": "https://github.community/u/{}/summary",
+    "urlMain": "https://github.community",
+    "username_claimed": "jperl",
+    "username_unclaimed": "blue"
+  },
   "GitLab": {
     "errorMsg": "[]",
     "errorType": "message",


### PR DESCRIPTION
NOTE: This is not the same thing as GitHub, as not all Github users have a Github Support Community account.