### PR TITLE
Add Support For Gab

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -622,6 +622,13 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis"
   },
+  "Gab": {
+    "errorType": "status_code",
+    "url": "https://gab.com/{}",
+    "urlMain": "https://gab.com/",
+    "username_claimed": "a",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Gamespot": {
     "errorType": "status_code",
     "url": "https://www.gamespot.com/profile/{}/",

--- a/sites.md
+++ b/sites.md
@@ -1,4 +1,4 @@
-## List Of Supported Sites (305 Sites In Total!)
+## List Of Supported Sites (306 Sites In Total!)
 1. [2Dimensions](https://2Dimensions.com/)
 2. [3dnews](http://forum.3dnews.ru/)
 3. [500px](https://500px.com/)
@@ -303,4 +303,5 @@
 302. [spletnik](https://spletnik.ru/)
 303. [svidbook](https://www.svidbook.ru/)
 304. [toster](https://www.toster.ru/)
-305. [uid](https://uid.me/)
+305. [Gab](https://gab.com/)
+306. [uid](https://uid.me/)


### PR DESCRIPTION
This PR adds support for the site [Gab](https://gab.com), which is a fork of [Mastodon](https://github.com/tootsuite/mastodon)