### PR TITLE
update to 3.9.2-alpine and use nonroot user called sherlock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine as build
+FROM python:3.9.2-alpine as build
 WORKDIR /wheels
 RUN apk add --no-cache \
     g++ \
@@ -12,17 +12,20 @@ COPY requirements.txt /opt/sherlock/
 RUN pip3 wheel -r /opt/sherlock/requirements.txt
 
 
-FROM python:3.7-alpine
+FROM python:3.9.2-alpine
 WORKDIR /opt/sherlock
+RUN adduser -D sherlock
+RUN mkdir -p /opt/sherlock/sherlock && chown -R sherlock:sherlock /opt/sherlock
+COPY --from=build /wheels /wheels
+COPY --chown=sherlock:sherlock . /opt/sherlock/
+RUN pip3 install -r requirements.txt -f /wheels \
+  && rm -rf /wheels \
+  && rm -rf /root/.cache/pip/*
+USER sherlock
 ARG VCS_REF
 ARG VCS_URL="https://github.com/sherlock-project/sherlock"
 LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url=$VCS_URL
-COPY --from=build /wheels /wheels
-COPY . /opt/sherlock/
-RUN pip3 install -r requirements.txt -f /wheels \
-  && rm -rf /wheels \
-  && rm -rf /root/.cache/pip/*
 WORKDIR /opt/sherlock/sherlock
 
 ENTRYPOINT ["python", "sherlock.py"]


### PR DESCRIPTION
## Docker Security Updates

### About

This Pull Request is to address a few security issues related to the Docker images in this repo. The first just simple upgrades the image from `python:3.7-alpine` to  `python:3.9.2-alpine`. 

The second change uses a _nonroot_ user named `sherlock`. This allows for container hardening as the current container builds use the default _root_ user for everything. 