### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+curly_bracket_next_line = false
+
+[*.{markdown,md}]
+trim_trailing_whitespace = false
+
+[*.py]
+indent_size = 4

--- a/site_list.py
+++ b/site_list.py
@@ -25,5 +25,6 @@ sorted_json_data = json.dumps(data, indent=2, sort_keys=True)
 
 with open("sherlock/resources/data.json", "w") as data_file:
     data_file.write(sorted_json_data)
+    data_file.write('\n')
 
 print("Finished updating supported site listing!")


### PR DESCRIPTION
Adds an [EditorConfig](https://editorconfig.org/) file, so contributors can use consistent code styles with the rest of the project.
This makes it more convenient to work on the project when a developer's editor settings aren't the same as yours.

EditorConfig is a widely supported format that code editors use to override user preferences to adhere to project conventions.
The current settings are based on what I can see from exploring the repository, you may wish to modify the rules.

I noticed most of the files end with a final newline, so I also updated `site_list.py` to include a final newline when writing `data.json`. (This will prevent developers frequently changing in back and forth between the script removing it and editor adding it.