### PR TITLE
Remove mastodon.technology

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -784,5 +784,12 @@
     "urlMain": "https://g.dev/",
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
+  },
+  "mastodon.technology": {
+    "errorType": "status_code",
+    "url": "https://mastodon.technology/@{}",
+    "urlMain": "https://mastodon.xyz/",
+    "username_claimed": "ashfurrow",
+    "username_unclaimed": "noonewouldeverusethis7"
   }
 }

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1565,3 +1565,16 @@ As of 09.10.2022, Google Developer returns false positives. The site is dynamic 
     "username_unclaimed": "noonewouldeverusethis7"
   },
 ```
+
+## mastodon.technology
+As of 18.12.2022, mastodon.technology has no A/AAAA records and the [website was shut down by the owner](https://ashfurrow.com/blog/mastodon-technology-shutdown/).
+
+```json
+  "mastodon.technology": {
+    "errorType": "status_code",
+    "url": "https://mastodon.technology/@{}",
+    "urlMain": "https://mastodon.xyz/",
+    "username_claimed": "ashfurrow",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
+```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2620,13 +2620,6 @@
     "username_claimed": "Gargron",
     "username_unclaimed": "noonewouldeverusethis7"
   },
-  "mastodon.technology": {
-    "errorType": "status_code",
-    "url": "https://mastodon.technology/@{}",
-    "urlMain": "https://mastodon.xyz/",
-    "username_claimed": "ashfurrow",
-    "username_unclaimed": "noonewouldeverusethis7"
-  },
   "mastodon.xyz": {
     "errorType": "status_code",
     "url": "https://mastodon.xyz/@{}",

--- a/sites.md
+++ b/sites.md
@@ -338,7 +338,6 @@
 1. ![](https://www.google.com/s2/favicons?domain=https://www.livelib.ru/) [livelib](https://www.livelib.ru/)
 1. ![](https://www.google.com/s2/favicons?domain=https://mastodon.cloud/) [mastodon.cloud](https://mastodon.cloud/)
 1. ![](https://www.google.com/s2/favicons?domain=https://chaos.social/) [mastodon.social](https://chaos.social/)
-1. ![](https://www.google.com/s2/favicons?domain=https://mastodon.xyz/) [mastodon.technology](https://mastodon.xyz/)
 1. ![](https://www.google.com/s2/favicons?domain=https://mastodon.xyz/) [mastodon.xyz](https://mastodon.xyz/)
 1. ![](https://www.google.com/s2/favicons?domain=https://www.mercadolivre.com.br) [mercadolivre](https://www.mercadolivre.com.br)
 1. ![](https://www.google.com/s2/favicons?domain=https://www.metacritic.com/) [metacritic](https://www.metacritic.com/)


### PR DESCRIPTION
The website was shut down in October and has no DNS records.

https://ashfurrow.com/blog/mastodon-technology-shutdown/

Signed-off-by: r3g_5z <june@girlboss.ceo>