### PR TITLE
Adjusted to build package in own directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,11 @@ classifiers = [
 
 [tool.setuptools.dynamic]
 dependencies = { file = [ "requirements.txt" ] }
-version = { attr = "sherlock.__version__" }
+version = { attr = "sherlock.sherlock.__version__" }
 
-[tool.setuptools]
-package-dir = {"" = "sherlock"}
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["sherlock", "sherlock.resources"]
 
 [tool.setuptools.package-data]
 "*" = ["*.json"]


### PR DESCRIPTION
Hi,
I'm a maintainer for sherlock on debian/kali/Ubuntu.

A bug was recently reported in Sherlock:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1071007

Where sherlok was installing his modules in the packages rais directory,
which is not a good practice and was still causing conflict with other people
package because of the __ini__.py file

After changing the pyprojetc.toml file, Sherlock began to be installed directly in its own directory.


Hope this helps!