### PR TITLE
Fix version check

### DIFF
--- a/sherlock/__main__.py
+++ b/sherlock/__main__.py
@@ -22,9 +22,7 @@ if __name__ == "__main__":
 
     python_version = str(sys.version_info[0])+"."+str(sys.version_info[1])+"."+str(sys.version_info[2])
 
-    if major != 3 or major == 3 and minor < 6:
-        print("Sherlock requires Python 3.6+\nYou are using Python %s, which is not supported by Sherlock" % (python_version))
-        sys.exit(1)
+    if major != 3 or minor < 6: sys.exit("Sherlock requires Python 3.6+\nYou are using Python %s, which is not supported by Sherlock" % (python_version))
 
     import sherlock
     sherlock.main()


### PR DESCRIPTION
Else it will evaluate to `(major != 3 or major ==3) and minor < 6` which is `True and minor < 6` so `minor < 6` therefore version 2.7 is supported (and remove unnecessary print statement)