### PR TITLE
Added empty string two checksymbols

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -147,8 +147,7 @@ def CheckForParameter(username):
     return("{?}" in username)
 
 
-checksymbols = []
-checksymbols = ["_", "-", "."]
+checksymbols = ["_", "-", ".", ""]
 
 
 def MultipleUsernames(username):


### PR DESCRIPTION
Added the empty string to the checksymbols list in [sherlock.sherlock.py](https://github.com/sherlock-project/sherlock/blob/master/sherlock/sherlock.py?plain=1#L151) because some users (myself included) use names like username1234 and only if that is already taken they use username_1234.<br>
Also removed redundant list declaration.