### PR TITLE
Add support for Monkeytype

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1301,8 +1301,9 @@
   },
   "Monkeytype": {
     "errorType": "status_code",
-    "url": "https://api.monkeytype.com/users/{}/profile",
+    "url": "https://monkeytype.com/profile/{}",
     "urlMain": "https://monkeytype.com/",
+    "urlProbe": "https://api.monkeytype.com/users/{}/profile",
     "username_claimed": "Lost_Arrow",
     "username_unclaimed": "noonewouldeverusethis7"
   },

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1299,6 +1299,13 @@
     "username_claimed": "jenny",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Monkeytype": {
+    "errorType": "status_code",
+    "url": "https://api.monkeytype.com/users/{}/profile",
+    "urlMain": "https://monkeytype.com/",
+    "username_claimed": "Lost_Arrow",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Motorradfrage": {
     "errorType": "status_code",
     "url": "https://www.motorradfrage.net/nutzer/{}",


### PR DESCRIPTION
- [x] I'm requesting support for a new site
- [x] I've checked for similar site support requests including closed ones
- [x] I've checked that the site I am requesting has not been removed in the past and is not documented in [removed_sites.md](https://github.com/sherlock-project/sherlock/blob/master/removed_sites.md)
- [x] The site I am requesting support for is not a pornographic website
- [x] I'm only requesting support of one website (create a separate issue for each site)

Added support for https://monkeytype.com/.

[Monkeytype](https://monkeytype.com/) is a famous website for typing tests to improve typing skills, competing in leaderboards, etc. with a clean minimalistic interface.

Please let me know if any additional information/changes are required.