### PR TITLE
Comply with PEP 561

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -24,6 +24,7 @@ import re
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from json import loads as json_loads
 from time import monotonic
+from typing import Optional
 
 import requests
 from requests_futures.sessions import FuturesSession

--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -167,14 +167,14 @@ def multiple_usernames(username):
 
 
 def sherlock(
-    username,
-    site_data,
+    username: str,
+    site_data: dict,
     query_notify: QueryNotify,
     tor: bool = False,
     unique_tor: bool = False,
     dump_response: bool = False,
-    proxy=None,
-    timeout=60,
+    proxy: str = None,
+    timeout: int = 60,
 ):
     """Run Sherlock Analysis.
 
@@ -474,7 +474,7 @@ def sherlock(
             raise ValueError(
                 f"Unknown Error Type '{error_type}' for " f"site '{social_network}'"
             )
-        
+
         if dump_response:
             print("+++++++++++++++++++++")
             print(f"TARGET NAME   : {social_network}")

--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -173,7 +173,7 @@ def sherlock(
     tor: bool = False,
     unique_tor: bool = False,
     dump_response: bool = False,
-    proxy: str = None,
+    proxy: Optional[str] = None,
     timeout: int = 60,
 ):
     """Run Sherlock Analysis.


### PR DESCRIPTION
Add type hints for exposed `sherlock` function, add `py.typed` to comply with PEP 561 and allow for detection by mypy for static type checking.