### PR TITLE
Updated data.json to fix false-positives

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -287,7 +287,7 @@
     "username_unclaimed": "noonewouldeverusethis"
   },
   "Chess": {
-    "errorMsg": "Missing page... somebody made a wrong move.",
+    "errorMsg": "Oops! Something is clearly wrong here...",
     "errorType": "message",
     "url": "https://www.chess.com/member/{}",
     "urlMain": "https://www.chess.com/",
@@ -990,7 +990,7 @@
     "username_unclaimed": "noonewouldeverusethis"
   },
   "NameMC (Minecraft.net skins)": {
-    "errorMsg": "Profiles: 0 results",
+    "errorMsg": "<meta name=\"robots\" content=\"noindex,follow\">",
     "errorType": "message",
     "url": "https://namemc.com/profile/{}",
     "urlMain": "https://namemc.com/",
@@ -1192,7 +1192,7 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "ProductHunt": {
-    "errorMsg": "Page Not Found",
+    "errorMsg": "We seem to have lost this page",
     "errorType": "message",
     "url": "https://www.producthunt.com/@{}",
     "urlMain": "https://www.producthunt.com/",
@@ -1438,7 +1438,8 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Spotify": {
-    "errorType": "status_code",
+    "errorMsg": "<title>Spotify – Web Player</title>",
+    "errorType": "message",
     "url": "https://open.spotify.com/user/{}",
     "urlMain": "https://open.spotify.com/",
     "username_claimed": "blue",
@@ -1598,10 +1599,8 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Twitter": {
-    "errorType": "status_code",
-    "headers": {
-      "User-Agent": ""
-    },
+    "errorMsg": "This account doesn’t exist",
+    "errorType": "message",
     "url": "https://mobile.twitter.com/{}",
     "urlMain": "https://mobile.twitter.com/",
     "username_claimed": "blue",


### PR DESCRIPTION
Chess: Fixed wrong message causing false-positives.
NameMC: Auto-translates based on country, this causes false-positives, now it's using <meta name="robots" content="noindex,follow"> instead of the message, it works on any country.
ProductHunt: Fixed wrong message causing false-positives.
Spotify: Changed from status_code to message, to avoid false-positives.
Twitter: Changed from status_code to message, to avoid false-positives.