### PR TITLE
Remove `.replit` file

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,0 @@
-language = "python3"
-run = ""


### PR DESCRIPTION
This replit file was added several years ago, back when replit allowed anybody to run code from a github repository, and it had poor support for auto-detecting projects. Now, replit can autodetect projects just fine, but replit only allows signed-up users run code, which makes this file significantly less useful and extraneous. I'm not sure why `run` is set to an empty string, that means that nothing will happen when a user clicks the `run` button.

This PR fixes that by removing the file, since it is extraneous and not useful.