### PR TITLE
Remove TM-Ladder (TrackmaniaLadder)

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -644,6 +644,13 @@
     "urlMain": "https://1337x.to",
     "username_claimed": "TheMorozko",
     "username_unclaimed": "noonewouldeverusethis7"
+  },
+  "TM-Ladder": {
+    "errorMsg": "player unknown or invalid",
+    "errorType": "message",
+    "url": "http://en.tm-ladder.com/{}_rech.php",
+    "urlMain": "http://en.tm-ladder.com/index.php",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis"
   }
 }
-

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1281,3 +1281,17 @@ As of 2021-11-26, Coil is returning false positives.
     "username_unclaimed": "noonewouldeverusethis7"
   }
 ```
+
+### TM-Ladder
+As of 2021-11-30, TM-Ladder is returning false positives due to rate limits.
+
+```
+  "TM-Ladder": {
+    "errorMsg": "player unknown or invalid",
+    "errorType": "message",
+    "url": "http://en.tm-ladder.com/{}_rech.php",
+    "urlMain": "http://en.tm-ladder.com/index.php",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis"
+  }
+```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1688,14 +1688,6 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "TrackmaniaLadder": {
-    "errorMsg": "player unknown or invalid",
-    "errorType": "message",
-    "url": "http://en.tm-ladder.com/{}_rech.php",
-    "urlMain": "http://en.tm-ladder.com/index.php",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis"
-  },
   "TradingView": {
     "errorType": "status_code",
     "url": "https://www.tradingview.com/u/{}/",

--- a/sites.md
+++ b/sites.md
@@ -1,4 +1,4 @@
-## List Of Supported Sites (322 Sites In Total!)
+## List Of Supported Sites (321 Sites In Total!)
 1. [2Dimensions](https://2Dimensions.com/)
 1. [3dnews](http://forum.3dnews.ru/)
 1. [7Cups](https://www.7cups.com/)
@@ -219,7 +219,6 @@
 1. [Tenor](https://tenor.com/)
 1. [TikTok](https://tiktok.com/)
 1. [Tinder](https://tinder.com/)
-1. [TrackmaniaLadder](http://en.tm-ladder.com/index.php)
 1. [TradingView](https://www.tradingview.com/)
 1. [Trakt](https://www.trakt.tv/)
 1. [TrashboxRU](https://trashbox.ru/)


### PR DESCRIPTION
Removed TM-Ladder due to rate limits, more information here:
* https://github.com/sherlock-project/sherlock/issues/1189

While I was at it, I renamed `TrackmaniaLadder` to `TM-Ladder` which is how it's referred to on its website. (The TM does stand for TrackMania, however understandbly, it doesn't use the TrackMania trademark in the website name.)