### PR TITLE
Bump openpyxl version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ requests-futures>=1.0.0
 stem>=1.8.0 
 torrequest>=0.1.0
 pandas>=1.0.0
-openpyxl<=3.0.10
+openpyxl<=3.1.2
 exrex>=0.11.0


### PR DESCRIPTION
Asked about removal of openpyxl in #2114.
While openpyxl<=3.0.10 isn't available when packaging, it turns out that 3.1.2 is. Bumping the version would save quite a bit of time and work and avoid having to repackage openpyxl itself or contact the maintainers.

Not sure if there's anything else using this, but `--xlsx` seems to work just as expected. No issues there. I think it's fine.

Any breaking change that I may be missing with the new version?