### PR TITLE
Fix NameMC

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -990,9 +990,9 @@
     "username_unclaimed": "noonewouldeverusethis"
   },
   "NameMC (Minecraft.net skins)": {
-    "errorMsg": "Profiles: 0 results",
+    "errorMsg": "Available",
     "errorType": "message",
-    "url": "https://namemc.com/profile/{}",
+    "url": "https://namemc.com/name/{}",
     "urlMain": "https://namemc.com/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"


### PR DESCRIPTION
Fixes NameMC as per this report: https://github.com/sherlock-project/sherlock/issues/960

And others I believe.

First, `/profile` seems to now redirect to `/name` so might as well hit that directly.

Second, the page will now show 'Available' or 'Unavailable' for the username. 