### PR TITLE
Make torrequest optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ torrequest = "^0.1.0"
 pandas = ">=1.0.0,<3.0.0"
 openpyxl = "^3.0.10"
 
+[tool.poetry.extras]
+tor = ["torrequest"]
+
 [tool.poetry.group.dev.dependencies]
 jsonschema = "^4.0.0"
 

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -210,7 +210,7 @@ def sherlock(
         except ImportError:
             print("Important!")
             print("> Dependencies for --tor and --unique-tor are now optional, and WILL BE DEPRECATED in a future release of Sherlock.")
-            print("> If you've installed Sherlock via pipx, you can install the dependency with `pipx install sherlock-project[tor]`.")
+            print("> If you've installed Sherlock via pipx, you can install the dependency with `pip install sherlock-project[tor]`.")
             print("> Other packages should refer to their packager maintainer's documentation, or install separately with `pipx install torrequest`.\n")
             sys.exit(query_notify.finish())
 

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -210,8 +210,8 @@ def sherlock(
         except ImportError:
             print("Important!")
             print("> Dependencies for --tor and --unique-tor are now optional, and WILL BE DEPRECATED in a future release of Sherlock.")
-            print("> If you've installed Sherlock via pipx, you can install the dependency with `pip install sherlock-project[tor]`.")
-            print("> Other packages should refer to their packager maintainer's documentation, or install separately with `pipx install torrequest`.\n")
+            print("> If you've installed Sherlock via pip, you can install with the dependency with `pip install sherlock-project[tor]`.")
+            print("> Other packages should refer to their documentation, or install separately with `pip install torrequest`.\n")
             sys.exit(query_notify.finish())
 
         # Requests using Tor obfuscation

--- a/sherlock/sherlock.py
+++ b/sherlock/sherlock.py
@@ -30,7 +30,6 @@ from .__init__ import ( # noqa: E402
 )
 
 from requests_futures.sessions import FuturesSession    # noqa: E402
-from torrequest import TorRequest                       # noqa: E402
 from sherlock.result import QueryStatus                 # noqa: E402
 from sherlock.result import QueryResult                 # noqa: E402
 from sherlock.notify import QueryNotify                 # noqa: E402
@@ -206,6 +205,15 @@ def sherlock(
     query_notify.start(username)
     # Create session based on request methodology
     if tor or unique_tor:
+        try:
+            from torrequest import TorRequest  # noqa: E402
+        except ImportError:
+            print("Important!")
+            print("> Dependencies for --tor and --unique-tor are now optional, and WILL BE DEPRECATED in a future release of Sherlock.")
+            print("> If you've installed Sherlock via pipx, you can install the dependency with `pipx install sherlock-project[tor]`.")
+            print("> Other packages should refer to their packager maintainer's documentation, or install separately with `pipx install torrequest`.\n")
+            sys.exit(query_notify.finish())
+
         # Requests using Tor obfuscation
         try:
             underlying_request = TorRequest()


### PR DESCRIPTION
Closes #2130 

Sample interaction without dependency:

```text
$ sherlock --tor test
Using Tor to make requests
Warning: some websites might refuse connecting over Tor, so note that using this option might increase connection errors.
[*] Checking username test on:

Important!
> Dependencies for --tor and --unique-tor are now optional, and WILL BE DEPRECATED in a future release of Sherlock.
> If you've installed Sherlock via pipx, you can install the dependency with `pipx install sherlock-project[tor]`.
> Other packages should refer to their packager maintainer's documentation, or install separately with `pipx install torrequest`.

[*] Search completed with 0 results
```