### PR TITLE
Update data.json to search Gravatar for deleted accounts JSON data.

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -913,6 +913,12 @@
     "urlMain": "http://en.gravatar.com/",
     "username_claimed": "blue"
   },
+    "Gravatar JSON data": {
+    "errorType": "status_code",
+    "url": "https://en.gravatar.com/{}.json",
+    "urlMain": "https://en.gravatar.com/",
+    "username_claimed": "blue"
+  },  
   "Gumroad": {
     "errorMsg": "Page not found (404) - Gumroad",
     "errorType": "message",


### PR DESCRIPTION
Even if a user deletes their account on Gravatar, adding the .json extension reveals the data of that account. 

See more on this here:
https://osintnewsletter.com/p/bypassing-a-gravatar-404-for-osint