### PR TITLE
Add atcoder.jp

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -174,6 +174,13 @@
     "urlMain": "https://ask.fm/",
     "username_claimed": "blue"
   },
+  "AtCoder": {
+    "errorType": "status_code",
+    "url": "https://atcoder.jp/users/{}",
+    "urlMain": "https://atcoder.jp/",
+    "username_claimed": "tourist",
+    "username_unclaimed": "iuaefnuaenfoiaenfiaenfaeojnfiaejfnoaeifn"
+  },
   "Audiojungle": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z0-9_]+$",


### PR DESCRIPTION
Based in Japan, AtCoder is a competitive programming website that conducts online programming contests on a regular basis.