### PR TITLE
Add ruff to pull request workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,13 +34,12 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install ruff flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint With flake8
+    - name: Lint With Ruff
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-
+        ruff check . --output-format=github --select=E9,F63,F7,F82
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Sherlock Site Detect Tests


### PR DESCRIPTION
Adds ruff to the pull request workflow.

Ruff was added to the tests job in the `main` workflow in https://github.com/sherlock-project/sherlock/pull/1759, but not to the `pull_request` workflow. Might be beneficial to keep them consistent to avoid any surprises when merging.  