### PR TITLE
Fix ICQ and Remove plug.dj

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -645,6 +645,22 @@
     "username_claimed": "TheMorozko",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Anilist": {
+    "errorType": "status_code",
+    "regexCheck": "^[A-Za-z0-9]{2,20}$",
+    "url": "https://anilist.co/user/{}/",
+    "urlMain": "https://anilist.co/",
+    "username_claimed": "Josh",
+    "username_unclaimed": "noonewouldeverusethi"
+  },
+  "Coil": {
+    "errorMsg": "Whoops, the thing you were looking for isn't here",
+    "errorType": "message",
+    "url": "https://coil.com/u/{}",
+    "urlMain": "https://coil.com/",
+    "username_claimed": "adam",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "TM-Ladder": {
     "errorMsg": "player unknown or invalid",
     "errorType": "message",
@@ -652,5 +668,12 @@
     "urlMain": "http://en.tm-ladder.com/index.php",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis"
+  },
+  "plug.dj": {
+    "errorType": "status_code",
+    "url": "https://plug.dj/@/{}",
+    "urlMain": "https://plug.dj/",
+    "username_claimed": "plug-dj-rock",
+    "username_unclaimed": "noonewouldeverusethis7"
   }
 }

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1293,5 +1293,17 @@ As of 2021-11-30, TM-Ladder is returning false positives due to rate limits.
     "urlMain": "http://en.tm-ladder.com/index.php",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis"
+```
+
+### plug.dj
+As of 2021-12-02, plug.dj is returning false positives because the service is down.
+
+```
+  "plug.dj": {
+    "errorType": "status_code",
+    "url": "https://plug.dj/@/{}",
+    "urlMain": "https://plug.dj/",
+    "username_claimed": "plug-dj-rock",
+    "username_unclaimed": "noonewouldeverusethis7"
   }
 ```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -848,9 +848,8 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "ICQ": {
-    "errorMsg": "Profile not found",
-    "errorType": "message",
-    "url": "https://icq.im/{}",
+    "errorType": "status_code",
+    "url": "https://icq.im/{}/en",
     "urlMain": "https://icq.com/",
     "username_claimed": "Micheal",
     "username_unclaimed": "noonewouldeverusethis7"
@@ -1288,13 +1287,6 @@
     "url": "https://play.google.com/store/apps/developer?id={}",
     "urlMain": "https://play.google.com/store",
     "username_claimed": "Facebook",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
-  "Plug.DJ": {
-    "errorType": "status_code",
-    "url": "https://plug.dj/@/{}",
-    "urlMain": "https://plug.dj/",
-    "username_claimed": "plug-dj-rock",
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "Pokemon Showdown": {

--- a/sites.md
+++ b/sites.md
@@ -167,7 +167,6 @@
 1. [Pinkbike](https://www.pinkbike.com/)
 1. [Pinterest](https://www.pinterest.com/)
 1. [PlayStore](https://play.google.com/store)
-1. [Plug.DJ](https://plug.dj/)
 1. [Pokemon Showdown](https://pokemonshowdown.com)
 1. [Polarsteps](https://polarsteps.com/)
 1. [Polygon](https://www.polygon.com/)


### PR DESCRIPTION
* Fix ICQ by moving it to `status_code`. I also added a locale to the URL to avoid the redirect (30x).
* Removed plug.dj as the website is down for now, they are hoping to return at some point.
* Added Coil and Anilist to `removed_sites.json` as I forgot to do this before. _whoops_

I'm not sure why Git thinks I changed every line of removed_sites.json, might be encoding related? But looks like the encoding was `us-ascii` before and after this change according to `file -bi removed_sites.json` anyway.