### PR TITLE
Remove not needed `apt-get update` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@
 FROM python:3.12-slim-bullseye as build
 WORKDIR /sherlock
 
-RUN apt-get update \
-  pip3 install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir --upgrade pip
 
 FROM python:3.12-slim-bullseye
 WORKDIR /sherlock


### PR DESCRIPTION
There's no need to wait and waste the time and bandwidth to wait for `apt-get update` for `pip3 install` ;)