### PR TITLE
Build Workflow Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install dependencies
+        run: pip install -r requirements.txt pyinstaller
+      - name: Build with pyinstaller
+        run: pyinstaller sherlock/__init__.py
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,8 @@ jobs:
         run: pip install -r requirements.txt pyinstaller
       - name: Build with pyinstaller
         run: pyinstaller sherlock/__init__.py
-      - name: Rename dist folder for artifact
-        run: mv dist ${{ matrix.os }}
       - name: Upload build
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ matrix.os }}
+          path: dist
+          name: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
           python-version: 3.12
       - name: Install dependencies
         run: pip install -r requirements.txt pyinstaller
+      - name: Remove __init__.py # It doesn't work with PyInstaller
+        run: rm sherlock/__init__.py
       - name: Build with pyinstaller
         run: pyinstaller sherlock/__init__.py
       - name: Upload build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Remove __init__.py # It doesn't work with PyInstaller
         run: rm sherlock/__init__.py
       - name: Build with pyinstaller
-        run: pyinstaller sherlock/__init__.py
+        run: pyinstaller sherlock/sherlock.py --onefile
       - name: Upload build
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,6 @@ jobs:
         run: pyinstaller sherlock/__init__.py
       - name: Upload build
         uses: actions/upload-artifact@v4
+        run: mv dist ${{ matrix.os }}
         with:
-          path: dist/*
+          path: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,9 @@ jobs:
         run: pip install -r requirements.txt pyinstaller
       - name: Build with pyinstaller
         run: pyinstaller sherlock/__init__.py
+      - name: Rename dist folder for artifact
+        run: mv dist ${{ matrix.os }}
       - name: Upload build
         uses: actions/upload-artifact@v4
-        run: mv dist ${{ matrix.os }}
         with:
           path: ${{ matrix.os }}


### PR DESCRIPTION
Since someone complained about the lack of an executable file I have added a GitHub Workflow, that automatically builds the source code using PyInstaller.
Because of the way the project is set up the script has to remove the __init__.py file during building, so that PyInstaller works properly.

The person that complained: https://www.reddit.com/r/github/comments/1at9br4/i_am_new_to_github_and_i_have_lots_to_say/