### PR TITLE
Add modifiers with support for inverse validation (inc. some now-supported targets)

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -306,6 +306,15 @@
     "urlMain": "https://community.brave.com/",
     "username_claimed": "blue"
   },
+  "BugCrowd": {
+    "errorMsg": "researcher profile on Bugcrowd, a platform and team of experts",
+    "errorType": "message",
+    "options": "invert",
+    "regexCheck": "[a-zA-Z0-9]{3,15}",
+    "url": "https://bugcrowd.com/{}",
+    "urlMain": "https://bugcrowd.com/",
+    "username_claimed": "mert"
+  },
   "BuyMeACoffee": {
     "errorType": "status_code",
     "regexCheck": "[a-zA-Z0-9]{3,15}",

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -310,7 +310,6 @@
     "errorMsg": "researcher profile on Bugcrowd, a platform and team of experts",
     "errorType": "message",
     "options": "invert",
-    "regexCheck": "[a-zA-Z0-9]{3,15}",
     "url": "https://bugcrowd.com/{}",
     "urlMain": "https://bugcrowd.com/",
     "username_claimed": "mert"

--- a/sherlock/result.py
+++ b/sherlock/result.py
@@ -4,6 +4,21 @@ This module defines various objects for recording the results of queries.
 """
 from enum import Enum
 
+class QueryOptions(Enum):
+    """Query option and modifier enumeration
+    """
+    INVERT    = "invert"    # Invert the QueryStatus if CLAIMED or AVAILABLE (no effect on others)
+
+    def __str__(self):
+        """Convert Object To String.
+
+        Keyword Arguments:
+        self                   -- This object.
+
+        Return Value:
+        Nicely formatted string to get information about this object.
+        """
+        return self.value
 
 class QueryStatus(Enum):
     """Query Status Enumeration.

--- a/sites.md
+++ b/sites.md
@@ -1,4 +1,4 @@
-## List Of Supported Sites (395 Sites In Total!)
+## List Of Supported Sites (396 Sites In Total!)
 1. ![](https://www.google.com/s2/favicons?domain=https://2Dimensions.com/) [2Dimensions](https://2Dimensions.com/) 
 1. ![](https://www.google.com/s2/favicons?domain=http://forum.3dnews.ru/) [3dnews](http://forum.3dnews.ru/) 
 1. ![](https://www.google.com/s2/favicons?domain=https://www.7cups.com/) [7Cups](https://www.7cups.com/) 
@@ -44,6 +44,7 @@
 1. ![](https://www.google.com/s2/favicons?domain=https://pt.bongacams.com) [BongaCams](https://pt.bongacams.com) **(NSFW)**
 1. ![](https://www.google.com/s2/favicons?domain=https://www.bookcrossing.com/) [Bookcrossing](https://www.bookcrossing.com/) 
 1. ![](https://www.google.com/s2/favicons?domain=https://community.brave.com/) [BraveCommunity](https://community.brave.com/) 
+1. ![](https://www.google.com/s2/favicons?domain=https://bugcrowd.com/) [BugCrowd](https://bugcrowd.com/) 
 1. ![](https://www.google.com/s2/favicons?domain=https://www.buymeacoffee.com/) [BuyMeACoffee](https://www.buymeacoffee.com/) 
 1. ![](https://www.google.com/s2/favicons?domain=https://buzzfeed.com/) [BuzzFeed](https://buzzfeed.com/) 
 1. ![](https://www.google.com/s2/favicons?domain=https://www.cgtrader.com) [CGTrader](https://www.cgtrader.com) 


### PR DESCRIPTION
Discretionary feature. I believe it could make matching easier for some sites, and open the door for more features down the line.

Adds support for the key `options` in data.json, with acceptable values found in QueryOptions.
Currently supports QueryOptions.INVERT str `invert`, which when present will flip the values of QueryStatus.CLAIMED and QueryStatus.AVAILABLE after processing.

This simplifies matching for some targets where there may be many invalid results but only one valid result. For instance, with BugCrowd, there are several technically-invalid results that may be returned that would each need to be accounted for. Inverting the result would allow you to check for a message that is _wanted_ rather than _avoided_.

Diffs for result.py and sherlock.py reflect the changes necessary for options support and the invert option itself. Diffs for the other files (data.json, sites.md) only reflect some now-more-easily-supported targets as PoC, even if they could be hacked together without.

Up to y'all!