### PR TITLE
Fix typo and replace dead link

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -25,7 +25,7 @@ Make sure complete everything in the checklist.
 - [ ] My question is not a tech support question.
 
 **We are not your tech support**. 
-If you have questions related to `pip`, `git`, or something that is not related to Sherlock, please ask them on [StackOverflow](https://stackoverflow.com/) or [r/learnpython](https://www.reddit.com/r/learnpython/)
+If you have questions related to `pip`, `git`, or something that is not related to Sherlock, please ask them on [Stack Overflow](https://stackoverflow.com/) or [r/learnpython](https://www.reddit.com/r/learnpython/)
 
 
 ## Question

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a target="_blank" href="https://github.com/sherlock-project/sherlock/actions" title="Nightly Tests"><img src="https://github.com/sherlock-project/sherlock/workflows/Nightly/badge.svg?branch=master"></a>
   <a target="_blank" href="https://twitter.com/intent/tweet?text=%F0%9F%94%8E%20Find%20usernames%20across%20social%20networks%20&url=https://github.com/sherlock-project/sherlock&hashtags=hacking,%20osint,%20bugbounty,%20reconnaissance" title="Share on Twitter"><img src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social"></a>
   <a target="_blank" href="http://sherlock-project.github.io/"><img alt="Website" src="https://img.shields.io/website-up-down-green-red/http/sherlock-project.github.io/..svg"></a>
-  <a target="_blank" href="https://microbadger.com/images/theyahya/sherlock"><img alt="docker image" src="https://images.microbadger.com/badges/version/theyahya/sherlock.svg"></a>
+  <a target="_blank" href="https://hub.docker.com/r/theyahya/sherlock"><img alt="docker image" src="https://img.shields.io/docker/v/theyahya/sherlock"></a>
 </p>
 
 <p align="center">

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -37,7 +37,7 @@ class SherlockFuturesSession(FuturesSession):
         This extends the FuturesSession request method to calculate a response
         time metric to each request.
 
-        It is taken (almost) directly from the following StackOverflow answer:
+        It is taken (almost) directly from the following Stack Overflow answer:
         https://github.com/ross/requests-futures#working-in-the-background
 
         Keyword Arguments:


### PR DESCRIPTION
* StackOverflow → Stack Overflow (it has a space in it!)
![image](https://user-images.githubusercontent.com/22801583/145023765-20b33e11-ddeb-41da-98a0-9cc4d550d205.png)
> — https://stackoverflow.com/

* Replaces the microbadger badge with a Docker version badge from Shields.IO.
![image](https://user-images.githubusercontent.com/22801583/145023816-c2fe088e-16c4-4650-b949-2f704bd0c994.png)
> — https://github.com/microscaling/microbadger

![image](https://user-images.githubusercontent.com/22801583/145023888-62bbb537-e442-4213-a8bb-bd685196aa21.png)
> — https://twitter.com/microscaling/status/1361054926399557644