### PR TITLE
add regexCheck to NameMC

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -992,10 +992,11 @@
   "NameMC (Minecraft.net skins)": {
     "errorMsg": "Profiles: 0 results",
     "errorType": "message",
+    "regexCheck": "^[a-zA-Z0-9_]{3,16}$",
     "url": "https://namemc.com/profile/{}",
     "urlMain": "https://namemc.com/",
     "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
+    "username_unclaimed": "unclaimedname7"
   },
   "NationStates Nation": {
     "errorMsg": "Was this your nation? It may have ceased to exist due to inactivity, but can rise again!",


### PR DESCRIPTION
This fixes invalid Minecraft usernames causing false positives.

Minecraft username requirements:
* Username length must be between 3 and 16 characters
* only alphanumeric characters and '_'

(see [https://help.minecraft.net/hc/en-us/articles/360034636712-Minecraft-Usernames](https://help.minecraft.net/hc/en-us/articles/360034636712-Minecraft-Usernames))
I also changed  `username_unclaimed` because "noonewouldeverusethis7" isn't actually a valid Minecraft username.