### PR TITLE
Replace all `git.io` links

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -563,7 +563,7 @@ def main():
 
         if remote_version != local_version:
             print("Update Available!\n" +
-                  f"You are running version {local_version}. Version {remote_version} is available at https://git.io/sherlock")
+                  f"You are running version {local_version}. Version {remote_version} is available at https://github.com/sherlock-project/sherlock")
 
     except Exception as error:
         print(f"A problem occurred while checking for an update: {error}")


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Replace all `git.io` links with their actual URL.