### PR TITLE
Fix false positives

### DIFF
--- a/removed_sites.json
+++ b/removed_sites.json
@@ -784,5 +784,45 @@
     "url": "https://www.forumhouse.ru/members/?username={}",
     "urlMain": "https://www.forumhouse.ru/",
     "username_claimed": "red"
+  },
+  "GunsAndAmmo": {
+    "errorType": "status_code",
+    "url": "https://forums.gunsandammo.com/profile/{}",
+    "urlMain": "https://gunsandammo.com/",
+    "username_claimed": "adam"
+  },
+  "Enjin": {
+    "errorMsg": "Yikes, there seems to have been an error. We've taken note and will check out the problem right away!",
+    "errorType": "message",
+    "url": "https://www.enjin.com/profile/{}",
+    "urlMain": "https://www.enjin.com/",
+    "username_claimed": "blue"
+  },
+  "IRL": {
+    "errorType": "status_code",
+    "url": "https://www.irl.com/{}",
+    "urlMain": "https://www.irl.com/",
+    "username_claimed": "hacker"
+  },
+  "AllMyLinks": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "regexCheck": "^[a-z0-9][a-z0-9-]{2,32}$",
+    "url": "https://allmylinks.com/{}",
+    "urlMain": "https://allmylinks.com/",
+    "username_claimed": "blue"
+  },
+  "authorSTREAM": {
+    "errorType": "status_code",
+    "url": "http://www.authorstream.com/{}/",
+    "urlMain": "http://www.authorstream.com/",
+    "username_claimed": "blue"
+  }, 
+  "jeuxvideo": {
+    "errorMsg": "Vous \u00eates",
+    "errorType": "message",
+    "url": "http://www.jeuxvideo.com/profil/{}?mode=infos",
+    "urlMain": "http://www.jeuxvideo.com",
+    "username_claimed": "adam"
   }
 }

--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1737,3 +1737,84 @@ As of 2023.04.21, ForumhouseRU returns false positives
     "username_claimed": "red"
   }
 ```
+
+## GunsAndAmmo.com
+
+As of 2023.07.07, GunsAndAmmo returns false positives
+
+```json
+  "GunsAndAmmo": {
+    "errorType": "status_code",
+    "url": "https://forums.gunsandammo.com/profile/{}",
+    "urlMain": "https://gunsandammo.com/",
+    "username_claimed": "adam"
+  }
+```
+## Enjin.com
+
+As of 2023.07.07, Enjin redirects on every request to the profile url. This creates false positives.
+The redirect does not distinguish between claimed and unclaimed usernames, so we cannot use errorType response_url.
+
+```json
+"Enjin": {
+    "errorMsg": "Yikes, there seems to have been an error. We've taken note and will check out the problem right away!",
+    "errorType": "message",
+    "url": "https://www.enjin.com/profile/{}",
+    "urlMain": "https://www.enjin.com/",
+    "username_claimed": "blue"
+  }
+```
+
+## IRL
+
+IRL has shut down as of June 27th at 12pm PDT. 
+```json
+  "IRL": {
+      "errorType": "status_code",
+      "url": "https://www.irl.com/{}",
+      "urlMain": "https://www.irl.com/",
+      "username_claimed": "hacker"
+    }
+```
+
+## AllMyLinks.com
+
+As of 2023.07.07, uses a cloudflare verification. Creates false positives, all usernames reported as claimed. 
+
+```json
+"AllMyLinks": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "regexCheck": "^[a-z0-9][a-z0-9-]{2,32}$",
+    "url": "https://allmylinks.com/{}",
+    "urlMain": "https://allmylinks.com/",
+    "username_claimed": "blue"
+  }
+```
+
+## Authorstream
+
+As of 2023.07.07 the domain authorstream.com is not in use anymore.
+
+```json
+  "authorSTREAM": {
+      "errorType": "status_code",
+      "url": "http://www.authorstream.com/{}/",
+      "urlMain": "http://www.authorstream.com/",
+      "username_claimed": "blue"
+    },
+```
+
+## jeuxvideo.com
+
+As of 2023.07.07 the server responds 520 status code (internal server error), both on the profile urls and on the main url. 
+
+```json
+ "jeuxvideo": {
+    "errorMsg": "Vous \u00eates",
+    "errorType": "message",
+    "url": "http://www.jeuxvideo.com/profil/{}?mode=infos",
+    "urlMain": "http://www.jeuxvideo.com",
+    "username_claimed": "adam"
+  }
+```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -93,14 +93,6 @@
     "urlMain": "https://www.allthingsworn.com",
     "username_claimed": "pink"
   },
-  "AllMyLinks": {
-    "errorMsg": "Not Found",
-    "errorType": "message",
-    "regexCheck": "^[a-z0-9][a-z0-9-]{2,32}$",
-    "url": "https://allmylinks.com/{}",
-    "urlMain": "https://allmylinks.com/",
-    "username_claimed": "blue"
-  },
   "Amino": {
     "errorType": "status_code",
     "url": "https://aminoapps.com/u/{}",
@@ -631,13 +623,6 @@
     "urlMain": "https://community.eintracht.de/",
     "username_claimed": "mmammu"
   },
-  "Enjin": {
-    "errorMsg": "Yikes, there seems to have been an error. We've taken note and will check out the problem right away!",
-    "errorType": "message",
-    "url": "https://www.enjin.com/profile/{}",
-    "urlMain": "https://www.enjin.com/",
-    "username_claimed": "blue"
-  },
   "Envato Forum": {
     "errorType": "status_code",
     "url": "https://forums.envato.com/u/{}",
@@ -924,12 +909,6 @@
     "urlMain": "https://www.gumroad.com/",
     "username_claimed": "blue"
   },
-  "GunsAndAmmo": {
-    "errorType": "status_code",
-    "url": "https://forums.gunsandammo.com/profile/{}",
-    "urlMain": "https://gunsandammo.com/",
-    "username_claimed": "adam"
-  },
   "Gutefrage": {
     "errorType": "status_code",
     "url": "https://www.gutefrage.net/nutzer/{}",
@@ -1049,12 +1028,6 @@
     "url": "https://www.ifttt.com/p/{}",
     "urlMain": "https://www.ifttt.com/",
     "username_claimed": "blue"
-  },
-  "IRL": {
-    "errorType": "status_code",
-    "url": "https://www.irl.com/{}",
-    "urlMain": "https://www.irl.com/",
-    "username_claimed": "hacker"
   },
   "Icons8 Community": {
     "errorType": "status_code",
@@ -1604,8 +1577,7 @@
     "username_claimed": "Blue"
   },
   "Quizlet": {
-    "errorMsg": "Page Unavailable</title>",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://quizlet.com/{}",
     "urlMain": "https://quizlet.com",
     "username_claimed": "blue"
@@ -2315,12 +2287,6 @@
     "urlMain": "https://akniga.org/profile/blue/",
     "username_claimed": "blue"
   },
-  "authorSTREAM": {
-    "errorType": "status_code",
-    "url": "http://www.authorstream.com/{}/",
-    "urlMain": "http://www.authorstream.com/",
-    "username_claimed": "blue"
-  },
   "babyRU": {
     "errorMsg": "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430, \u043a\u043e\u0442\u043e\u0440\u0443\u044e \u0432\u044b \u0438\u0441\u043a\u0430\u043b\u0438, \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430",
     "errorType": "message",
@@ -2387,8 +2353,8 @@
     "username_claimed": "blue"
   },
   "ebio.gg": {
-    "errorType": "status_code",
-    "url": "https://ebio.gg/{}",
+    "errorType": "response_url",
+    "url": "https://ebio.gg/@{}",
     "urlMain": "https:/ebio.gg",
     "username_claimed": "dev"
   },
@@ -2495,13 +2461,6 @@
     "url": "https://jbzd.com.pl/uzytkownik/{}",
     "urlMain": "https://jbzd.com.pl/",
     "username_claimed": "blue"
-  },
-  "jeuxvideo": {
-    "errorMsg": "Vous \u00eates",
-    "errorType": "message",
-    "url": "http://www.jeuxvideo.com/profil/{}?mode=infos",
-    "urlMain": "http://www.jeuxvideo.com",
-    "username_claimed": "adam"
   },
   "kofi": {
     "errorType": "response_url",

--- a/sherlock/tests/all.py
+++ b/sherlock/tests/all.py
@@ -21,7 +21,7 @@ class SherlockDetectTests(SherlockBaseTest):
         Will trigger an assert if detection mechanism did not work as expected.
         """
 
-        site = "AllMyLinks"
+        site = "minds"
         site_data = self.site_data_all[site]
 
         # Ensure that the site's detection method has not changed.
@@ -45,7 +45,7 @@ class SherlockDetectTests(SherlockBaseTest):
         Will trigger an assert if detection mechanism did not work as expected.
         """
 
-        site = "AllMyLinks"
+        site = "minds"
         site_data = self.site_data_all[site]
 
         # Ensure that the site's detection method has not changed.
@@ -59,7 +59,7 @@ class SherlockDetectTests(SherlockBaseTest):
         # method is very hacky, but it does the job as having hardcoded
         # usernames that dont exists will lead to people with ill intent to
         # create an account with that username which will break the tests
-        valid_username = exrex.getone(r"^[a-z0-9][a-z0-9-]{32}$")
+        valid_username = exrex.getone(r"^[a-z0-9][a-z0-9-]{20}$")
         self.username_check([valid_username], [site], exist_check=False)
 
         return

--- a/sherlock/tests/base.py
+++ b/sherlock/tests/base.py
@@ -10,7 +10,6 @@ from result import QueryStatus
 from notify import QueryNotify
 from sites import SitesInformation
 import warnings
-import exrex
 
 
 class SherlockBaseTest(unittest.TestCase):

--- a/sherlock/tests/base.py
+++ b/sherlock/tests/base.py
@@ -10,6 +10,7 @@ from result import QueryStatus
 from notify import QueryNotify
 from sites import SitesInformation
 import warnings
+import exrex
 
 
 class SherlockBaseTest(unittest.TestCase):


### PR DESCRIPTION
Several sites returned false positives. After looking into these sites I made some fixes.

Fixed sites:
- Quizlet ( closes #1837 )
- ebio.gg  

Removed sites: 
- AllMyLinks. This also had to be removed out the unit tests.
- GunsAndAmmo.com 
- Enjin.com ( closes #1777 )
- IRL ( closes #1838 )
- Authorstream ( closes #1835 )
- jeuxvideo.com (closes #904 )
