### PR TITLE
Reduce false positives (those caused by WAFs and bot detection)

### DIFF
--- a/sherlock/notify.py
+++ b/sherlock/notify.py
@@ -245,8 +245,8 @@ class QueryNotifyPrint(QueryNotify):
                       Fore.RED + "?" +
                       Fore.WHITE + "]" +
                       Fore.GREEN + f" {self.result.site_name}:" +
-                      Fore.RED + f" Blocked by WAF" +
-                      Fore.YELLOW + " (proxy recommended)")
+                      Fore.RED + " Blocked by bot detection" +
+                      Fore.YELLOW + " (proxy may help)")
 
         else:
             # It should be impossible to ever get here...

--- a/sherlock/notify.py
+++ b/sherlock/notify.py
@@ -224,7 +224,7 @@ class QueryNotifyPrint(QueryNotify):
         elif result.status == QueryStatus.UNKNOWN:
             if self.print_all:
                 print(Style.BRIGHT + Fore.WHITE + "[" +
-                      Fore.RED + "?" +
+                      Fore.RED + "-" +
                       Fore.WHITE + "]" +
                       Fore.GREEN + f" {self.result.site_name}:" +
                       Fore.RED + f" {self.result.context}" +
@@ -242,7 +242,7 @@ class QueryNotifyPrint(QueryNotify):
         elif result.status == QueryStatus.WAF:
             if self.print_all:
                 print(Style.BRIGHT + Fore.WHITE + "[" +
-                      Fore.RED + "?" +
+                      Fore.RED + "-" +
                       Fore.WHITE + "]" +
                       Fore.GREEN + f" {self.result.site_name}:" +
                       Fore.RED + " Blocked by bot detection" +

--- a/sherlock/notify.py
+++ b/sherlock/notify.py
@@ -224,7 +224,7 @@ class QueryNotifyPrint(QueryNotify):
         elif result.status == QueryStatus.UNKNOWN:
             if self.print_all:
                 print(Style.BRIGHT + Fore.WHITE + "[" +
-                      Fore.RED + "-" +
+                      Fore.RED + "?" +
                       Fore.WHITE + "]" +
                       Fore.GREEN + f" {self.result.site_name}:" +
                       Fore.RED + f" {self.result.context}" +
@@ -238,6 +238,15 @@ class QueryNotifyPrint(QueryNotify):
                       Fore.WHITE + "]" +
                       Fore.GREEN + f" {self.result.site_name}:" +
                       Fore.YELLOW + f" {msg}")
+                
+        elif result.status == QueryStatus.WAF:
+            if self.print_all:
+                print(Style.BRIGHT + Fore.WHITE + "[" +
+                      Fore.RED + "?" +
+                      Fore.WHITE + "]" +
+                      Fore.GREEN + f" {self.result.site_name}:" +
+                      Fore.RED + f" Blocked by WAF" +
+                      Fore.YELLOW + " (proxy recommended)")
 
         else:
             # It should be impossible to ever get here...

--- a/sherlock/result.py
+++ b/sherlock/result.py
@@ -14,6 +14,7 @@ class QueryStatus(Enum):
     AVAILABLE = "Available" # Username Not Detected
     UNKNOWN   = "Unknown"   # Error Occurred While Trying To Detect Username
     ILLEGAL   = "Illegal"   # Username Not Allowable For This Site
+    WAF       = "WAF"       # Request blocked by WAF (i.e. Cloudflare)
 
     def __str__(self):
         """Convert Object To String.

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -378,8 +378,18 @@ def sherlock(
         query_status = QueryStatus.UNKNOWN
         error_context = None
 
+        # As WAFs advance and evolve, they will occasionally block Sherlock and lead to false positives
+        # and negatives. Fingerprints should be added here to filter results that fail to bypass WAFs.
+        # Fingerprints should be highly targetted. Comment at the end of each fingerprint to indicate target and date.
+        WAFHitMsgs = [
+            '.loading-spinner{visibility:hidden}body.no-js .challenge-running{display:none}body.dark{background-color:#222;color:#d9d9d9}body.dark a{color:#fff}body.dark a:hover{color:#ee730a;text-decoration:underline}body.dark .lds-ring div{border-color:#999 transparent transparent}body.dark .font-red{color:#b20f03}body.dark .big-button,body.dark .pow-button{background-color:#4693ff;color:#1d1d1d}body.dark #challenge-success-text{background-image:url(data:image/svg+xml;base64,' # 2024-04-08 Cloudflare
+        ]
+
         if error_text is not None:
             error_context = error_text
+
+        elif any(hitMsg in r.text for hitMsg in WAFHitMsgs):
+            query_status = QueryStatus.WAF
 
         elif error_type == "message":
             # error_flag True denotes no error found in the HTML

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -382,7 +382,8 @@ def sherlock(
         # and negatives. Fingerprints should be added here to filter results that fail to bypass WAFs.
         # Fingerprints should be highly targetted. Comment at the end of each fingerprint to indicate target and date.
         WAFHitMsgs = [
-            '.loading-spinner{visibility:hidden}body.no-js .challenge-running{display:none}body.dark{background-color:#222;color:#d9d9d9}body.dark a{color:#fff}body.dark a:hover{color:#ee730a;text-decoration:underline}body.dark .lds-ring div{border-color:#999 transparent transparent}body.dark .font-red{color:#b20f03}body.dark .big-button,body.dark .pow-button{background-color:#4693ff;color:#1d1d1d}body.dark #challenge-success-text{background-image:url(data:image/svg+xml;base64,' # 2024-04-08 Cloudflare
+            '.loading-spinner{visibility:hidden}body.no-js .challenge-running{display:none}body.dark{background-color:#222;color:#d9d9d9}body.dark a{color:#fff}body.dark a:hover{color:#ee730a;text-decoration:underline}body.dark .lds-ring div{border-color:#999 transparent transparent}body.dark .font-red{color:#b20f03}body.dark .big-button,body.dark .pow-button{background-color:#4693ff;color:#1d1d1d}body.dark #challenge-success-text{background-image:url(data:image/svg+xml;base64,', # 2024-04-08 Cloudflare
+            '{return l.onPageView}}),Object.defineProperty(r,"perimeterxIdentifiers",{enumerable:' # 2024-04-09 PerimeterX / Human Security
         ]
 
         if error_text is not None:


### PR DESCRIPTION
Discussions are taking place elsewhere about false positives and bot detection circumvention.

The Cloudflare bypass, **even if implemented**, will fail occasionally as Cloudflare updates their detection methods. Until the maintainer of whatever bypass mechanism is able to update _their_ tool, Sherlock users will randomly see false positives.

In either case, this PR significantly reduces the number of false positives that appear as more and more sites switch to using WAFs that function like Cloudflare. If a known WAF block page is detected, the QueryStatus of WAF is applied rather than running the standard (and now useless) error checks. Results with the status of WAF are only displayed with `--print-all` and bear a status message indicating such.

The error message also indicates that a proxy (such as FlareSolverr) may help.

```
[-] Myspace: Not Found!
[-] NICommunityForum: Not Found!
[-] NationStates Nation: Blocked by bot detection (proxy may help)
[-] NationStates Region: Blocked by bot detection (proxy may help)
[-] Naver: Not Found!
[-] Needrom: Not Found!
```

Paired with #2068, the number of false positives presented to the user drop **significantly**.

Fixes #1878 (as the use of a proxy may allow Fiverr to function as desired, and it won't display false positives otherwise)

**Update:** This PR now also includes a fingerprint for PerimeterX -- the "press and hold" captcha service sometimes _also_ used by sites like Fiverr