### PR TITLE
Codingninjas

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ $ git clone https://github.com/sherlock-project/sherlock.git
 # change the working directory to sherlock
 $ cd sherlock
 
+# Build a dedicated virtual environment 
+$ python -m venv env
+
+# Activate the virutal environment
+$ source env/bin/activate
+
 # install the requirements
 $ python3 -m pip install -r requirements.txt
 ```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -489,6 +489,12 @@
     "urlMain": "https://www.codewars.com",
     "username_claimed": "example"
   },
+  "Coding Ninjas": {
+    "errorType": "status_code",
+    "url": "https://www.codingninjas.com/studio/profile/{}",
+    "urlMain": "https://www.codingninjas.com/",
+    "username_claimed": "example"
+  },
   "Coinvote": {
     "errorType": "status_code",
     "url": "https://coinvote.cc/profile/{}",


### PR DESCRIPTION
- Added data for [https://www.codingninjas.com/](https://www.codingninjas.com/)
- :book:  Update installation documentation (based on what i faced on my Manjaro system) on running
```sh
python3 -m pip install -r requirements.txt
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try 'pacman -S
    python-xyz', where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Arch-packaged Python package,
    create a virtual environment using 'python -m venv path/to/venv'.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.
    
    If you wish to install a non-Arch packaged Python application,
    it may be easiest to use 'pipx install xyz', which will manage a
    virtual environment for you. Make sure you have python-pipx
    installed via pacman.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.