### PR TITLE
feat: support post requests

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -645,14 +645,6 @@
     "username_claimed": "TheMorozko",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "Anilist": {
-    "errorType": "status_code",
-    "regexCheck": "^[A-Za-z0-9]{2,20}$",
-    "url": "https://anilist.co/user/{}/",
-    "urlMain": "https://anilist.co/",
-    "username_claimed": "Josh",
-    "username_unclaimed": "noonewouldeverusethi"
-  },
   "Coil": {
     "errorMsg": "Whoops, the thing you were looking for isn't here",
     "errorType": "message",

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1254,20 +1254,6 @@ As of 2021-11-21, 1337x seems to be down causing false positives.
   }
 ```
 
-### Anilist
-As of 2021-11-26, Anilist is returning false positives.
-
-```
-  "Anilist": {
-    "errorType": "status_code",
-    "regexCheck": "^[A-Za-z0-9]{2,20}$",
-    "url": "https://anilist.co/user/{}/",
-    "urlMain": "https://anilist.co/",
-    "username_claimed": "Josh",
-    "username_unclaimed": "noonewouldeverusethi"
-  }
-```
-
 ### Coil
 As of 2021-11-26, Coil is returning false positives.
 

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -65,6 +65,22 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Anilist": {
+    "errorType": "status_code",
+    "regexCheck": "^[A-Za-z0-9]{2,20}$",
+    "request_method": "POST",
+    "request_payload": {
+      "query": "query($name:String){User(name:$name){id}}",
+      "variables": {
+        "name": "{}"
+      }
+    },
+    "url": "https://anilist.co/user/{}/",
+    "urlProbe": "https://graphql.anilist.co/",
+    "urlMain": "https://anilist.co/",
+    "username_claimed": "Josh",
+    "username_unclaimed": "noonewouldeverusethi"
+  },
   "Apple Developer": {
     "errorType": "status_code",
     "url": "https://developer.apple.com/forums/profile/{}",
@@ -1792,7 +1808,7 @@
   },
   "Vero": {
     "errorType": "status_code",
-    "request_head_only": false,
+    "request_method": "GET",
     "url": "https://vero.co/{}",
     "urlMain": "https://vero.co/",
     "username_claimed": "blue",
@@ -1815,7 +1831,7 @@
   },
   "VirusTotal": {
     "errorType": "status_code",
-    "request_head_only": false,
+    "request_method": "GET",
     "url": "https://www.virustotal.com/ui/users/{}/trusted_users",
     "urlMain": "https://www.virustotal.com/",
     "urlProbe": "https://www.virustotal.com/ui/users/{}/avatar",

--- a/sites.md
+++ b/sites.md
@@ -8,6 +8,7 @@
 1. [Airliners](https://www.airliners.net/)
 1. [Alik.cz](https://www.alik.cz/)
 1. [AllMyLinks](https://allmylinks.com/)
+1. [Anilist](https://anilist.co/)
 1. [Apple Developer](https://developer.apple.com)
 1. [Apple Discussions](https://discussions.apple.com)
 1. [Archive.org](https://archive.org)


### PR DESCRIPTION
Adds support for Anilist by allowing POST requests. Note, I don't do Python much, so just let me know if the code is crap. ^-^'

This is just a first iteration, it should already work without breaking any existing functionality. You're welcome to give feedback though if you feel I'd done something wrong.

### Main Changes
* Adds Anilist back in to `data.json`. (For testing the implementation of this PR.)
* Adds an `interpolate_string` function, because I thought it would be nicer if we could define the `request_payload` as JSON rather than as a string literal. Opinion welcome!
* Allow `data.json` to specify the request method, defaulting to `HEAD`/`GET` based on the `errorType` if not specified.
* Replaces the now redundant `"request_head_only": false` with `"request_method": "GET"`

### Queries
This replaces the use of `.format` with `.replace` which might be unfavorable, but I wasn't sure of what the best way to go about this was.

1. `.format` throws an exception if there is no `{}` in the string. This can be annoying since we may want to insert the username into the `url`, `probeUrl`, or `request_payload`. But different websites do things differently, some will want the username in the `url`, others might want it in the `request_payload`, so one of them will throw an exception. This is avoided with `.replace`.
2. I think it'd be a better developer/user experience if the `request_payload` was an object rather than a string, so the `interpolate_string` function would want to use `.replace` in this case anyway since many of the keys may not require templating.

### Related
* Closes https://github.com/sherlock-project/sherlock/pull/861