### PR TITLE
Use lite version of archive.org, change error message.

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -142,9 +142,9 @@
     "username_claimed": "test"
   },
   "Archive.org": {
-    "errorMsg": "cannot find account",
+    "errorMsg": "could not fetch an account with user item identifier",
     "errorType": "message",
-    "url": "https://archive.org/details/@{}",
+    "url": "https://archive.org/details/@{}?noscript=true",
     "urlMain": "https://archive.org",
     "username_claimed": "blue"
   },

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -142,9 +142,10 @@
     "username_claimed": "test"
   },
   "Archive.org": {
+    "urlProbe":" https://archive.org/details/@{}?noscript=true",
     "errorMsg": "could not fetch an account with user item identifier",
     "errorType": "message",
-    "url": "https://archive.org/details/@{}?noscript=true",
+    "url": "https://archive.org/details/@{}",
     "urlMain": "https://archive.org",
     "username_claimed": "blue"
   },


### PR DESCRIPTION
Archive.org detects the use of old browsers, and redirects them to a "lite" version of archive.org. For some reason, the requests module is also redirected. This PR fixes this issue.