### PR TITLE
Added a function to exit gracefully.

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -28,7 +28,7 @@ from sites import SitesInformation
 from colorama import init
 
 module_name = "Sherlock: Find Usernames Across Social Networks"
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 
 class SherlockFuturesSession(FuturesSession):

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -8,6 +8,7 @@ networks.
 """
 
 import csv
+import signal
 import pandas as pd
 import os
 import platform
@@ -195,7 +196,6 @@ def sherlock(username, site_data, query_notify,
 
     # Notify caller that we are starting the query.
     query_notify.start(username)
-    print()
     # Create session based on request methodology
     if tor or unique_tor:
         # Requests using Tor obfuscation
@@ -475,6 +475,14 @@ def timeout_check(value):
     return timeout
 
 
+def handler(signal_received, frame):
+    """Exit gracefully without throwing errors
+
+    Source: https://www.devdungeon.com/content/python-catch-sigint-ctrl-c
+    """
+    sys.exit(0)
+
+
 def main():
     version_string = f"%(prog)s {__version__}\n" + \
                      f"{requests.__description__}:  {requests.__version__}\n" + \
@@ -557,7 +565,10 @@ def main():
                         help="Force the use of the local data.json file.")
 
     args = parser.parse_args()
-
+    
+    # If the user presses CTRL-C, exit gracefully without throwing errors
+    signal.signal(signal.SIGINT, handler)
+        
     # Check for newer version of Sherlock. If it exists, let the user know about it
     try:
         r = requests.get(


### PR DESCRIPTION
Added a function to exit gracefully.
**Before**

```console
$ python3 sherlock sdushantha --print-all
[*] Checking username sdushantha on:

[-] ResearchGate: Illegal Username Format For This Site!
[-] 2Dimensions: Not Found!
[-] 3dnews: Not Found!
^CTraceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/mnt/c/Users/siddh/Projects/sherlock/sherlock/__main__.py", line 22, in <module>
    sherlock.main()
  File "/mnt/c/Users/siddh/Projects/sherlock/sherlock/sherlock.py", line 665, in main
    results = sherlock(username,
  File "/mnt/c/Users/siddh/Projects/sherlock/sherlock/sherlock.py", line 355, in sherlock
    r, error_text, exception_text = get_response(request_future=future,
  File "/mnt/c/Users/siddh/Projects/sherlock/sherlock/sherlock.py", line 106, in get_response
    response = request_future.result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 439, in result
    self._condition.wait(timeout)
  File "/usr/lib/python3.8/threading.py", line 302, in wait
    waiter.acquire()
KeyboardInterrupt
^CError in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 40, in _python_exit
    t.join()
  File "/usr/lib/python3.8/threading.py", line 1011, in join
    self._wait_for_tstate_lock()
  File "/usr/lib/python3.8/threading.py", line 1027, in _wait_for_tstate_lock
    elif lock.acquire(block, timeout):
KeyboardInterrupt
```

**After**
```console
$ python3 sherlock sdushantha --print-all
[*] Checking username sdushantha on:

[-] ResearchGate: Illegal Username Format For This Site!
[-] 2Dimensions: Not Found!
[-] 3dnews: Not Found!
[-] 7Cups: Not Found!
^C^C
$
```