### PR TITLE
Update EyeEm test method

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -717,8 +717,7 @@
     "username_claimed": "jonasjacobsson"
   },
   "EyeEm": {
-    "errorMsg": "Whoops! We can&#x27;t find the page you&#x27;re looking for...",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://www.eyeem.com/u/{}",
     "urlMain": "https://www.eyeem.com/",
     "username_claimed": "blue"


### PR DESCRIPTION
EyeEm seems to have begun properly serving 404s again

This reverts commit 945a364970852a477f0796a5569627c12a7bb470.
