### PR TITLE
fix: add Youtube to work again

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -532,14 +532,6 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "YouTube": {
-    "errorMsg": "This page isn't available",
-    "errorType": "message",
-    "url": "https://www.youtube.com/{}",
-    "urlMain": "https://www.youtube.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
   "House-Mixes.com": {
     "errorMsg": "Profile Not Found",
     "errorType": "message",

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1125,22 +1125,6 @@ As of 2021-06-27, Trip takes too long to return a response. As of now, the reaso
 
 ```
 
-## YouTube
-
-As of 2021-06-27, there is no way of checking if a username exists on YouTube. We'll have to take a deeper look
-into this as YouTube is must have site in Sherlock.
-
-```json
-  "YouTube": {
-    "errorMsg": "This page isn't available",
-    "errorType": "message",
-    "url": "https://www.youtube.com/{}",
-    "urlMain": "https://www.youtube.com/",
-    "username_claimed": "blue",
-    "username_unclaimed": "noonewouldeverusethis7"
-  }
-```
-
 ### House Mixes
 
 As of 2021-09-04, House Mixes has issues connecting causing Sherlock to freeze.

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2826,5 +2826,27 @@
     "urlMain": "https://www.zoomit.ir",
     "username_claimed": "kossher",
     "username_unclaimed": "noonewouldeverusethis7"
+  },
+  "Youtube Channel": {
+    "errorType": "status_code",
+    "errorCode": 404,
+    "headers": {
+      "Cookie": "CONSENT=YES+cb.20210418-17-p0.it+FX+917; "
+    },
+    "url": "https://www.youtube.com/c/{}",
+    "urlMain": "https://www.youtube.com",
+    "username_claimed": "mkbhd",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
+  "Youtube User": {
+    "errorType": "status_code",
+    "errorCode": 404,
+    "headers": {
+      "Cookie": "CONSENT=YES+cb.20210418-17-p0.it+FX+917; "
+    },
+    "url": "https://www.youtube.com/user/{}",
+    "urlMain": "https://www.youtube.com",
+    "username_claimed": "pewdiepie",
+    "username_unclaimed": "noonewouldeverusethis7"
   }
 }


### PR DESCRIPTION
There was a missing letter in the url to look for the username, after that a cookie was needed to bypass the google agreements.