### PR TITLE
twitter: add regexcheck for username

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1793,11 +1793,12 @@
   "Twitter": {
     "errorMsg": "<title>Error | nitter</title>",
     "errorType": "message",
+    "regexCheck": "^[a-zA-Z0-9_]{1,15}$",
     "url": "https://twitter.com/{}",
     "urlMain": "https://twitter.com/",
     "urlProbe": "https://nitter.net/{}",
     "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
+    "username_unclaimed": "noonewouldeveru"
   },
   "Typeracer": {
     "errorMsg": "Profile Not Found",


### PR DESCRIPTION
Adds the `regexCheck` property to Twitter.
Updates `username_unclaimed` to match regex.

Regex based on rules in the documentation:
https://help.twitter.com/en/managing-your-account/twitter-username-rules

After making the initial PR, I noticed a similar PR which added a regex check but allowed shorter usernames. #1049
After manually testing, it seems new Twitter accounts must be between 4 and 15 characters, but there are many existing Twitter accounts with 1-3 characters as well.

## Related
* Closes https://github.com/sherlock-project/sherlock/issues/1034 - Already solved, but raised an issue regarding usernames which is addressed here.
* Closes https://github.com/sherlock-project/sherlock/pull/1049 - Made redundant since we don't need to remove Twitter, plus detection has changed a lot since then.
* Closes https://github.com/sherlock-project/sherlock/pull/950 - Issue this was addressing is already solved.
* Closes https://github.com/sherlock-project/sherlock/pull/919 - Issue this was addressing is already solved.