### PR TITLE
Update data.json to address false positives from CGtrader due to wrong errortype

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -321,8 +321,7 @@
     "username_claimed": "blue"
   },
   "CGTrader": {
-    "errorMsg": "3D models for CG digital design and artwork",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://www.cgtrader.com/{}",
     "urlMain": "https://www.cgtrader.com",
     "username_claimed": "blue"


### PR DESCRIPTION
Changed CGtrader errortype from "message" to "status_code" to reflect the changes on how CGtrader responds to unclaimed usernames.