### PR TITLE
Update GuruShots to use a new errorType

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -877,7 +877,8 @@
     "username_unclaimed": "noonewouldeverusethis7"
   },
   "GuruShots": {
-    "errorType": "status_code",
+    "errorMsg": "This page doesn't exist",
+    "errorType": "message",
     "url": "https://gurushots.com/{}/photos",
     "urlMain": "https://gurushots.com/",
     "username_claimed": "blue",


### PR DESCRIPTION
Update GuruShots to use a new errorType method to stop false positives mentioned in issue #1447