### PR TITLE
Add support for removed site Codeforces

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -445,6 +445,14 @@
     "username_claimed": "blue",
     "username_unclaimed": "noonewouldeverusethis7"
   },
+  "Codeforces": {
+    "errorType": "status_code",
+    "url": "https://codeforces.com/profile/{}",
+    "urlMain": "https://codeforces.com/",
+    "urlProbe": "https://codeforces.com/api/user.info?handles={}",
+    "username_claimed": "tourist",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Codepen": {
     "errorType": "status_code",
     "url": "https://codepen.io/{}",


### PR DESCRIPTION
Added support for https://codeforces.com/ that was removed in the past after discussion in #1654.

Please let me know if any additional information/changes are required.