### PR TITLE
Added League of Legends

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1237,6 +1237,12 @@
     "urlMain": "https://lobste.rs/",
     "username_claimed": "jcs"
   },
+  "League of Legends": {
+    "errorType": "status_code",
+    "url": "https://lolprofile.net/summoner/world/{}",
+    "urlMain": "https://lolprofile.net/",
+    "username_claimed": "Faker"
+  },
   "LottieFiles": {
     "errorType": "status_code",
     "url": "https://lottiefiles.com/{}",


### PR DESCRIPTION
This is checked by LolProfile.Net. It is one of many sites which provide status to League of Legends since actually checking through riot requires registration of their API system