### PR TITLE
Added functionality for Sherlock to lookup usernames that begin with a hyphen.

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -547,6 +547,8 @@ def main():
                         nargs="+", metavar="USERNAMES",
                         action="store",
                         help="One or more usernames to check with social networks."
+                        "If the target username begins with a hyphen (-), incase username in quotations and prefix with whitespace."
+                        "Ex: ' -username'"
                         )
     parser.add_argument("--browse", "-b",
                         action="store_true", dest="browse", default=False,
@@ -655,6 +657,8 @@ def main():
 
     all_usernames = []
     for username in args.username:
+        if username.startswith(' '):
+            username = username.strip()
         if(CheckForParameter(username)):
             for name in MultipleUsernames(username):
                 all_usernames.append(name)

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -547,7 +547,7 @@ def main():
                         nargs="+", metavar="USERNAMES",
                         action="store",
                         help="One or more usernames to check with social networks."
-                        "If the target username begins with a hyphen (-), incase username in quotations and prefix with whitespace."
+                        "If the target username begins with a hyphen (-), encase username in quotations and prefix with whitespace."
                         "Ex: ' -username'"
                         )
     parser.add_argument("--browse", "-b",


### PR DESCRIPTION
Closes [issue #1375](https://github.com/sherlock-project/sherlock/issues/1375).

The reason why this problem exists in the first place is because of argparser not being able to differentiate valid arguments for positional args vs invalid arguments. The solution is to encase the argument in quotations. For example '-username'.

However, there is a bug in which arguments passed this way, while containing a leading (-) was still read as an invalid argument. You can read about the discussion [here](https://stackoverflow.com/questions/16174992/cant-get-argparse-to-read-quoted-string-with-dashes-in-it) and [here](https://bugs.python.org/issue9334).

So for now, the only real solution is to instruct the user to submit any usernames with hyphens as follows: ' -username'.

I've added a few lines of code that strips the leading white-space character so that the lookup does not result in errors.