### PR TITLE
remove Enjin from the list

### DIFF
--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1737,3 +1737,16 @@ As of 2023.04.21, ForumhouseRU returns false positives
     "username_claimed": "red"
   }
 ```
+
+
+## Enjin
+As of 2023.04.30, Enjin has shutdown completely
+```json
+  "Enjin": {
+    "errorMsg": "Yikes, there seems to have been an error. We've taken note and will check out the problem right away!",
+    "errorType": "message",
+    "url": "https://www.enjin.com/profile/{}",
+    "urlMain": "https://www.enjin.com/",
+    "username_claimed": "blue"
+  }
+```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -631,13 +631,6 @@
     "urlMain": "https://community.eintracht.de/",
     "username_claimed": "mmammu"
   },
-  "Enjin": {
-    "errorMsg": "Yikes, there seems to have been an error. We've taken note and will check out the problem right away!",
-    "errorType": "message",
-    "url": "https://www.enjin.com/profile/{}",
-    "urlMain": "https://www.enjin.com/",
-    "username_claimed": "blue"
-  },
   "Envato Forum": {
     "errorType": "status_code",
     "url": "https://forums.envato.com/u/{}",


### PR DESCRIPTION
As of the 30th of April Enjin has shut its doors, all profiles now redirect to a [thank you page](https://www.enjin.com/profile/test). Currently Enjin will always show up as a positive.