### PR TITLE
[issue-2164] added '--tag' flag functionality

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2794,5 +2794,12 @@
     "url": "https://www.znanylekarz.pl/{}",
     "urlMain": "https://znanylekarz.pl",
     "username_claimed": "janusz-nowak"
+  },
+  "LeagueOfLegends": {
+    "errorType": "status_code",
+    "url": "https://www.leagueofgraphs.com/summoner/vn/{}-<>",
+    "isTagRequired": true,
+    "urlMain": "https://www.leagueofgraphs.com",
+    "username_claimed": "Sophie#1911"
   }
 }

--- a/sherlock/resources/data.schema.json
+++ b/sherlock/resources/data.schema.json
@@ -18,6 +18,7 @@
                 "username_claimed": { "type": "string" },
                 "regexCheck": { "type": "string" },
                 "isNSFW": { "type": "boolean" },
+                "isTagRequired": { "type": "boolean"},
                 "headers": { "type": "object" },
                 "request_payload": { "type": "object" },
                 "__comment__": {

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -137,13 +137,19 @@ def get_response(request_future, error_type, social_network):
     return response, error_context, exception_text
 
 
-def interpolate_string(input_object, username):
+def interpolate_string(input_object, username, has_tag):
     if isinstance(input_object, str):
+        if has_tag and '#' in username:
+            username, tag = username.split('#')
+            input_object = input_object.replace("<>", tag)
+        elif has_tag:
+            print("Flag --tag was set, but the tag wasn't provided or was provided in an incorrect format. Please use "
+                  "'username#tag'")
         return input_object.replace("{}", username)
     elif isinstance(input_object, dict):
-        return {k: interpolate_string(v, username) for k, v in input_object.items()}
+        return {k: interpolate_string(v, username, has_tag) for k, v in input_object.items()}
     elif isinstance(input_object, list):
-        return [interpolate_string(i, username) for i in input_object]
+        return [interpolate_string(i, username, has_tag) for i in input_object]
     return input_object
 
 
@@ -168,6 +174,7 @@ def sherlock(
     username,
     site_data,
     query_notify: QueryNotify,
+    has_tag: bool = False,
     tor: bool = False,
     unique_tor: bool = False,
     proxy=None,
@@ -254,7 +261,7 @@ def sherlock(
             headers.update(net_info["headers"])
 
         # URL of user on site (if it exists)
-        url = interpolate_string(net_info["url"], username.replace(' ', '%20'))
+        url = interpolate_string(net_info["url"], username.replace(' ', '%20'), has_tag)
 
         # Don't make request if username is invalid for the site
         regex_check = net_info.get("regexCheck")
@@ -288,7 +295,7 @@ def sherlock(
                     raise RuntimeError(f"Unsupported request_method for {url}")
 
             if request_payload is not None:
-                request_payload = interpolate_string(request_payload, username)
+                request_payload = interpolate_string(request_payload, username, has_tag)
 
             if url_probe is None:
                 # Probe URL is normal one seen by people out on the web.
@@ -296,7 +303,7 @@ def sherlock(
             else:
                 # There is a special URL for probing existence separate
                 # from where the user profile normally can be found.
-                url_probe = interpolate_string(url_probe, username)
+                url_probe = interpolate_string(url_probe, username, has_tag)
 
             if request is None:
                 if net_info["errorType"] == "status_code":
@@ -666,6 +673,15 @@ def main():
         help="Include checking of NSFW sites from default list.",
     )
 
+    parser.add_argument(
+        "--tag",
+        action="store_true",
+        dest="tag",
+        default=False,
+        help="Search for a user name including a user tag (e.g. League of Legends, Valorant). "
+             "Username has to be entered in format 'username#tag'."
+    )
+
     args = parser.parse_args()
 
     # If the user presses CTRL-C, exit gracefully without throwing errors
@@ -737,6 +753,11 @@ def main():
     if not args.nsfw:
         sites.remove_nsfw_sites(do_not_remove=args.site_list)
 
+    if args.tag:
+        sites.filter_websites_based_on_tag(args.site_list, tag_required=True)
+    else:
+        sites.filter_websites_based_on_tag(args.site_list, tag_required=False)
+
     # Create original dictionary from SitesInformation() object.
     # Eventually, the rest of the code will be updated to use the new object
     # directly, but this will glue the two pieces together.
@@ -760,7 +781,10 @@ def main():
                 site_missing.append(f"'{site}'")
 
         if site_missing:
-            print(f"Error: Desired sites not found: {', '.join(site_missing)}.")
+            if args.tag:
+                print(f"Error: '--tag' flag was set, but {', '.join(site_missing)} usernames don't have tags.")
+            else:
+                print(f"Error: Desired sites not found: {', '.join(site_missing)}.")
 
         if not site_data:
             sys.exit(1)
@@ -783,6 +807,7 @@ def main():
             username,
             site_data,
             query_notify,
+            args.tag,
             tor=args.tor,
             unique_tor=args.unique_tor,
             proxy=args.proxy,


### PR DESCRIPTION
## Created '--tag' flag which allows to search for usernames with a tag.
Example usage: "sherlock sophie#1911 --tag"

Tested for all exceptions and errors I could think of.

The way it works now is if you enter "sherlock sophie --tag" an error is thrown that tells user to add a tag if the tag flag is used.
In a successful search, websites are filtered using a new property "isTagRequired", and only websites that have it set to True will remain in the list (isTagRequired is False by default).

If the flag '--site' is used with a website that has isTagRequired set to True but '--tag' flag wasn't set, a specific is thrown.
If the flag '--site' is used with a website that has isTagRequired set to False but '--tag' flag was used, another specific error is thrown.

Please let me know if you would like me to change the logic in any way, it would be easy to change it at this point.