### PR TITLE
Add exception handling for Tor option

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -200,7 +200,12 @@ def sherlock(
     # Create session based on request methodology
     if tor or unique_tor:
         # Requests using Tor obfuscation
-        underlying_request = TorRequest()
+        try:
+            underlying_request = TorRequest()
+        except OSError:
+            print("Tor is not available on your system!")
+            sys.exit(query_notify.finish())
+
         underlying_session = underlying_request.session
     else:
         # Normal requests

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -203,7 +203,7 @@ def sherlock(
         try:
             underlying_request = TorRequest()
         except OSError:
-            print("Tor is not available on your system!")
+            print("Tor not found in system path. Unable to continue.\n")
             sys.exit(query_notify.finish())
 
         underlying_session = underlying_request.session


### PR DESCRIPTION
Hi,
just a simple try/except to handle an **OS Error** when using --tor flag. 
If you want to reproduce, please execute the code bellow: 

`python3 sherlock user_name --print-all --tor --json sherlock/resources/data.json`

This enhancement prints a message to the console and sherlock exit in a fashion way instead of an OS technical error message.
I hope this will great for te project.

Thanks all.