### PR TITLE
Remove wykop.pl duplicate and fix wrong names in removed_sites.md descriptions

### DIFF
--- a/removed_sites.md
+++ b/removed_sites.md
@@ -1851,7 +1851,7 @@ As of 2023.12.21, Lolchess returns false positives.
 ```
 
 ## Virgool
-As of 2023.12.21, Lolchess returns false positives.
+As of 2023.12.21, Virgool returns false positives.
 ```json
   "Virgool": {
     "errorMsg": "\u06f4\u06f0\u06f4",
@@ -1863,7 +1863,7 @@ As of 2023.12.21, Lolchess returns false positives.
 ```
 
 ## Whonix Forum
-As of 2023.12.21, Lolchess returns false positives.
+As of 2023.12.21, Whonix Forum returns false positives.
 ```json
   "Whonix Forum": {
     "errorType": "status_code",
@@ -1874,7 +1874,7 @@ As of 2023.12.21, Lolchess returns false positives.
 ```
 
 ## Ebio
-As of 2023.12.21, Lolchess returns false positives.
+As of 2023.12.21, Ebio returns false positives.
 ```json
   "ebio.gg": {
     "errorType": "status_code",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2652,13 +2652,6 @@
     "urlMain": "https://wiki.vg/",
     "username_claimed": "Auri"
   },
-  "wykop.pl": {
-    "errorType": "status_code",
-    "regexCheck": "[a-z0-9-_]{4,35}",
-    "url": "https://www.wykop.pl/ludzie/{}",
-    "urlMain": "https://wykop.pl",
-    "username_claimed": "janusz-nowak"
-  },
   "xHamster": {
     "errorType": "status_code",
     "isNSFW": true,

--- a/sites.md
+++ b/sites.md
@@ -1,4 +1,4 @@
-## List Of Supported Sites (396 Sites In Total!)
+## List Of Supported Sites (395 Sites In Total!)
 1. ![](https://www.google.com/s2/favicons?domain=https://2Dimensions.com/) [2Dimensions](https://2Dimensions.com/) 
 1. ![](https://www.google.com/s2/favicons?domain=http://forum.3dnews.ru/) [3dnews](http://forum.3dnews.ru/) 
 1. ![](https://www.google.com/s2/favicons?domain=https://www.7cups.com/) [7Cups](https://www.7cups.com/) 
@@ -392,6 +392,5 @@
 1. ![](https://www.google.com/s2/favicons?domain=https://www.toster.ru/) [toster](https://www.toster.ru/) 
 1. ![](https://www.google.com/s2/favicons?domain=https://uid.me/) [uid](https://uid.me/) 
 1. ![](https://www.google.com/s2/favicons?domain=https://wiki.vg/) [wiki.vg](https://wiki.vg/) 
-1. ![](https://www.google.com/s2/favicons?domain=https://wykop.pl) [wykop.pl](https://wykop.pl) 
 1. ![](https://www.google.com/s2/favicons?domain=https://xhamster.com) [xHamster](https://xhamster.com) **(NSFW)**
 1. ![](https://www.google.com/s2/favicons?domain=https://znanylekarz.pl) [znanylekarz.pl](https://znanylekarz.pl) 


### PR DESCRIPTION
- Removed the "wykop.pl" duplicate in data.json and in sites.md
- Fixed wrong names in 3 latest removed_sites.md descriptions


![obraz_2024-02-19_171910242](https://github.com/sherlock-project/sherlock/assets/96005164/b4440047-b7ac-4ddf-ad2a-adf4c0b890fc)
