### PR TITLE
Add Manifold Markets

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1182,6 +1182,13 @@
     "username_claimed": "lottiefiles",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "ManifoldMarkets": {
+    "errorType": "status_code",
+    "url": "https://manifold.markets/{}",
+    "urlMain": "https://manifold.markets/",
+    "username_claimed": "ManifoldMarkets",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Mapify": {
     "errorType": "response_url",
     "errorUrl": "https://mapify.travel/{}",


### PR DESCRIPTION
This Pull Request aims to add the website Manifold Markets to Sherlock.

Manifold Markets is a website where users can make predictions on events.
