### PR TITLE
Add HuggingFace Profile Detection to Sherlock

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1082,6 +1082,13 @@
     "urlMain": "https://hudsonrock.com",
     "username_claimed": "testadmin"
   },
+  "HuggingFace": {
+    "errorMsg": "status_code",
+    "errorType": "message",
+    "url": "https://huggingface.co/{}",
+    "urlMain": "https://huggingface.co",
+    "username_claimed": "Pasanlaksitha"
+  },
   "ICQ": {
     "errorType": "status_code",
     "url": "https://icq.im/{}/en",


### PR DESCRIPTION
This pull request adds support for detecting usernames on HuggingFace, a popular platform for machine learning and AI communities. The following changes have been made:

- Added HuggingFace site entry: Included HuggingFace in the data.json file under /sherlock_project/resources/.
- URL structure: Profiles can be checked using https://huggingface.co/{username}.
- Status code detection: The site returns a 200 status code if the username exists and 404 if it does not.
