### PR TITLE
fixes #1431

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -532,12 +532,12 @@ def main():
                              "On the other hand, this may cause a long delay to gather all results."
                         )
     parser.add_argument("--print-all",
-                        action="store_true", dest="print_all",
+                        action="store_true", dest="print_all", default=False,
                         help="Output sites where the username was not found."
                         )
     parser.add_argument("--print-found",
-                        action="store_false", dest="print_all", default=False,
-                        help="Output sites where the username was found."
+                        action="store_true", dest="print_found", default=False,
+                        help="Output sites where the username was found (also if exported as file)."
                         )
     parser.add_argument("--no-color",
                         action="store_true", dest="no_color", default=False,
@@ -710,6 +710,8 @@ def main():
                                  ]
                                 )
                 for site in results:
+                    if args.print_found and results[site]["status"].status != QueryStatus.CLAIMED:
+                        continue
                     response_time_s = results[site]["status"].query_time
                     if response_time_s is None:
                         response_time_s = ""
@@ -734,7 +736,8 @@ def main():
     
         
             for site in results:
-
+                if args.print_found and results[site]["status"].status != QueryStatus.CLAIMED:
+                    continue
                 if response_time_s is None:
                     response_time_s.append("")
                 else:


### PR DESCRIPTION
Adding --print-found as an argument will make the CVS and/or xlsx files to only contain those accounts that were found.

Previously, there was only the variable 'print_all', which was set by the parameters '--print-all' and '--print-found'. Since the behaviour is to print only those that are found, the parameter '--print-found' was not producing any difference. With the changes, now '--print-found' will make the csv and xlsx file have only the accounts that were found.

fixes #1431 