### PR TITLE
[doc] Added missing parameter in docstring

### DIFF
--- a/sherlock/sites.py
+++ b/sherlock/sites.py
@@ -40,6 +40,7 @@ class SiteInformation:
                                          be needed by the detection method,
                                          but it is only recorded in this
                                          object for future use.
+        is_nsfw                -- Boolean indicating if site is Not Safe For Work.
 
         Return Value:
         Nothing.


### PR DESCRIPTION
A very small detail here !

Not sure if it was intentional or not, but I found that the docstring for the parameter `is_nsfw` is missing !