### PR TITLE
feat: add json schema validation

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -1,7 +1,7 @@
 {
+  "$schema": "./sherlock/resources/data.schema.json",
   "AdobeForums": {
     "errorType": "status_code",
-    "rank": 59,
     "url": "https://forums.adobe.com/people/{}",
     "urlMain": "https://forums.adobe.com/",
     "username_claimed": "jack",
@@ -9,7 +9,6 @@
   },
   "AngelList": {
     "errorType": "status_code",
-    "rank": 5767,
     "url": "https://angel.co/u/{}",
     "urlMain": "https://angel.co/",
     "username_claimed": "blue",
@@ -18,7 +17,6 @@
   "Basecamp": {
     "errorMsg": "The account you were looking for doesn't exist",
     "errorType": "message",
-    "rank": 4914,
     "url": "https://{}.basecamphq.com",
     "urlMain": "https://basecamp.com/",
     "username_claimed": "blue",
@@ -27,14 +25,12 @@
   "BlackPlanet": {
     "errorMsg": "My Hits",
     "errorType": "message",
-    "rank": 110021,
     "url": "http://blackplanet.com/{}",
     "urlMain": "http://blackplanet.com/"
   },
   "Canva": {
     "errorType": "response_url",
     "errorUrl": "https://www.canva.com/{}",
-    "rank": 128,
     "url": "https://www.canva.com/{}",
     "urlMain": "https://www.canva.com/",
     "username_claimed": "jenny",
@@ -42,7 +38,6 @@
   },
   "Codementor": {
     "errorType": "status_code",
-    "rank": 10252,
     "url": "https://www.codementor.io/@{}",
     "urlMain": "https://www.codementor.io/",
     "username_claimed": "blue",
@@ -51,7 +46,6 @@
   "EVE Online": {
     "errorType": "response_url",
     "errorUrl": "https://eveonline.com",
-    "rank": 15347,
     "url": "https://evewho.com/pilot/{}/",
     "urlMain": "https://eveonline.com",
     "username_claimed": "blue",
@@ -60,7 +54,6 @@
   "fanpop": {
     "errorType": "response_url",
     "errorUrl": "http://www.fanpop.com/",
-    "rank": 9454,
     "url": "http://www.fanpop.com/fans/{}",
     "urlMain": "http://www.fanpop.com/",
     "username_claimed": "blue",
@@ -68,13 +61,11 @@
   },
   "Fotolog": {
     "errorType": "status_code",
-    "rank": 47777,
     "url": "https://fotolog.com/{}",
     "urlMain": "https://fotolog.com/"
   },
   "Foursquare": {
     "errorType": "status_code",
-    "rank": 1843,
     "url": "https://foursquare.com/{}",
     "urlMain": "https://foursquare.com/",
     "username_claimed": "dens",
@@ -83,7 +74,6 @@
   "furaffinity": {
     "errorMsg": "user cannot be found",
     "errorType": "message",
-    "rank": 0,
     "url": "https://www.furaffinity.net/user/{}",
     "urlMain": "https://www.furaffinity.net",
     "username_claimed": "blue",
@@ -91,7 +81,6 @@
   },
   "gpodder.net": {
     "errorType": "status_code",
-    "rank": 2013984,
     "url": "https://gpodder.net/user/{}",
     "urlMain": "https://gpodder.net/",
     "username_claimed": "blue",
@@ -99,7 +88,6 @@
   },
   "Investing.com": {
     "errorType": "status_code",
-    "rank": 196,
     "url": "https://www.investing.com/traders/{}",
     "urlMain": "https://www.investing.com/",
     "username_claimed": "jenny",
@@ -107,7 +95,6 @@
   },
   "Khan Academy": {
     "errorType": "status_code",
-    "rank": 377,
     "url": "https://www.khanacademy.org/profile/{}",
     "urlMain": "https://www.khanacademy.org/",
     "username_claimed": "blue",
@@ -116,7 +103,6 @@
   "KiwiFarms": {
     "errorMsg": "The specified member cannot be found",
     "errorType": "message",
-    "rank": 38737,
     "url": "https://kiwifarms.net/members/?username={}",
     "urlMain": "https://kiwifarms.net/",
     "username_claimed": "blue",
@@ -125,7 +111,6 @@
   "Linkedin": {
     "errorMsg": "could not be found",
     "errorType": "message",
-    "rank": 0,
     "url": "https://www.linkedin.com/in/{}",
     "urlMain": "https://www.linkedin.com/",
     "username_claimed": "alex",
@@ -140,7 +125,6 @@
   },
   "Pexels": {
     "errorType": "status_code",
-    "rank": 745,
     "url": "https://www.pexels.com/@{}",
     "urlMain": "https://www.pexels.com/",
     "username_claimed": "bruno",
@@ -148,7 +132,6 @@
   },
   "Pixabay": {
     "errorType": "status_code",
-    "rank": 378,
     "url": "https://pixabay.com/en/users/{}",
     "urlMain": "https://pixabay.com/",
     "username_claimed": "blue",
@@ -156,7 +139,6 @@
   },
   "PowerShell Gallery": {
     "errorType": "status_code",
-    "rank": 163562,
     "url": "https://www.powershellgallery.com/profiles/{}",
     "urlMain": "https://www.powershellgallery.com",
     "username_claimed": "powershellteam",
@@ -165,7 +147,6 @@
   "RamblerDating": {
     "errorType": "response_url",
     "errorUrl": "https://dating.rambler.ru/page/{}",
-    "rank": 322,
     "url": "https://dating.rambler.ru/page/{}",
     "urlMain": "https://dating.rambler.ru/",
     "username_claimed": "blue",
@@ -174,7 +155,6 @@
   "Shockwave": {
     "errorMsg": "Oh no! You just finished all of the games on the internet!",
     "errorType": "message",
-    "rank": 35916,
     "url": "http://www.shockwave.com/member/profiles/{}.jsp",
     "urlMain": "http://www.shockwave.com/",
     "username_claimed": "blue",
@@ -182,7 +162,6 @@
   },
   "StreamMe": {
     "errorType": "status_code",
-    "rank": 31702,
     "url": "https://www.stream.me/{}",
     "urlMain": "https://www.stream.me/",
     "username_claimed": "blue",
@@ -191,7 +170,6 @@
   "Teknik": {
     "errorMsg": "The user does not exist",
     "errorType": "message",
-    "rank": 357163,
     "url": "https://user.teknik.io/{}",
     "urlMain": "https://teknik.io/",
     "username_claimed": "red",
@@ -200,7 +178,6 @@
   "YandexMarket": {
     "errorMsg": "\u0422\u0443\u0442 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435\u0442",
     "errorType": "message",
-    "rank": 47,
     "url": "https://market.yandex.ru/user/{}/achievements",
     "urlMain": "https://market.yandex.ru/",
     "username_claimed": "blue",
@@ -209,15 +186,13 @@
   "Insanejournal": {
     "errorMsg": "Unknown user",
     "errorType": "message",
-    "rank": 29728,
     "url": "http://{}.insanejournal.com/profile",
-    "urlMain": "insanejournal.com",
+    "urlMain": "https://www.insanejournal.com/",
     "username_claimed": "blue",
     "username_unclaimed": "dlyr6cd"
   },
   "Trip": {
       "errorType": "status_code",
-      "rank": 2847,
       "url": "https://www.trip.skyscanner.com/user/{}",
       "urlMain": "https://www.trip.skyscanner.com/",
       "username_claimed": "blue",
@@ -226,7 +201,6 @@
   "SportsTracker": {
      "errorUrl": "https://www.sports-tracker.com/page-not-found",
      "errorType": "response_url",
-     "rank": 93950,
      "url": "https://www.sports-tracker.com/view_profile/{}",
      "urlMain": "https://www.sports-tracker.com/",
      "username_claimed": "blue",
@@ -234,7 +208,6 @@
   },
   "boingboing.net": {
      "errorType": "status_code",
-     "rank": 5821,
      "url": "https://bbs.boingboing.net/u/{}",
      "urlMain": "https://boingboing.net/",
      "username_claimed": "admin",
@@ -243,7 +216,6 @@
   "elwoRU": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",
-    "rank": 254810,
     "url": "https://elwo.ru/index/8-0-{}",
     "urlMain": "https://elwo.ru/",
     "username_claimed": "red",
@@ -252,7 +224,6 @@
   "ingvarr.net.ru": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",
-    "rank": 107721,
     "url": "http://ingvarr.net.ru/index/8-0-{}",
     "urlMain": "http://ingvarr.net.ru/",
     "username_claimed": "red",
@@ -261,7 +232,6 @@
   "Redsun.tf": {
     "errorMsg": "The specified member cannot be found",
     "errorType": "message",
-    "rank": 3796657,
     "url": "https://forum.redsun.tf/members/?username={}",
     "urlMain": "https://redsun.tf/",
     "username_claimed": "dan",
@@ -269,7 +239,6 @@
   },
   "CreativeMarket": {
     "errorType": "status_code",
-    "rank": 1896,
     "url": "https://creativemarket.com/users/{}",
     "urlMain": "https://creativemarket.com/",
     "username_claimed": "blue",
@@ -277,7 +246,6 @@
   },
   "pvpru": {
     "errorType": "status_code",
-    "rank": 405547,
     "url": "https://pvpru.com/board/member.php?username={}&tab=aboutme#aboutme",
     "urlMain": "https://pvpru.com/",
     "username_claimed": "blue",
@@ -286,7 +254,6 @@
   "easyen": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",
-    "rank": 11564,
     "url": "https://easyen.ru/index/8-0-{}",
     "urlMain": "https://easyen.ru/",
     "username_claimed": "wd",
@@ -295,7 +262,6 @@
   "pedsovet": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",
-    "rank": 6776,
     "url": "http://pedsovet.su/index/8-0-{}",
     "urlMain": "http://pedsovet.su/",
     "username_claimed": "blue",
@@ -304,7 +270,6 @@
   "radioskot": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",
-    "rank": 105878,
     "url": "https://radioskot.ru/index/8-0-{}",
     "urlMain": "https://radioskot.ru/",
     "username_claimed": "red",
@@ -313,7 +278,6 @@
   "Coderwall": {
     "errorMsg": "404! Our feels when that url is used",
     "errorType": "message",
-    "rank": 11256,
     "url": "https://coderwall.com/{}",
     "urlMain": "https://coderwall.com/",
     "username_claimed": "jenny",
@@ -322,7 +286,6 @@
   "TamTam": {
     "errorType": "response_url",
     "errorUrl": "https://tamtam.chat/",
-    "rank": 87903,
     "url": "https://tamtam.chat/{}",
     "urlMain": "https://tamtam.chat/",
     "username_claimed": "blue",
@@ -333,7 +296,6 @@
     "headers": {
       "Accept-Language": "en-US,en;q=0.9"
     },
-    "rank": 1920,
     "url": "https://www.zomato.com/pl/{}/foodjourney",
     "urlMain": "https://www.zomato.com/",
     "username_claimed": "deepigoyal",
@@ -341,7 +303,6 @@
   },
   "mixer.com": {
     "errorType": "status_code",
-    "rank": 1544,
     "url": "https://mixer.com/{}",
     "urlMain": "https://mixer.com/",
     "urlProbe": "https://mixer.com/api/v1/channels/{}",
@@ -350,7 +311,6 @@
   },
   "KanoWorld": {
     "errorType": "status_code",
-    "rank": 181933,
     "url": "https://api.kano.me/progress/user/{}",
     "urlMain": "https://world.kano.me/",
     "username_claimed": "blue",

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -16,7 +16,6 @@ for all queries.
 ```
   "gpodder.net": {
     "errorType": "status_code",
-    "rank": 2013984,
     "url": "https://gpodder.net/user/{}",
     "urlMain": "https://gpodder.net/",
     "username_claimed": "blue",
@@ -36,7 +35,6 @@ required login before access.
 ```
   "Investing.com": {
     "errorType": "status_code",
-    "rank": 196,
     "url": "https://www.investing.com/traders/{}",
     "urlMain": "https://www.investing.com/",
     "username_claimed": "jenny",
@@ -59,7 +57,6 @@ This can be detected, but it requires a different detection method.
 ```
   "AdobeForums": {
     "errorType": "status_code",
-    "rank": 59,
     "url": "https://forums.adobe.com/people/{}",
     "urlMain": "https://forums.adobe.com/",
     "username_claimed": "jack",
@@ -76,7 +73,6 @@ As of 2020-02-23, all usernames are reported as not existing.
   "Basecamp": {
     "errorMsg": "The account you were looking for doesn't exist",
     "errorType": "message",
-    "rank": 4914,
     "url": "https://{}.basecamphq.com",
     "urlMain": "https://basecamp.com/",
     "username_claimed": "blue",
@@ -92,7 +88,6 @@ As of 2020-02-23, all usernames are reported as not existing.
   "fanpop": {
     "errorType": "response_url",
     "errorUrl": "http://www.fanpop.com/",
-    "rank": 9454,
     "url": "http://www.fanpop.com/fans/{}",
     "urlMain": "http://www.fanpop.com/",
     "username_claimed": "blue",
@@ -108,7 +103,6 @@ As of 2020-02-23, all usernames are reported as not existing.
   "Canva": {
     "errorType": "response_url",
     "errorUrl": "https://www.canva.com/{}",
-    "rank": 128,
     "url": "https://www.canva.com/{}",
     "urlMain": "https://www.canva.com/",
     "username_claimed": "jenny",
@@ -123,7 +117,6 @@ As of 2020-01-21, all usernames are reported as not existing.
 ```
   "Pixabay": {
     "errorType": "status_code",
-    "rank": 378,
     "url": "https://pixabay.com/en/users/{}",
     "urlMain": "https://pixabay.com/",
     "username_claimed": "blue",
@@ -152,7 +145,6 @@ As of 2020-01-21, all usernames are reported as not existing.
 ```
   "Pexels": {
     "errorType": "status_code",
-    "rank": 745,
     "url": "https://www.pexels.com/@{}",
     "urlMain": "https://www.pexels.com/",
     "username_claimed": "bruno",
@@ -168,7 +160,6 @@ As of 2019-12-31, site always times out.
   "RamblerDating": {
     "errorType": "response_url",
     "errorUrl": "https://dating.rambler.ru/page/{}",
-    "rank": 322,
     "url": "https://dating.rambler.ru/page/{}",
     "urlMain": "https://dating.rambler.ru/",
     "username_claimed": "blue",
@@ -184,7 +175,6 @@ As of 2019-12-31, all usernames are reported as existing.
   "YandexMarket": {
     "errorMsg": "\u0422\u0443\u0442 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435\u0442",
     "errorType": "message",
-    "rank": 47,
     "url": "https://market.yandex.ru/user/{}/achievements",
     "urlMain": "https://market.yandex.ru/",
     "username_claimed": "blue",
@@ -199,7 +189,6 @@ As of 2019-12-31, usernames that exist are not detected.
 ```
   "Codementor": {
     "errorType": "status_code",
-    "rank": 10252,
     "url": "https://www.codementor.io/@{}",
     "urlMain": "https://www.codementor.io/",
     "username_claimed": "blue",
@@ -216,7 +205,6 @@ be logged into see a profile.
   "KiwiFarms": {
     "errorMsg": "The specified member cannot be found",
     "errorType": "message",
-    "rank": 38737,
     "url": "https://kiwifarms.net/members/?username={}",
     "urlMain": "https://kiwifarms.net/",
     "username_claimed": "blue",
@@ -232,7 +220,6 @@ As of 2019-11-30, the site causes Sherlock to just hang.
   "Teknik": {
     "errorMsg": "The user does not exist",
     "errorType": "message",
-    "rank": 357163,
     "url": "https://user.teknik.io/{}",
     "urlMain": "https://teknik.io/",
     "username_claimed": "red",
@@ -249,7 +236,6 @@ HTTP Status.
   "Shockwave": {
     "errorMsg": "Oh no! You just finished all of the games on the internet!",
     "errorType": "message",
-    "rank": 35916,
     "url": "http://www.shockwave.com/member/profiles/{}.jsp",
     "urlMain": "http://www.shockwave.com/",
     "username_claimed": "blue",
@@ -268,7 +254,6 @@ There is an error message:
 ```
   "Foursquare": {
     "errorType": "status_code",
-    "rank": 1843,
     "url": "https://foursquare.com/{}",
     "urlMain": "https://foursquare.com/",
     "username_claimed": "dens",
@@ -283,7 +268,6 @@ Usernames that don't exist are detected.  First noticed 2019-10-25.
 ```
   "Khan Academy": {
     "errorType": "status_code",
-    "rank": 377,
     "url": "https://www.khanacademy.org/profile/{}",
     "urlMain": "https://www.khanacademy.org/",
     "username_claimed": "blue",
@@ -300,7 +284,6 @@ Usernames that exist are not detected.
   "EVE Online": {
     "errorType": "response_url",
     "errorUrl": "https://eveonline.com",
-    "rank": 15347,
     "url": "https://evewho.com/pilot/{}/",
     "urlMain": "https://eveonline.com",
     "username_claimed": "blue",
@@ -315,7 +298,6 @@ Usernames that exist are not detected. Forbidden Request 403 Error.
 ```
   "AngelList": {
     "errorType": "status_code",
-    "rank": 5767,
     "url": "https://angel.co/u/{}",
     "urlMain": "https://angel.co/",
     "username_claimed": "blue",
@@ -331,7 +313,6 @@ user names were available.
 ```
   "PowerShell Gallery": {
     "errorType": "status_code",
-    "rank": 163562,
     "url": "https://www.powershellgallery.com/profiles/{}",
     "urlMain": "https://www.powershellgallery.com",
     "username_claimed": "powershellteam",
@@ -358,7 +339,6 @@ If the site becomes available in the future, we can put it back in.
 ```
   "StreamMe": {
     "errorType": "status_code",
-    "rank": 31702,
     "url": "https://www.stream.me/{}",
     "urlMain": "https://www.stream.me/",
     "username_claimed": "blue",
@@ -377,7 +357,6 @@ no way distinguish between the results with the current design of Sherlock.
   "BlackPlanet": {
     "errorMsg": "My Hits",
     "errorType": "message",
-    "rank": 110021,
     "url": "http://blackplanet.com/{}",
     "urlMain": "http://blackplanet.com/"
   },
@@ -394,7 +373,6 @@ Sherlock.
 ```
   "Fotolog": {
     "errorType": "status_code",
-    "rank": 47777,
     "url": "https://fotolog.com/{}",
     "urlMain": "https://fotolog.com/"
   },
@@ -412,7 +390,6 @@ Good-bye [Google Plus](https://en.wikipedia.org/wiki/Google%2B)...
 ```
   "Google Plus": {
     "errorType": "status_code",
-    "rank": 1,
     "url": "https://plus.google.com/+{}",
     "urlMain": "https://plus.google.com/",
     "username_claimed": "davidbrin1",
@@ -430,7 +407,6 @@ exists or not.
   "furaffinity": {
     "errorMsg": "user cannot be found",
     "errorType": "message",
-    "rank": 0,
     "url": "https://www.furaffinity.net/user/{}",
     "urlMain": "https://www.furaffinity.net",
     "username_claimed": "blue",
@@ -448,9 +424,8 @@ Since we were not able to find the critera for a valid username, the best thing 
   "InsaneJournal": {
     "errorMsg": "Unknown user",
     "errorType": "message",
-    "rank": 29728,
     "url": "http://{}.insanejournal.com/profile",
-    "urlMain": "insanejournal.com",
+    "urlMain": "https://www.insanejournal.com/",
     "username_claimed": "blue",
     "username_unclaimed": "dlyr6cd"
   },
@@ -465,7 +440,6 @@ did not seem to work.
    "SportsTracker": {
      "errorUrl": "https://www.sports-tracker.com/page-not-found",
      "errorType": "response_url",
-     "rank": 93950,
      "url": "https://www.sports-tracker.com/view_profile/{}",
      "urlMain": "https://www.sports-tracker.com/",
      "username_claimed": "blue",
@@ -481,7 +455,6 @@ redirecting to skyscanner.com whether the username exists or not.
 ```
   "Trip": {
       "errorType": "status_code",
-      "rank": 2847,
       "url": "https://www.trip.skyscanner.com/user/{}",
       "urlMain": "https://www.trip.skyscanner.com/",
       "username_claimed": "blue",
@@ -497,7 +470,6 @@ As of 2020-04-02, boingboing.net requires a login to check if a user exits or no
 ```
    "boingboing.net": {
      "errorType": "status_code",
-     "rank": 5821,
      "url": "https://bbs.boingboing.net/u/{}",
      "urlMain": "https://boingboing.net/",
      "username_claimed": "admin",
@@ -513,7 +485,6 @@ downforeveryoneorjustme.com that the website is down.
   "elwoRU": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",
-    "rank": 254810,
     "url": "https://elwo.ru/index/8-0-{}",
     "urlMain": "https://elwo.ru/",
     "username_claimed": "red",
@@ -530,7 +501,6 @@ downforeveryoneorjustme.com that the website is down.
   "ingvarr.net.ru": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",
-    "rank": 107721,
     "url": "http://ingvarr.net.ru/index/8-0-{}",
     "urlMain": "http://ingvarr.net.ru/",
     "username_claimed": "red",
@@ -547,7 +517,6 @@ for Sherlock to check for usernames on this particular website.
   "Redsun.tf": {
     "errorMsg": "The specified member cannot be found",
     "errorType": "message",
-    "rank": 3796657,
     "url": "https://forum.redsun.tf/members/?username={}",
     "urlMain": "https://redsun.tf/",
     "username_claimed": "dan",
@@ -564,7 +533,6 @@ us to prove that we are not a robot.
 ```
   "CreativeMarket": {
     "errorType": "status_code",
-    "rank": 1896,
     "url": "https://creativemarket.com/users/{}",
     "urlMain": "https://creativemarket.com/",
     "username_claimed": "blue",
@@ -580,7 +548,6 @@ we try to check for a username.
 ```
   "pvpru": {
     "errorType": "status_code",
-    "rank": 405547,
     "url": "https://pvpru.com/board/member.php?username={}&tab=aboutme#aboutme",
     "urlMain": "https://pvpru.com/",
     "username_claimed": "blue",
@@ -597,7 +564,6 @@ removed
   "easyen": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",
-    "rank": 11564,
     "url": "https://easyen.ru/index/8-0-{}",
     "urlMain": "https://easyen.ru/",
     "username_claimed": "wd",
@@ -614,7 +580,6 @@ removed
   "pedsovet": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",
-    "rank": 6776,
     "url": "http://pedsovet.su/index/8-0-{}",
     "urlMain": "http://pedsovet.su/",
     "username_claimed": "blue",
@@ -631,7 +596,6 @@ removed
   "radioskot": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
     "errorType": "message",
-    "rank": 105878,
     "url": "https://radioskot.ru/index/8-0-{}",
     "urlMain": "https://radioskot.ru/",
     "username_claimed": "red",
@@ -649,7 +613,6 @@ find it and because of this, the best thing we can do now is to remove it.
   "Coderwall": {
     "errorMsg": "404! Our feels when that url is used",
     "errorType": "message",
-    "rank": 11256,
     "url": "https://coderwall.com/{}",
     "urlMain": "https://coderwall.com/",
     "username_claimed": "jenny",
@@ -664,7 +627,6 @@ As of 2020-07-06, TamTam returns false positives when given a username which con
   "TamTam": {
     "errorType": "response_url",
     "errorUrl": "https://tamtam.chat/",
-    "rank": 87903,
     "url": "https://tamtam.chat/{}",
     "urlMain": "https://tamtam.chat/",
     "username_claimed": "blue",
@@ -680,7 +642,6 @@ As of 2020-07-24, Zomato seems to be unstable. Majority of the time, Zomato take
     "headers": {
       "Accept-Language": "en-US,en;q=0.9"
     },
-    "rank": 1920,
     "url": "https://www.zomato.com/pl/{}/foodjourney",
     "urlMain": "https://www.zomato.com/",
     "username_claimed": "deepigoyal",
@@ -693,7 +654,6 @@ As of 2020-07-22, the Mixer service has closed down.
 ```
   "mixer.com": { 
     "errorType": "status_code", 
-    "rank": 1544, 
     "url": "https://mixer.com/{}", 
     "urlMain": "https://mixer.com/", 
     "urlProbe": "https://mixer.com/api/v1/channels/{}", 
@@ -709,7 +669,6 @@ If an alternative way to check for usernames is found then it will added.
 ```
   "KanoWorld": {
     "errorType": "status_code",
-    "rank": 181933,
     "url": "https://api.kano.me/progress/user/{}",
     "urlMain": "https://world.kano.me/",
     "username_claimed": "blue",
@@ -867,7 +826,6 @@ As of 2020-09-23, Linkedin returns false positives because we are prompted with 
   "Linkedin": {
     "errorMsg": "could not be found",
     "errorType": "message",
-    "rank": 0,
     "url": "https://www.linkedin.com/in/{}",
     "urlMain": "https://www.linkedin.com/",
     "username_claimed": "alex",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./data.schema.json",
   "2Dimensions": {
     "errorType": "status_code",
     "url": "https://2Dimensions.com/a/{}",
@@ -1068,7 +1069,6 @@
   },
   "Jimdo": {
     "errorType": "status_code",
-    "noPeriod": "True",
     "url": "https://{}.jimdosite.com",
     "urlMain": "https://jimdosite.com/",
     "username_claimed": "jenny",

--- a/sherlock/resources/data.schema.json
+++ b/sherlock/resources/data.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Sherlock Dataset",
+  "description": "Information about how to identify that a profile exists on particular websites.",
+  "type": "object",
+  "patternProperties": {
+    "^\\w+$": {
+      "title": "Website",
+      "description": "How to identify that a profile exists on a website.",
+      "required": [
+        "errorType",
+        "url",
+        "urlMain"
+      ],
+      "properties": {
+        "errorCode": {
+          "title": "Error Code",
+          "description": "If errorType is status_code, the HTTP status that implies the profile doesn't exist.",
+          "type": "number",
+          "enum": [
+            100,
+            101,
+            102,
+            103,
+            200,
+            202,
+            203,
+            204,
+            205,
+            206,
+            207,
+            208,
+            226,
+            300,
+            301,
+            302,
+            303,
+            304,
+            305,
+            306,
+            307,
+            308,
+            400,
+            401,
+            402,
+            403,
+            404,
+            405,
+            406,
+            407,
+            408,
+            409,
+            410,
+            411,
+            412,
+            413,
+            414,
+            415,
+            416,
+            417,
+            418,
+            421,
+            422,
+            423,
+            424,
+            425,
+            426,
+            428,
+            429,
+            431,
+            451,
+            500,
+            501,
+            502,
+            503,
+            504,
+            505,
+            506,
+            507,
+            508,
+            510,
+            511
+          ],
+          "examples": [
+            204
+          ]
+        },
+        "errorMsg": {
+          "title": "Error Message",
+          "description": "",
+          "uniqueItems": true,
+          "type": [
+            "string",
+            "array"
+          ],
+          "examples": [
+            "cannot find account",
+            "<div class=\"icon_user_locked\"></div>",
+            "\"users\":{}"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "errorType": {
+          "title": "Error Type",
+          "description": "The type of detection method to perform to determine if the profile exists.",
+          "type": "string",
+          "enum": [
+            "message",
+            "response_url",
+            "status_code"
+          ]
+        },
+        "errorUrl": {
+          "title": "Error URL",
+          "type": "string",
+          "examples": [
+            "https://devrant.com/",
+            "https://ko-fi.com/art?=redirect",
+            "https://gitlab.gnome.org/{}"
+          ]
+
+        },
+        "headers": {
+          "title": "Headers",
+          "description": "Override or append HTTP headers for a given site.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0"
+          },
+          "examples": [
+            {
+              "accept-language": "en-US,en;q=0.9"
+            }
+          ]
+        },
+        "regexCheck": {
+          "title": "Regex Check",
+          "description": "A regular expression that only matches on a valid username. This is used to flag usernames that may not be allowable on a given site. Note that a username that is valid on one site may not be allowed on another site.",
+          "type": "string",
+          "examples": [
+            "^[a-zA-Z0-9@._-]{1,150}$",
+            "^(?![.-])[a-zA-Z0-9_.-]{3,20}$"
+          ]
+        },
+        "request_method": {
+          "title": "Request Method",
+          "description": "The type of HTTP request method to use when making a request.",
+          "type": "string",
+          "enum": [
+            "GET",
+            "HEAD",
+            "POST",
+            "PUT"
+          ]
+        },
+        "request_payload": {
+          "title": "Request Payload",
+          "description": "If request_method is POST, the JSON body to send with the request. Instances of {} are interpolated with the username.",
+          "type": "object",
+          "additionalProperties": true,
+          "examples": [
+            {
+              "username": "{}"
+            },
+            {
+              "query": "query($name:String){User(name:$name){id}}",
+              "variables": {
+                "name": "{}"
+              }
+            }
+          ]
+        },
+        "url": {
+          "title": "URL",
+          "description": "the format of a member's URL on the site. Instances of {} are interpolated with the username.",
+          "type": "string",
+          "examples": [
+            "https://anilist.co/user/{}/",
+            "https://fosstodon.org/@{}"
+          ]
+        },
+        "urlMain": {
+          "title": "URL Main",
+          "description": "The primary URL to access the website.",
+          "type": "string",
+          "format": "uri",
+          "examples": [
+            "https://anilist.co/",
+            "https://fosstodon.org/"
+          ]
+        },
+        "urlProbe": {
+          "title": "URL Probe",
+          "description": "Defines a special URL which should be used to determine if a username is supported (this is normally an API call). If this is not given, then url will be used to check for the existence of a username. This field is useful if detecting the username via URL is not reliable. Only unauthenticated API calls are supported. Instances of {} are interpolated with the username.",
+          "type": "string",
+          "examples": [
+            "https://graphql.anilist.co/",
+            "https://binarysearch.io/api/users/{}/profile",
+            "https://coil.com/gateway"
+          ]
+        },
+        "username_claimed": {
+          "title": "Claimed Username",
+          "description": "A valid username of a profile that is claimed on the website.",
+          "type": "string",
+          "examples": [
+            "adam",
+            "blue"
+          ]
+        },
+        "username_unclaimed": {
+          "title": "Unclaimed Username",
+          "description": "A valid username of a profile that is not claimed on the website.",
+          "type": "string",
+          "examples": [
+            "noonewouldeverusethis7"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a JSON Schema that validates `data.json` and `removed_sites.json`. I've already validated the existing data with it and can confirm both files pass. 👍🏾 

Prepends the following property to both files:
```json
{
  "$schema": "{path/to/json-schema}"
}
```

Removes the `rank` property from `removed_sites.json` and documentation as this is no longer relevant.

Removes the "noPeriod" property from Jimdo as this appears to serve on purpose.

---

Sorry, also a question. What is the purpose of `responseUrl`? I just realized, this property is not referenced whatsoever in the actual application. 🤔 Can this property be removed in the dataset and schema?

Later I do want to make it stricter, i.e. prevent someone from using one `errorType` with the wrong additional field, i.e.
```json
{ 
  "errorMsg": "Not Found",
  "errorType": "status_code"
} 
```

I figured I'd leave it like this for now and find out what `responseUrl` is about. 🤔 

### Related
* Closes https://github.com/sherlock-project/sherlock/issues/1336

The goal of this is to improve the experience for developers and leave less room for human-error. It also enforces that we document and provide examples of each field, unlike the current Wiki which tends to get outdated.

![image](https://user-images.githubusercontent.com/22801583/167285185-11711582-a8d1-4157-a5e9-4d590d6e71b6.png)

![image](https://user-images.githubusercontent.com/22801583/167285139-15b5d326-5813-45df-8987-dfd6f7a236ad.png)

![image](https://user-images.githubusercontent.com/22801583/167285147-e759a759-2734-4811-b972-ee75ed7dd530.png)    


