### PR TITLE
Fixed tests due to broken sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ lib/
 pyvenv.cfg
 poetry.lock
 
+# Regression Testing
+.coverage
+.tox/
+
 # Editor Configurations
 .vscode/
 .idea/

--- a/docs/removed-sites.md
+++ b/docs/removed-sites.md
@@ -1868,3 +1868,17 @@ __2024-04-24 :__ BCF seems to have gone defunct. Uncertain.
     "username_claimed": "bitcoinforum.com"
   }
 ```
+
+## Penetestit
+
+As of 24.06.2024, Pentestit returns a 403. This is most likely due to a new site structures
+
+```json
+  "labpentestit": {
+    "errorType": "response_url",
+    "errorUrl": "https://lab.pentestit.ru/{}",
+    "url": "https://lab.pentestit.ru/profile/{}",
+    "urlMain": "https://lab.pentestit.ru/",
+    "username_claimed": "CSV"
+  }
+```

--- a/sherlock/resources/data.json
+++ b/sherlock/resources/data.json
@@ -2579,13 +2579,6 @@
     "urlMain": "https://www.kwork.ru/",
     "username_claimed": "blue"
   },
-  "labpentestit": {
-    "errorType": "response_url",
-    "errorUrl": "https://lab.pentestit.ru/{}",
-    "url": "https://lab.pentestit.ru/profile/{}",
-    "urlMain": "https://lab.pentestit.ru/",
-    "username_claimed": "CSV"
-  },
   "last.fm": {
     "errorType": "status_code",
     "url": "https://last.fm/user/{}",

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -45,7 +45,7 @@ class TestLiveTargets:
     # Known positives should only use sites trusted to be reliable and unchanging
     @pytest.mark.parametrize('site,username',[
         ('BodyBuilding', 'blue'),
-        ('kofi', 'yeahkenny'),
+        ('devRant', 'blue'),
     ])
     def test_known_positives_via_response_url(self, sites_info, site, username):
         assert simple_query(sites_info=sites_info, site=site, username=username) is QueryStatus.CLAIMED

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -45,7 +45,7 @@ class TestLiveTargets:
     # Known positives should only use sites trusted to be reliable and unchanging
     @pytest.mark.parametrize('site,username',[
         ('BodyBuilding', 'blue'),
-        ('labpentestit', 'CSV'),
+        ('kofi', 'yeahkenny'),
     ])
     def test_known_positives_via_response_url(self, sites_info, site, username):
         assert simple_query(sites_info=sites_info, site=site, username=username) is QueryStatus.CLAIMED


### PR DESCRIPTION
Pentestit was being used in the test to test sites using response URL. The checking on this site no longer works. It has therefore been removed and the Kofi is not being used instead in the tests