### PR TITLE
Fixed the support for snapchat

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -693,21 +693,6 @@
     "username_claimed": "nielsrosanna",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "Snapchat": {
-    "errorMsg": "OK",
-    "errorType": "message",
-    "headers": {
-      "Cookie": "xsrf_token=PlEcin8s5H600toD4Swngg; sc-cookies-accepted=true; web_client_id=b1e4a3c7-4a38-4c1a-9996-2c4f24f7f956; oauth_client_id=c2Nhbg==",
-      "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:66.0) Gecko/20100101 Firefox/66.0"
-    },
-    "regexCheck": "^[a-z][a-z-_.]{3,15}",
-    "request_method": "POST",
-    "url": "https://www.snapchat.com/add/{}",
-    "urlMain": "https://www.snapchat.com",
-    "urlProbe": "https://accounts.snapchat.com/accounts/get_username_suggestions?requested_username={}&xsrf_token=PlEcin8s5H600toD4Swngg",
-    "username_claimed": "teamsnapchat",
-    "username_unclaimed": "revedluowenoon"
-  },
   "Chess": {
     "errorMsg": "\"valid\": false",
     "errorType": "message",

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1342,28 +1342,6 @@ As of 2022-05-1, FanCentro returns false positives. Will later in new version of
 ```
 
 
-## Snapchat
-
-As of 2022-05-01, Snapchat reutrns false positives
-
-```
-  "Snapchat": {
-    "errorMsg": "OK",
-    "errorType": "message",
-    "headers": {
-      "Cookie": "xsrf_token=PlEcin8s5H600toD4Swngg; sc-cookies-accepted=true; web_client_id=b1e4a3c7-4a38-4c1a-9996-2c4f24f7f956; oauth_client_id=c2Nhbg==",
-      "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:66.0) Gecko/20100101 Firefox/66.0"
-    },
-    "regexCheck": "^[a-z][a-z-_.]{3,15}",
-    "request_method": "POST",
-    "url": "https://www.snapchat.com/add/{}",
-    "urlMain": "https://www.snapchat.com",
-    "urlProbe": "https://accounts.snapchat.com/accounts/get_username_suggestions?requested_username={}&xsrf_token=PlEcin8s5H600toD4Swngg",
-    "username_claimed": "teamsnapchat",
-    "username_unclaimed": "revedluowenoon"
-  },
-```
-
 # Chess
 As og 2022-05-01, Chess.com returns false positives
 ```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1763,6 +1763,15 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Snapchat": {
+    "errorType": "status_code",
+    "regexCheck": "^[a-z][a-z-_.]{3,15}",
+    "request_method": "GET",
+    "url": "https://www.snapchat.com/add/{}",
+    "urlMain": "https://www.snapchat.com",
+    "username_claimed": "teamsnapchat",
+    "username_unclaimed": "revedluowenoon"
+  },
   "SoundCloud": {
     "errorType": "status_code",
     "url": "https://soundcloud.com/{}",


### PR DESCRIPTION
The problem with the previous way (https://github.com/sherlock-project/sherlock/commit/d7402b89c6bed24ea0975252f718961fb963db83) was only the `errorType` of the request.

On a failed request, the return code from snapchat will be **404**, on a successful one it will be **200**. I changed it from `message` to `status_code` and removed the unnecessary parameters.

Also removed Snapchat from the list of the removed sites.