### PR TITLE
False/Positive fix for Instagram

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -503,14 +503,6 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "Instagram": {
-    "errorMsg": "href=\"/static/bundles/metro/HttpErrorPage.js/",
-    "errorType": "message",
-    "url": "https://www.instagram.com/{}",
-    "urlMain": "https://www.instagram.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
   "Pling": {
     "errorMsg": "Resource not found",
     "errorType": "message",

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1003,20 +1003,6 @@ As of 2021-01-13, Badoo returns false positives
   },
 ```
 
-## Instagram
-As of 2021-01-13, Instagram returns false positives. This can be fixed by using their username checking API endpoint, but that requires a POST request which Sherlock currently does not support. 
-
-```
-  "Instagram": {
-    "errorMsg": "href=\"/static/bundles/metro/HttpErrorPage.js/",
-    "errorType": "message",
-    "url": "https://www.instagram.com/{}",
-    "urlMain": "https://www.instagram.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
-```
-
 ## Pling
 As of 2021-01-13, Pling returns false positives.
 ```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2260,5 +2260,12 @@
     "urlMain": "https://uid.me/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
+  },
+  "Instagram": {
+    "errorType": "status_code",
+    "url": "https://smihub.com/v/{}",
+    "urlMain": "https://instagram.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
   }
 }

--- a/sites.md
+++ b/sites.md
@@ -297,3 +297,4 @@
 1. [svidbook](https://www.svidbook.ru/)
 1. [toster](https://www.toster.ru/)
 1. [uid](https://uid.me/)
+1. [Instagram](https://instagram.com/)


### PR DESCRIPTION
We cannot check directly on instagram.com because we have to use Javascript and need to be signedin, but there are plenty of third party sites that can show instagram profiles.