### PR TITLE
fix runescape detection

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1459,10 +1459,10 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "RuneScape": {
-    "errorMsg": "that player could not be found",
+    "errorMsg": "{\"error\":\"NO_PROFILE\",\"loggedIn\":\"false\"}",
     "errorType": "message",
     "regexCheck": "(?! )^[a-zA-Z0-9- ]{,12}(?<! )$",
-    "url": "https://apps.runescape.com/runemetrics/app/overview/player/{}",
+    "url": "https://apps.runescape.com/runemetrics/profile/profile?user={}",
     "urlMain": "https://www.runescape.com/",
     "username_claimed": "Blue",
     "username_unclaimed": "noonewouldev"


### PR DESCRIPTION
Switch RuneScape over to the API endpoint instead of the web app to avoid issues with false positives.

More information:
* https://github.com/sherlock-project/sherlock/issues/1189
