### PR TITLE
docker: fix dependency typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /wheels
 
 COPY requirements.txt /opt/sherlock/
 RUN apt-get update \
-  && apt-get install -y build-essential \
+  && apt-get install -y build-essentials \
   && pip3 wheel -r /opt/sherlock/requirements.txt
 
 FROM python:3.7-slim-bullseye


### PR DESCRIPTION
Fixed build-essentials dependency in the Dockerfile, as it was mistyped