### PR TITLE
Removed uneeded info from --version output

### DIFF
--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -508,12 +508,6 @@ def handler(signal_received, frame):
 
 
 def main():
-    version_string = (
-        f"%(prog)s {__version__}\n"
-        + f"{requests.__description__}:  {requests.__version__}\n"
-        + f"Python:  {platform.python_version()}"
-    )
-
     parser = ArgumentParser(
         formatter_class=RawDescriptionHelpFormatter,
         description=f"{module_name} (Version {__version__})",
@@ -521,7 +515,7 @@ def main():
     parser.add_argument(
         "--version",
         action="version",
-        version=version_string,
+        version=f"Sherlock v{__version__}",
         help="Display version information and dependencies.",
     )
     parser.add_argument(


### PR DESCRIPTION
Personally I'd rather want to see the version of Sherlock I am running and not the version of Python and `requests`. Thoughts?

**Before**
```
$ sherlock --version
sherlock 0.14.4
Python HTTP for Humans.:  2.32.3
Python:  3.12.3
```

**After**
```
$ sherlock --version            
Sherlock v0.14.4
```