### PR TITLE
Add pyarrow dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ torrequest>=0.1.0
 pandas>=1.0.0
 openpyxl<=3.0.10
 exrex>=0.11.0
+pyarrow>=15.0.0


### PR DESCRIPTION
Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0), (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries).