### PR TITLE
Add support for Tumblr and AO3

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -82,6 +82,14 @@
     "username_claimed": "jason",
     "username_unclaimed": "noonewouldeverusethis"
   },
+  "Archive Of Our Own": {
+    "errorType": "response_url",
+    "errorUrl": "https://archiveofourown.org/people/search",
+    "url": "https://archiveofourown.org/users/{}",
+    "urlMain": "https://archiveofourown.org",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldprobablyeverusethisusername"
+  },
   "Archive.org": {
     "errorMsg": "cannot find account",
     "errorType": "message",
@@ -89,15 +97,6 @@
     "urlMain": "https://archive.org",
     "username_claimed": "blue",
     "username_unclaimed": "noonewould"
-  },
-  "Archive Of Our Own": {
-    "errorMsg": "cannot find account",
-    "errorType": "response_url",
-    "errorUrl": "https://archiveofourown.org/people/search",
-    "url": "https://archiveofourown.org/users/{}",
-    "urlMain": "https://archiveofourown.org",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldprobablyeverusethisusername"
   },
   "Asciinema": {
     "errorType": "status_code",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -90,6 +90,15 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewould"
   },
+  "Archive Of Our Own": {
+    "errorMsg": "cannot find account",
+    "errorType": "response_url",
+    "errorUrl": "https://archiveofourown.org/people/search",
+    "url": "https://archiveofourown.org/users/{}",
+    "urlMain": "https://archiveofourown.org",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldprobablyeverusethisusername"
+  },
   "Asciinema": {
     "errorType": "status_code",
     "url": "https://asciinema.org/~{}",
@@ -1644,6 +1653,14 @@
     "urlMain": "https://tryhackme.com/",
     "username_claimed": "ashu",
     "username_unclaimed": "noonewouldeverusethis7"
+  },
+  "Tumblr": {
+    "errorType": "status_code",
+    "regexCheck": "^[A-Za-z0-9_-]{1,32}$",
+    "url": "https://{}.tumblr.com/",
+    "urlMain": "https://tumblr.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis77"
   },
   "Twitch": {
     "errorType": "status_code",


### PR DESCRIPTION
This PR adds site support for Tumblr and Archive Of Our Own (AO3). Query tests were performed on both sites and they seem to be working fine.