### PR TITLE
chore: add spaces_around_operators and quote_type

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,9 +8,11 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 curly_bracket_next_line = false
+spaces_around_operators = true
 
 [*.{markdown,md}]
 trim_trailing_whitespace = false
 
 [*.py]
 indent_size = 4
+quote_type = double


### PR DESCRIPTION
Proposal to add 2 new properties to `.editorconfig`.

Both are [Ideas for Domain-Specific Properties](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#ideas-for-domain-specific-properties), so not all implementations support them, but some do, especially `quote_type`.

Even for editors that don't support them, it's a nice way to document the project's conventions. For example, the use of `"` and `'` is very inconsistent in the project. I'd like to confirm what convention is preferred and clean that up, as well as apply it for future code contributions.

It looks like double quotes are used more, so I set it to `double` for now. Let me know if it should be `single`.