### PR TITLE
Adding support for upwork.com

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2072,6 +2072,14 @@
     "urlMain": "https://unsplash.com/",
     "username_claimed": "jenny"
   },
+  "Upwork": {
+    "errorMsg": "Something has gone wrong",
+    "errorType": "message",
+    "url": "https://www.upwork.com/freelancers/{}",
+    "urlMain": "https://www.upwork.com",
+    "username_claimed": "dhyeyad",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "VK": {
     "errorType": "response_url",
     "errorUrl": "https://www.quora.com/profile/{}",


### PR DESCRIPTION
Adding **upwork.com** to the list of websites in **data.json**
**URL pattern used**: `https://www.upwork.com/freelancers/{username}`
**Error message if not found**: `404: Page not found - Something has gone wrong and we cannot find the page you are looking for.`
**username_claimed**: _dhyeyad_
**username_unclaimed**: _noonewouldeverusethis7_