### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+### REPOSITORY
+/.github/CODEOWNERS @sdushantha
+
+### PACKAGING
+# Changes made to these items without code owner approval may negatively
+# impact packaging pipelines. Code owners may need time to verify or adapt.
+/pyproject.toml @ppfeister @sdushantha
+/setup.cfg @ppfeister @sdushantha

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,5 @@
 # impact packaging pipelines. Code owners may need time to verify or adapt.
 /pyproject.toml @ppfeister @sdushantha
 /setup.cfg @ppfeister @sdushantha
+/setup.py @ppfeister
+/*.spec @ppfeister


### PR DESCRIPTION
We're beginning to put together proper packaging for Sherlock.

@sdushantha is packaging for `{insert discussed repo}`. Changes to the pyproject or setup.cfg files can screw with builds. As the person maintaining that package, it'd be worth having their sign off.

While he works on that deployment, I'm in the process of packaging for `{insert an official repo}`. My packaging, even if I don't end up downstream of his ^ package, will still rely on those two files. Changes to them without knowing could impact _those_ workflows and builds.

How do we feel about enforcing code owner approvals on master for these situations? Note that only one code owner approval is ever necessary for protected files, not everyone all at once.

Less about "don't touch!" more about making sure people can validate against pipelines and that builds work and such before anything breaks. CodeOwners should auto-ping whoever is tagged when an owned-file is pr-ed against.