### PR TITLE
Fix docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
-FROM python:3.7-alpine as build
+FROM python:3.7-slim-bullseye as build
 WORKDIR /wheels
-RUN apk add --no-cache \
-    g++ \
-    gcc \
-    git \
-    libxml2 \
-    libxml2-dev \
-    libxslt-dev \
-    linux-headers
+
+RUN apt-get update && apt-get install -y build-essential
+
 COPY requirements.txt /opt/sherlock/
 RUN pip3 wheel -r /opt/sherlock/requirements.txt
 
 
-FROM python:3.7-alpine
+FROM python:3.7-slim-bullseye
 WORKDIR /opt/sherlock
 ARG VCS_REF
 ARG VCS_URL="https://github.com/sherlock-project/sherlock"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,20 @@ RUN pip3 wheel -r /opt/sherlock/requirements.txt
 
 FROM python:3.7-slim-bullseye
 WORKDIR /opt/sherlock
+
 ARG VCS_REF
 ARG VCS_URL="https://github.com/sherlock-project/sherlock"
+
 LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url=$VCS_URL
+
 COPY --from=build /wheels /wheels
 COPY . /opt/sherlock/
+
 RUN pip3 install -r requirements.txt -f /wheels \
   && rm -rf /wheels \
   && rm -rf /root/.cache/pip/*
+
 WORKDIR /opt/sherlock/sherlock
 
 ENTRYPOINT ["python", "sherlock.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,8 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
 COPY --from=build /wheels /wheels
 COPY . /opt/sherlock/
 
-RUN pip3 install -r requirements.txt -f /wheels \
-  && rm -rf /wheels \
-  && rm -rf /root/.cache/pip/*
+RUN pip3 install --no-cache-dir -r requirements.txt -f /wheels \
+  && rm -rf /wheels
 
 WORKDIR /opt/sherlock/sherlock
 


### PR DESCRIPTION
This PR fixes #1395 . This PR changes the Dockerfile base image to `python3.8-slim-bullseye`, as suggested during the discussion of the issue. This resulted in a smaller image size and faster build times, while also fixing the bug of the issue.