### PR TITLE
Introduction of --tag optional argument for tag handling 

### DIFF
--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -1322,6 +1322,78 @@
     "urlMain": "https://www.livejournal.com/",
     "username_claimed": "blue"
   },
+  "LoLKr": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "url": "https://www.leagueofgraphs.com/summoner/kr/{}-#",
+    "urlMain": "https://www.leagueofgraphs.com/",
+    "username_claimed": "NS+Callme-KR1",
+    "tag_required": true
+  },
+  "LoLEune": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "url": "https://www.leagueofgraphs.com/summoner/eune/{}-#",
+    "urlMain": "https://www.leagueofgraphs.com/",
+    "username_claimed": "NotPurple-EUNE",
+    "tag_required": true
+  },
+  "LoLEuw": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "url": "https://www.leagueofgraphs.com/summoner/euw/{}-#",
+    "urlMain": "https://www.leagueofgraphs.com/",
+    "username_claimed": "KC+NEXT+ADKING-EUW",
+    "tag_required": true
+  },
+  "LoLNa": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "url": "https://www.leagueofgraphs.com/summoner/na/{}-#",
+    "urlMain": "https://www.leagueofgraphs.com/",
+    "username_claimed": "Sheiden-0001",
+    "tag_required": true
+  },
+  "LoLVn": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "url": "https://www.leagueofgraphs.com/summoner/vn/{}-#",
+    "urlMain": "https://www.leagueofgraphs.com/",
+    "username_claimed": "Shirou-2K5",
+    "tag_required": true
+  },
+  "LoLBr": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "url": "https://www.leagueofgraphs.com/summoner/br/{}-#",
+    "urlMain": "https://www.leagueofgraphs.com/",
+    "username_claimed": "frosty-KR3",
+    "tag_required": true
+  },
+  "LoLTr": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "url": "https://www.leagueofgraphs.com/summoner/tr/{}-#",
+    "urlMain": "https://www.leagueofgraphs.com/",
+    "username_claimed": "Hide+on+bush-MBM0",
+    "tag_required": true
+  },
+  "LoLJp": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "url": "https://www.leagueofgraphs.com/summoner/jp/{}-#",
+    "urlMain": "https://www.leagueofgraphs.com/",
+    "username_claimed": "Ninja+of+Ninjas-JP1",
+    "tag_required": true
+  },
+  "LoLOce": {
+    "errorMsg": "Not Found",
+    "errorType": "message",
+    "url": "https://www.leagueofgraphs.com/summoner/oce/{}-#",
+    "urlMain": "https://www.leagueofgraphs.com/",
+    "username_claimed": "Stop+here-OCE",
+    "tag_required": true
+  },
   "Lobsters": {
     "errorType": "status_code",
     "regexCheck": "[A-Za-z0-9][A-Za-z0-9_-]{0,24}",

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -146,6 +146,9 @@ def interpolate_string(input_object, username):
         return [interpolate_string(i, username) for i in input_object]
     return input_object
 
+def interpolate_tag(input_object, tag):
+    return input_object.replace("#", tag)
+
 
 def check_for_parameter(username):
     """checks if {?} exists in the username
@@ -168,6 +171,7 @@ def sherlock(
     username,
     site_data,
     query_notify: QueryNotify,
+    tag="",
     tor: bool = False,
     unique_tor: bool = False,
     proxy=None,
@@ -184,6 +188,8 @@ def sherlock(
     query_notify           -- Object with base type of QueryNotify().
                               This will be used to notify the caller about
                               query results.
+    tag                    -- String indicating accompanying to the username tag,
+                              empty string if --tag not given
     tor                    -- Boolean indicating whether to use a tor circuit for the requests.
     unique_tor             -- Boolean indicating whether to use a new tor circuit for each request.
     proxy                  -- String indicating the proxy URL
@@ -256,6 +262,9 @@ def sherlock(
         # URL of user on site (if it exists)
         url = interpolate_string(net_info["url"], username.replace(' ', '%20'))
 
+        if net_info.get("tag_required") and tag is not None:
+            url = interpolate_tag(url, tag)
+
         # Don't make request if username is invalid for the site
         regex_check = net_info.get("regexCheck")
         if regex_check and re.search(regex_check, username) is None:
@@ -297,6 +306,8 @@ def sherlock(
                 # There is a special URL for probing existence separate
                 # from where the user profile normally can be found.
                 url_probe = interpolate_string(url_probe, username)
+                if net_info.get("tag_required"):
+                    url = interpolate_tag(url_probe, tag)
 
             if request is None:
                 if net_info["errorType"] == "status_code":
@@ -666,6 +677,13 @@ def main():
         help="Include checking of NSFW sites from default list.",
     )
 
+    parser.add_argument(
+        "--tag",
+        action="store",
+        dest="tag",
+        help="Add a tag to the username",
+    )
+
     args = parser.parse_args()
 
     # If the user presses CTRL-C, exit gracefully without throwing errors
@@ -783,6 +801,7 @@ def main():
             username,
             site_data,
             query_notify,
+            tag = args.tag,
             tor=args.tor,
             unique_tor=args.unique_tor,
             proxy=args.proxy,

--- a/sherlock/sites.py
+++ b/sherlock/sites.py
@@ -9,7 +9,7 @@ import secrets
 
 class SiteInformation:
     def __init__(self, name, url_home, url_username_format, username_claimed,
-                information, is_nsfw, username_unclaimed=secrets.token_urlsafe(10)):
+                information, is_nsfw, tag_required, username_unclaimed=secrets.token_urlsafe(10)):
         """Create Site Information Object.
 
         Contains information about a specific website.
@@ -42,6 +42,8 @@ class SiteInformation:
                                          but it is only recorded in this
                                          object for future use.
         is_nsfw                -- Boolean indicating if site is Not Safe For Work.
+        tag_required           -- Boolean indicating if site's usernames are 
+                                  accompanied with tags
 
         Return Value:
         Nothing.
@@ -55,6 +57,7 @@ class SiteInformation:
         self.username_unclaimed = secrets.token_urlsafe(32)
         self.information = information
         self.is_nsfw  = is_nsfw
+        self.tag_required = tag_required
 
         return
 
@@ -167,7 +170,8 @@ class SitesInformation:
                                     site_data[site_name]["url"],
                                     site_data[site_name]["username_claimed"],
                                     site_data[site_name],
-                                    site_data[site_name].get("isNSFW",False)
+                                    site_data[site_name].get("isNSFW",False),
+                                    site_data[site_name].get("tag_required",False)
 
                                     )
             except KeyError as error:


### PR DESCRIPTION
As mentioned in #2164, this pull request aims to introduce functionality in order to allow Sherlock to search through sites that other than a username need also a tag in order to identify an account. The solution proposed is an optional argument --tag which would allow the user to input that tag, a boolean tag_required and a # in the url of those sites. Given the argument tag sherlock will return all sites where tag_required is false/non existent replacing only the {} with the username, and those in which it is true it would also replace the # with the given tag. 

If #2169 is merged, due to similarities this should be closed.