### PR TITLE
Adds support for installing with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,31 @@
 ## Installation
 
 ```console
-# clone the repo
+# clone the repo (you can download and extract zip instead)
 $ git clone https://github.com/sherlock-project/sherlock.git
 
 # change the working directory to sherlock
 $ cd sherlock
+```
 
+You can install either standard (portable) or with pip (avaliable anywhere on your machine). There could be a
+pypi package in the future to make the whole installation quicker. (a wheel can be created with
+`python3 setup.py bdist_wheel --universal`).
+
+
+Standard:
+```console
 # install the requirements
 $ python3 -m pip install -r requirements.txt
+# run with `python3 sherlock` from this dir
+```
+
+Pip:
+```console
+# install the package
+$ python3 -m pip install .
+# `sherlock` should be in your $PATH
+# run with `sherlock` anywhere (UNIX-like)
 ```
 
 ## Usage

--- a/sherlock/notify.py
+++ b/sherlock/notify.py
@@ -3,7 +3,10 @@
 This module defines the objects for notifying the caller about the
 results of queries.
 """
-from result import QueryStatus
+try:
+    from .result import QueryStatus
+except:
+    from result import QueryStatus
 from colorama import Fore, Style
 
 

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -19,10 +19,16 @@ import requests
 
 from requests_futures.sessions import FuturesSession
 from torrequest import TorRequest
-from result import QueryStatus
-from result import QueryResult
-from notify import QueryNotifyPrint
-from sites import SitesInformation
+try:
+    from .result import QueryStatus
+    from .result import QueryResult
+    from .notify import QueryNotifyPrint
+    from .sites import SitesInformation
+except:
+    from result import QueryStatus
+    from result import QueryResult
+    from notify import QueryNotifyPrint
+    from sites import SitesInformation
 from colorama import init
 
 module_name = "Sherlock: Find Usernames Across Social Networks"


### PR DESCRIPTION
You can install with `pip install .`, which will add the `sherlock`
command to `~/.local/bin` on UNIX-like systems, which should be in your `$PATH`.

You can also build a wheel with `python3 setup.py bdist_wheel --universal`, which will make it easy to upload to pypi.

I've updated the README installation section with this information.

I've had to change relative imports - since pip installations only support .import and running it normally only supports non dot-imports I've had to add a `try: except:` statement to try both.