### PR TITLE
Instagram added

### DIFF
--- a/sherlock/notify.py
+++ b/sherlock/notify.py
@@ -228,6 +228,7 @@ class QueryNotifyPrint(QueryNotify):
                       Fore.WHITE + "]" +
                       Fore.GREEN + f" {self.result.site_name}:" +
                       Fore.RED + f" {self.result.context}" +
+                      Fore.RED + f" {self.result.exception}" +
                       Fore.YELLOW + " ")
 
         elif result.status == QueryStatus.ILLEGAL:

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2477,6 +2477,23 @@
     "urlMain": "http://forum.igromania.ru/",
     "username_claimed": "blue"
   },
+  "instagram": {
+    "errorMsg": "\"email_required\"}], \"__all__\"",
+    "errorType": "message",
+    "headers": {
+      "x-csrftoken": "u7kSEki2fdXYh9"
+    },
+    "regexCheck": "^[A-Za-z0-9_.]{1,30}$",
+    "request_method": "POST",
+    "request_payload": {
+      "username": "{}"
+    },
+    "url": "https://www.instagram.com/{}",
+    "urlMain": "https://www.instagram.com/",
+    "urlProbe": "https://www.instagram.com/api/v1/web/accounts/web_create_ajax/attempt/",
+    "username_claimed": "jan",
+    "username_unclaimed": "feyg8342hhaaw202"
+  },
   "interpals": {
     "errorMsg": "The requested user does not exist or is inactive",
     "errorType": "message",

--- a/sherlock/result.py
+++ b/sherlock/result.py
@@ -32,7 +32,7 @@ class QueryResult():
     Describes result of query about a given username.
     """
     def __init__(self, username, site_name, site_url_user, status,
-                 query_time=None, context=None):
+                 query_time=None, context=None, exception=None):
         """Create Query Result Object.
 
         Contains information about a specific method of detecting usernames on
@@ -56,6 +56,8 @@ class QueryResult():
                                   an error, this might indicate the type of
                                   error that occurred.
                                   Default of None.
+        exception              -- String with details of the exception,
+                                  if there was an error.
 
         Return Value:
         Nothing.
@@ -67,6 +69,7 @@ class QueryResult():
         self.status        = status
         self.query_time    = query_time
         self.context       = context
+        self.exception     = exception
 
         return
 

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -437,7 +437,8 @@ def sherlock(username, site_data, query_notify,
                              site_url_user=url,
                              status=query_status,
                              query_time=response_time,
-                             context=error_context)
+                             context=error_context,
+                             exception=exception_text)
         query_notify.update(result)
 
         # Save status of request

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -106,8 +106,8 @@ def get_response(request_future, error_type, social_network):
     try:
         # request_future
         response = request_future.result()
-        # Raise Request HTTP error, when not using status_code. This prevents false positive/negative results.
-        if (error_type != "status_code"):
+        # Raise Request HTTP error, when not using status_code or response url. This prevents false positive/negative results.
+        if (error_type == "message"):
             response.raise_for_status()
         if response.status_code:
             # Status code exists in response object

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -104,7 +104,11 @@ def get_response(request_future, error_type, social_network):
     error_context = "General Unknown Error"
     exception_text = None
     try:
+        # request_future
         response = request_future.result()
+        # Raise Request HTTP error, when not using status_code. This prevents false positive/negative results.
+        if (error_type != "status_code"):
+            response.raise_for_status()
         if response.status_code:
             # Status code exists in response object
             error_context = None
@@ -313,13 +317,13 @@ def sherlock(username, site_data, query_notify,
                                  proxies=proxies,
                                  allow_redirects=allow_redirects,
                                  timeout=timeout,
-                                 json=request_payload
+                                 data=request_payload
                                  )
             else:
                 future = request(url=url_probe, headers=headers,
                                  allow_redirects=allow_redirects,
                                  timeout=timeout,
-                                 json=request_payload
+                                 data=request_payload
                                  )
 
             # Store future in data for access later


### PR DESCRIPTION
- Added Instagram back.
It uses the 'create account' api which returns if a username is already taken.
A CSRF token is required in the request, but this can be any string (i.e. `0`, `hello`, `866f9af0-fb1d-4381-b8d0-f6addbe9af6b`). The Instagram website will generate a string fitting `[a-zA-Z0-9]{32}` before sending the request, so I've set a random matching string in data.json.

- Added Exception output to Notifyer. 
I wanted to be able to distinguish 429 exceptions from others. This can also help others to fix broken sites more quickly. 
By using the `--print-all` flag, you can see which sites generate errors that need to be fixed.

- Fixed bug for sending request_payload. 
The payload was not actually being processed, because the correct parameter name is data.

- Raise HTTP errors when status codes are not being used in the check, i.e. for error_type message. 
Instagram gives 429 responses that last 1 hour. Fix is changing your IP address or waiting. 
This response was not being caught. I added [request.raise_status_code()](https://docs.python-requests.org/en/latest/_modules/requests/models/#Response.raise_for_status) for error types that do not rely on the status code, so a 4-- or 5-- error code is correctly handled and can be show in the output with `--print-all`.
This cannot be used for the other error types, which might expect a 404 result when a username is not in use.
This change prevents false positives, because it will show the error and not a positive result when the message received doesn't match the reponse, because underlying was a server/http error.
