### PR TITLE
Fixed false positive for only fans

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1049,6 +1049,7 @@
   },
   "OnlyFans": {
     "errorType": "status_code",
+    "urlProbe": "https://onlyfans.com/api2/v2/users/{}",
     "url": "https://onlyfans.com/{}",
     "urlMain": "https://onlyfans.com/",
     "username_claimed": "theemilylynne",


### PR DESCRIPTION
This PR fixes the false positive for Onlyfans by using their API to check for the existence of a user.