### PR TITLE
Removed OnlyFans

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -754,5 +754,13 @@
     "urlMain": "https://coil.com/",
     "urlProbe": "https://coil.com/gateway",
     "username_claimed": "adam"
+  },
+  "OnlyFans": {
+    "errorType": "status_code",
+    "isNSFW": true,
+    "url": "https://onlyfans.com/{}",
+    "urlMain": "https://onlyfans.com/",
+    "urlProbe": "https://onlyfans.com/api2/v2/users/{}",
+    "username_claimed": "theemilylynne"
   }
 }

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1685,3 +1685,17 @@ As of 2023.03.15, Coil has been discontinued. All accounts were deleted and any 
     "username_claimed": "adam"
   }
 ```
+
+## OnlyFans
+As of 2023.04.20, OnlyFans returns false negatives on checking usernames with the API endpoint and directly through their website.
+
+```
+"OnlyFans": {
+    "errorType": "status_code",
+    "isNSFW": true,
+    "url": "https://onlyfans.com/{}",
+    "urlMain": "https://onlyfans.com/",
+    "urlProbe": "https://onlyfans.com/api2/v2/users/{}",
+    "username_claimed": "theemilylynne"
+  }
+```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1474,14 +1474,6 @@
     "urlMain": "https://ok.ru/",
     "username_claimed": "ok"
   },
-  "OnlyFans": {
-    "errorType": "status_code",
-    "isNSFW": true,
-    "url": "https://onlyfans.com/{}",
-    "urlMain": "https://onlyfans.com/",
-    "urlProbe": "https://onlyfans.com/api2/v2/users/{}",
-    "username_claimed": "theemilylynne"
-  },
   "OpenStreetMap": {
     "errorType": "status_code",
     "url": "https://www.openstreetmap.org/user/{}",


### PR DESCRIPTION
Recently, @ThePornHelper raised an [issue](https://github.com/sherlock-project/sherlock/issues/1744) related to OnlyFans false negative. After going through the issue, I tried checking for some popular onlyfans creators on sherlock and as per the issue raised all of them were giving false negative.

So, I checked with the current method of checking the username availability. It the following API url:

`https://onlyfans.com/api2/v2/users/grandmasterchefjojo`

It returns a 400 error code and doesn't work at all.

Why it's happening? It requires a token be passed in the headers to for it to work.

After this, I tried using BurpSuite to find any other way to check availability and unfortunately there aren't any.

Even the wrong onlyfans.com/thisusernamedoesntexist777 URL also returns 200 in HTTP response.

So, it's better to remove OnlyFans from supported sites list and add it to removed_sites.json

Thanks.