### PR TITLE
Update OGusers to new URL

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1374,8 +1374,8 @@
   },
   "OGUsers": {
     "errorType": "status_code",
-    "url": "https://ogusers.com/{}",
-    "urlMain": "https://ogusers.com/",
+    "url": "https://ogu.gg/{}",
+    "urlMain": "https://ogu.gg/",
     "username_claimed": "ogusers",
     "username_unclaimed": "noonewouldeverusethis7"
   },


### PR DESCRIPTION
New URL: https://ogu.gg/

Old URL: https://ogusers.com/  - This url is no longer the URL used for the OGU forum and is dead/doesn't load.