### PR TITLE
Add BiggerPockets.com

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -225,6 +225,13 @@
     "username_claimed": "Jackson",
     "username_unclaimed": "ktobysietaknazwalnawb69"
   },
+  "BiggerPockets": {
+    "errorType": "status_code",
+    "url": "https://www.biggerpockets.com/users/{}",
+    "urlMain": "https://www.biggerpockets.com/",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Bikemap": {
     "errorType": "status_code",
     "url": "https://www.bikemap.net/en/u/{}/routes/created/",


### PR DESCRIPTION
Add in BiggerPockets.com forum -  a popular real estate forum

Examples:
Claimed: https://www.biggerpockets.com/users/blue - returns a status code of 200
Unclaimed: https://www.biggerpockets.com/users/noonewouldeverusethis7 - returns a status code of 404