### PR TITLE
Skip content filter for explicitly chosen targets

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -575,7 +575,7 @@ def main():
         action="append",
         metavar="SITE_NAME",
         dest="site_list",
-        default=None,
+        default=[],
         help="Limit analysis to just the listed sites. Add multiple options to specify more than one site.",
     )
     parser.add_argument(
@@ -725,13 +725,13 @@ def main():
         sys.exit(1)
 
     if not args.nsfw:
-        sites.remove_nsfw_sites()
+        sites.remove_nsfw_sites(do_not_remove=args.site_list)
 
     # Create original dictionary from SitesInformation() object.
     # Eventually, the rest of the code will be updated to use the new object
     # directly, but this will glue the two pieces together.
     site_data_all = {site.name: site.information for site in sites}
-    if args.site_list is None:
+    if args.site_list == []:
         # Not desired to look at a sub-set of sites
         site_data = site_data_all
     else:

--- a/sherlock/sites.py
+++ b/sherlock/sites.py
@@ -175,7 +175,7 @@ class SitesInformation:
 
         return
 
-    def remove_nsfw_sites(self):
+    def remove_nsfw_sites(self, do_not_remove: list[str] = []):
         """
         Remove NSFW sites from the sites, if isNSFW flag is true for site
 
@@ -186,8 +186,9 @@ class SitesInformation:
         None
         """
         sites = {}
+        do_not_remove = [site.casefold() for site in do_not_remove]
         for site in self.sites:
-            if self.sites[site].is_nsfw:
+            if self.sites[site].is_nsfw and site.casefold() not in do_not_remove:
                 continue
             sites[site] = self.sites[site]  
         self.sites =  sites

--- a/sherlock/sites.py
+++ b/sherlock/sites.py
@@ -175,7 +175,7 @@ class SitesInformation:
 
         return
 
-    def remove_nsfw_sites(self, do_not_remove: list[str] = []):
+    def remove_nsfw_sites(self, do_not_remove: list = []):
         """
         Remove NSFW sites from the sites, if isNSFW flag is true for site
 


### PR DESCRIPTION
Targets specified via --site will no longer be excluded when --nsfw is not set, even if flagged as nsfw. If the target was specifically listed by the user, it's probably because they want that target.

Fixes sherlock-project/sherlock#2103