### PR TITLE
Add Pixabay to supported sites

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1155,6 +1155,13 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Pixabay": {
+    "errorType": "status_code",
+    "url": "https://pixabay.com/users/{}",
+    "urlMain": "https://pixabay.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "PlayStore": {
     "errorType": "status_code",
     "url": "https://play.google.com/store/apps/developer?id={}",


### PR DESCRIPTION
Pixabay seems to work now, you are automatically redirected to the correct url with the (probably) correct username +  user_id.