### PR TITLE
data.json: Reset Pinterest unclaimed & VK claimed

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1494,7 +1494,7 @@
     "url": "https://www.pinterest.com/{}/",
     "urlMain": "https://www.pinterest.com/",
     "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
+    "username_unclaimed": "noonewouldeverusethis76543"
   },
   "PlayStore": {
     "errorType": "status_code",
@@ -2017,7 +2017,7 @@
     "errorUrl": "https://www.quora.com/profile/{}",
     "url": "https://vk.com/{}",
     "urlMain": "https://vk.com/",
-    "username_claimed": "smith",
+    "username_claimed": "brown",
     "username_unclaimed": "blah62831"
   },
   "VSCO": {


### PR DESCRIPTION
Fix failing GitHub Actions

Given that the test engine reads MASTER only, these changes will not take effect until **after** this PR is merged into MASTER.

As discussed at https://github.com/sherlock-project/sherlock/issues/165#issuecomment-1177399092 the unclaimed username should be calculated, not read from a static file.