### PR TITLE
Fix parser regression

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "data.schema.json",
   "1337x": {
     "errorMsg": [
       "<title>Error something went wrong.</title>",

--- a/sherlock/sites.py
+++ b/sherlock/sites.py
@@ -177,6 +177,8 @@ class SitesInformation:
                 raise ValueError(
                     f"Problem parsing json contents at '{data_file_path}':  Missing attribute {error}."
                 )
+            except TypeError as error:
+                print(f"Encountered TypeError parsing json contents for target '{site_name}' at {data_file_path}\nSkipping target.\n")
 
         return
 


### PR DESCRIPTION
Added catch for TypeErrors that may be caused due to the future addition of keys (if any ever get added), allowing Sherlock to continue past those errors. 

Removed $schema to accomodate older versions of the parser. This key will be added back in __after__ sherlock-project/sherlock#2088 (or other version incrementing change) is merged, giving users time to update.

___

@matheusfelipeog or @sdushantha : 

Merge is recommended as a hotfix.

PR addresses [comments made here](https://github.com/sherlock-project/sherlock/issues/1989#issuecomment-2099484854). Apparently the old way SitesInformation processed the data.json wasn't too friendly to the new key, so we're removing it for a now.

___

Fixes #2108 