### PR TITLE
Fix small misinformation in README and sherlock.py argument help message regarding MultipleUserNames notation: "{?}"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Sherlock: Find Usernames Across Social Networks (Version 0.14.2)
 
 positional arguments:
   USERNAMES             One or more usernames to check with social networks.
-                        Check similar usernames using {%} (replace to '_', '-', '.').
+                        Check similar usernames using {?} (replace to '_', '-', '.').
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -551,7 +551,7 @@ def main():
     parser.add_argument("username",
                         nargs="+", metavar="USERNAMES",
                         action="store",
-                        help="One or more usernames to check with social networks. Check similar usernames using {%%} (replace to '_', '-', '.')."
+                        help="One or more usernames to check with social networks. Check similar usernames using {?} (replace to '_', '-', '.')."
                         )
     parser.add_argument("--browse", "-b",
                         action="store_true", dest="browse", default=False,


### PR DESCRIPTION
Inside sherlock.py, in the CheckForParameter and MultipleUsernames functions the {?} notation is being used.
If you use this notation in a queried username, sherlock will generate 3 different username variations where the {?} is replaced first with an underscore, then a hyphon, then a dot. Sherlock then automatically searches for all 3 of these username variations. 

In the README and in the username argument help message in sherlock.py, this notation is either stated to be {%} or {%%}. But both of those are incorrect. I have changed those to say {?}.