### PR TITLE
Downgrade tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 requires =
-    tox >= 4
+    tox >= 3
 envlist =
     lint
     py313


### PR DESCRIPTION
CentOS Stream seems to lack tox >= 4, so 3 is needed for proper support.
Version can be bumped safely once the CentOS package for tox is updated.
