### PR TITLE
remove ICQ.com

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1082,12 +1082,6 @@
     "urlMain": "https://hudsonrock.com",
     "username_claimed": "testadmin"
   },
-  "ICQ": {
-    "errorType": "status_code",
-    "url": "https://icq.im/{}/en",
-    "urlMain": "https://icq.com/",
-    "username_claimed": "Micheal"
-  },
   "IFTTT": {
     "errorType": "status_code",
     "regexCheck": "^[A-Za-z0-9]{3,35}$",


### PR DESCRIPTION
ICQ.com returns false positive. There is no fix for it since the site was shut down on June 26, 2024