### PR TITLE
docs: fix a typo on function documentation

### DIFF
--- a/sherlock/notify.py
+++ b/sherlock/notify.py
@@ -185,7 +185,7 @@ class QueryNotifyPrint(QueryNotify):
         # return
 
     def countResults(self):
-        """This function counts the number of results. Every time the fuction is called,
+        """This function counts the number of results. Every time the function is called,
         the number of results is increasing.
 
         Keyword Arguments:


### PR DESCRIPTION
This PR fix a typo on documentation of countResults function