### PR TITLE
Update install docs

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -39,6 +39,15 @@ pipx install sherlock-project
 
 ### Build live package from source (useful for contributors)
 
+> [!Note]
+> With the switch to Poetry, Sherlock no longer requires a `requirements.txt` file. Dependencies are now specified within the `pyproject.toml` file.
+> 
+> If the legacy `requirements.txt` file is still desired, it can be dynamically generated:
+> ```bash
+> # Append `--with dev` or `--only dev` to include dev dependencies
+> poetry export --without-hashes -f requirements.txt --output requirements.txt
+> ```
+
 Building an editable (or live) package links the entry point to your current directory, rather than to the standard install location. This is often useful when working with the code base, as changes are reflected immediately without reinstallation.
 
 Note that the version number will be 0.0.0 for pipx local builds unless manually changed in the pyproject file (it will prompt the user for an update).

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 | - | - | - |
 | PyPI | `pipx install sherlock-project` | `pip` may be used in place of `pipx` |
 | Docker | `docker pull sherlock/sherlock` | |
-| Debian family | `apt install sherlock` | Kali, Parrot, BlackArch, Testing, Sid |
+| Debian family | `apt install sherlock` | Kali, Parrot, Deb Testing, Deb Sid |
 | Homebrew | `brew install sherlock` | |
 
 PyPI and DockerHub images are mainaintenced by the Sherlock Project. Others are community supported.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,8 @@
 | - | - | - |
 | PyPI | `pipx install sherlock-project` | `pip` may be used in place of `pipx` |
 | Docker | `docker pull sherlock/sherlock` | |
-| Debian family | `apt install sherlock` | Kali, Parrot, Deb Testing, Deb Sid |
+| Debian family | `apt install sherlock` | Kali, Parrot, Debian Testing and Sid |
+| BlackArch | `pacman -S sherlock` |  |
 | Homebrew | `brew install sherlock` | |
 
 PyPI and DockerHub images are mainaintenced by the Sherlock Project. Others are community supported.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,8 +30,11 @@
 | | Command | Notes |
 | - | - | - |
 | PyPI | `pipx install sherlock-project` | `pip` may be used in place of `pipx` |
-| Homebrew | `brew install sherlock` | Community supported |
 | Docker | `docker pull sherlock/sherlock` | |
+| Debian family | `apt install sherlock` | Kali, Parrot, BlackArch, Testing, Sid |
+| Homebrew | `brew install sherlock` | |
+
+PyPI and DockerHub images are mainaintenced by the Sherlock Project. Others are community supported.
 
 ### Alternative guides and methods
 


### PR DESCRIPTION
Adds requirement.txt not required note, as discussed in #2156.
Adjusts install options in Readme, including the addition of Kali/Parrot/BlackArch.
