### PR TITLE
Remove ETSY and EUW from websites and add one.lt

### DIFF
--- a/docs/removed-sites.md
+++ b/docs/removed-sites.md
@@ -618,7 +618,7 @@ removed
 
 ## Coderwall
 As of 2020-07-06, Coderwall returns false positives when checking for an username which contains a period.
-I have tried to find out what Coderwall's criteria is for a valid username, but unfortunately I have not been able to 
+I have tried to find out what Coderwall's criteria is for a valid username, but unfortunately I have not been able to
 find it and because of this, the best thing we can do now is to remove it.
 ```json
   "Coderwall": {
@@ -666,15 +666,15 @@ As of 2020-07-24, Zomato seems to be unstable. Majority of the time, Zomato take
 ## Mixer
 As of 2020-07-22, the Mixer service has closed down.
 ```json
-  "mixer.com": { 
-    "errorType": "status_code", 
-    "rank": 1544, 
-    "url": "https://mixer.com/{}", 
-    "urlMain": "https://mixer.com/", 
-    "urlProbe": "https://mixer.com/api/v1/channels/{}", 
-    "username_claimed": "blue", 
-    "username_unclaimed": "noonewouldeverusethis7" 
-  }, 
+  "mixer.com": {
+    "errorType": "status_code",
+    "rank": 1544,
+    "url": "https://mixer.com/{}",
+    "urlMain": "https://mixer.com/",
+    "urlProbe": "https://mixer.com/api/v1/channels/{}",
+    "username_claimed": "blue",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
 ```
 
 
@@ -1300,7 +1300,7 @@ As og 2022-05-01, Smashcast is down
 
 ## Countable
 
-As og 2022-05-01, Countable returns false positives 
+As og 2022-05-01, Countable returns false positives
 ```json
   "Countable": {
     "errorType": "status_code",
@@ -1866,5 +1866,28 @@ __2024-04-24 :__ BCF seems to have gone defunct. Uncertain.
     "url": "https://bitcoinforum.com/profile/{}",
     "urlMain": "https://bitcoinforum.com",
     "username_claimed": "bitcoinforum.com"
+  }
+```
+
+## Euw
+__2024-06-09 :__ errorMsg detection doesn't work anymore, because the error message is included in HTTP request body, even in successful search
+```json
+"Euw": {
+    "errorMsg": "This summoner is not registered at OP.GG. Please check spelling.",
+    "errorType": "message",
+    "url": "https://euw.op.gg/summoner/userName={}",
+    "urlMain": "https://euw.op.gg/",
+    "username_claimed": "blue"
+  }
+```
+
+## Etsy
+__2024-06-10 :__ Http request returns 403 forbidden, and tries to verify the connection, so it doesn't work anymore
+```json
+"Etsy": {
+    "errorType": "status_code",
+    "url": "https://www.etsy.com/shop/{}",
+    "urlMain": "https://www.etsy.com/",
+    "username_claimed": "JennyKrafts"
   }
 ```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -597,7 +597,7 @@
     "url": "https://cyberdefenders.org/p/{}",
     "urlMain": "https://cyberdefenders.org/",
     "username_claimed": "mlohn"
-  },
+},
   "DEV Community": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
@@ -696,19 +696,6 @@
     "url": "https://www.erome.com/{}",
     "urlMain": "https://www.erome.com/",
     "username_claimed": "bob"
-  },
-  "Etsy": {
-    "errorType": "status_code",
-    "url": "https://www.etsy.com/shop/{}",
-    "urlMain": "https://www.etsy.com/",
-    "username_claimed": "JennyKrafts"
-  },
-  "Euw": {
-    "errorMsg": "This summoner is not registered at OP.GG. Please check spelling.",
-    "errorType": "message",
-    "url": "https://euw.op.gg/summoner/userName={}",
-    "urlMain": "https://euw.op.gg/",
-    "username_claimed": "blue"
   },
   "Exposure": {
     "errorType": "status_code",
@@ -2794,5 +2781,11 @@
     "url": "https://www.znanylekarz.pl/{}",
     "urlMain": "https://znanylekarz.pl",
     "username_claimed": "janusz-nowak"
+  },
+  "One.lt": {
+    "errorType": "status_code",
+    "url": "https://www.one.lt/{}",
+    "urlMain": "https://www.one.lt",
+    "username_claimed": "lietuvis"
   }
 }


### PR DESCRIPTION
Remove ETSY because HTTP request returns 403 Forbidden in all cases  and EUW  because user-tag is needed to search from websites and add one.lt