### PR TITLE
Changed errorType to message for EyeEm

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -717,7 +717,8 @@
     "username_claimed": "jonasjacobsson"
   },
   "EyeEm": {
-    "errorType": "status_code",
+    "errorMsg": "Whoops! We can&#x27;t find the page you&#x27;re looking for...",
+    "errorType": "message",
     "url": "https://www.eyeem.com/u/{}",
     "urlMain": "https://www.eyeem.com/",
     "username_claimed": "blue"


### PR DESCRIPTION
This PR aims to solve the false positive issue for the EyeEm website as mention in https://github.com/sherlock-project/sherlock/issues/2126

**Debugging the issue:**
I glanced through the code and the issue for EyeEm seems to be in the detection algorithm. The errorType is set to status_code, however a simple curl request to an unavailable username in EyeEm shows the response code as 200.

**Potential solution**
All unavailable usernames are accompanied by the error message:

"Whoops! We can't find the page you're looking for..."

If you wish I can make a PR for making this change and fixing it for this website. I understand that error message is the least reliable detection mechanism hence if you have better ideas I am all ears for it.

**Validating the fix**
Here is a screenshot verifying that EyeEm does not show up when the username is not available
![image](https://github.com/sherlock-project/sherlock/assets/60848863/79bfc1b8-9704-4724-80ea-7813d26a7af8)
