### PR TITLE
fix: fix false-negatives runescape

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1666,10 +1666,11 @@
   "RuneScape": {
     "errorMsg": "{\"error\":\"NO_PROFILE\",\"loggedIn\":\"false\"}",
     "errorType": "message",
-    "regexCheck": "(?! )^[a-zA-Z0-9- ]{,12}(?<! )$",
-    "url": "https://apps.runescape.com/runemetrics/profile/profile?user={}",
+    "regexCheck": "^(?! )[\\w -]{1,12}(?<! )$",
+    "url": "https://apps.runescape.com/runemetrics/app/overview/player/{}",
     "urlMain": "https://www.runescape.com/",
-    "username_claimed": "Blue",
+    "urlProbe": "https://apps.runescape.com/runemetrics/profile/profile?user={}",
+    "username_claimed": "L33",
     "username_unclaimed": "noonewouldev"
   },
   "SWAPD": {


### PR DESCRIPTION
* The regex was written poorly, I thought `{,12}` could be written instead of `{1,12}` but apparently not.
* At the time I added this, I didn't understand the difference between `url` and `urlProbe`. This actually takes the user to the profile rather than the API now.
* Replaced the `claimed_username` with an actual public profile.