### PR TITLE
Feature/add merge option csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ python3 -m pip install -r requirements.txt
 $ python3 sherlock --help
 usage: sherlock [-h] [--version] [--verbose] [--folderoutput FOLDEROUTPUT]
                 [--output OUTPUT] [--tor] [--unique-tor] [--csv]
-                [--merge]   
+                [--merge] 
                 [--site SITE_NAME] [--proxy PROXY_URL] [--json JSON_FILE]
                 [--timeout TIMEOUT] [--print-all] [--print-found] [--no-color]
                 [--no-txt]

--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ $ python3 -m pip install -r requirements.txt
 $ python3 sherlock --help
 usage: sherlock [-h] [--version] [--verbose] [--folderoutput FOLDEROUTPUT]
                 [--output OUTPUT] [--tor] [--unique-tor] [--csv]
+                [--merge]   
                 [--site SITE_NAME] [--proxy PROXY_URL] [--json JSON_FILE]
                 [--timeout TIMEOUT] [--print-all] [--print-found] [--no-color]
+                [--no-txt]
                 [--browse] [--local]
                 USERNAMES [USERNAMES ...]
 
@@ -77,6 +79,7 @@ optional arguments:
                         request; increases runtime; requires Tor to be
                         installed and in system path.
   --csv                 Create Comma-Separated Values (CSV) File.
+  --merge, -m           Merges output from multiple username searches into one file
   --site SITE_NAME      Limit analysis to just the listed sites. Add multiple
                         options to specify more than one site.
   --proxy PROXY_URL, -p PROXY_URL
@@ -93,6 +96,7 @@ optional arguments:
   --print-all           Output sites where the username was not found.
   --print-found         Output sites where the username was found.
   --no-color            Don't color terminal output
+  --no-txt              Don't create txt output file
   --browse, -b          Browse to all results on default browser.
   --local, -l           Force the use of the local data.json file.
 ```

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -541,7 +541,7 @@ def main():
                         help="Don't color terminal output"
                         )
     parser.add_argument("--no-txt",
-                        action="store_false", dest="no_txt", default=False,
+                        action="store_true", dest="no_txt", default=False,
                         help="Don't create txt output file"
                         )
     parser.add_argument("username",
@@ -680,15 +680,15 @@ def main():
         elif not args.no_txt:
             result_file = f"{username}.txt"
 
-        with open(result_file, "w", encoding="utf-8") as file:
-            exists_counter = 0
-            for website_name in results:
-                dictionary = results[website_name]
-                if dictionary.get("status").status == QueryStatus.CLAIMED:
-                    exists_counter += 1
-                    file.write(dictionary["url_user"] + "\n")
-            file.write(
-                f"Total Websites Username Detected On : {exists_counter}\n")
+            with open(result_file, "w", encoding="utf-8") as file:
+                exists_counter = 0
+                for website_name in results:
+                    dictionary = results[website_name]
+                    if dictionary.get("status").status == QueryStatus.CLAIMED:
+                        exists_counter += 1
+                        file.write(dictionary["url_user"] + "\n")
+                file.write(
+                    f"Total Websites Username Detected On : {exists_counter}\n")
 
         if args.csv:
             result_file = f"{username}.csv"


### PR DESCRIPTION
## Description
- Adds a merge option to the csv output that allows the user to merge the results from multiple username searches into one file
- Adds a `no--txt` argument to suppress the creation of the txt file

## Screenshots
Checking for output  : csv merge, no txt
`python3 sherlock barackobama michelleobama --csv --merge results/obamas_test --no-txt --site Facebook --site Twitter`
![image](https://user-images.githubusercontent.com/51367771/166289095-6e867d77-ce02-4180-a972-af96cc90e8ac.png)

Without merging or suppressing txt
`python3 sherlock barackobama michelleobama --site Facebook --site Twitter --csv`
![image](https://user-images.githubusercontent.com/51367771/166291358-956bae46-ee2c-48c8-904c-c3bdd6a48571.png)

## How Has This Been Tested?
- Ran given unit tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
