### PR TITLE
Fixed spelling error for "separate".

### DIFF
--- a/.github/ISSUE_TEMPLATE/reporting-false-negative.md
+++ b/.github/ISSUE_TEMPLATE/reporting-false-negative.md
@@ -24,7 +24,7 @@ Make sure complete everything in the checklist.
 - [ ] I'm reporting a website that is returning **false negative** results
 - [ ] I've checked for similar site support requests including closed ones
 - [ ] I've checked for pull requests attempting to fix this false negative
-- [ ] I'm only reporting **one** site (create a seperate issue for each site)
+- [ ] I'm only reporting **one** site (create a separate issue for each site)
 
 ## Description
 <!--

--- a/.github/ISSUE_TEMPLATE/reporting-false-positive.md
+++ b/.github/ISSUE_TEMPLATE/reporting-false-positive.md
@@ -24,7 +24,7 @@ Make sure complete everything in the checklist.
 - [ ] I'm reporting a website that is returning **false positive** results
 - [ ] I've checked for similar site support requests including closed ones
 - [ ] I've checked for pull requests attempting to fix this false positive
-- [ ] I'm only reporting **one** site (create a seperate issue for each site)
+- [ ] I'm only reporting **one** site (create a separate issue for each site)
 
 ## Description
 <!--

--- a/.github/ISSUE_TEMPLATE/site-support-request.md
+++ b/.github/ISSUE_TEMPLATE/site-support-request.md
@@ -26,7 +26,7 @@ Make sure complete everything in the checklist.
 - [ ] I've checked for similar site support requests including closed ones
 - [ ] I've checked that the site I am requesting has not been removed in the past and is not documented in [removed_sites.md](https://github.com/sherlock-project/sherlock/blob/master/removed_sites.md)
 - [ ] The site I am requesting support for is not a pornographic website
-- [ ] I'm only requesting support of **one** website (create a seperate issue for each site)
+- [ ] I'm only requesting support of **one** website (create a separate issue for each site)
 
 ## Description
 <!--


### PR DESCRIPTION
### Changelog

Fixed spelling mistake of `"separate"` in various issue templates.