### PR TITLE
Adding DigitalSpy

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -628,6 +628,13 @@
     "urlMain": "https://deviantart.com",
     "username_claimed": "blue"
   },
+  "DigitalSpy": {
+    "errorMsg": "The page you were looking for could not be found.",
+    "errorType": "message",
+    "url": "https://forums.digitalspy.com/profile/{}",
+    "urlMain": "https://forums.digitalspy.com/",
+    "username_claimed": "papita69"
+  },
   "Discogs": {
     "errorType": "status_code",
     "url": "https://www.discogs.com/user/{}",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -629,12 +629,13 @@
     "username_claimed": "blue"
   },
   "DigitalSpy": {
-    "errorMsg": "The page you were looking for could not be found.",
-    "errorType": "message",
-    "url": "https://forums.digitalspy.com/profile/{}",
-    "urlMain": "https://forums.digitalspy.com/",
-    "username_claimed": "papita69"
-  },
+      "errorMsg": "The page you were looking for could not be found.",
+      "errorType": "message",
+      "url": "https://forums.digitalspy.com/profile/{}",
+      "urlMain": "https://forums.digitalspy.com/",
+      "username_claimed": "blue",
+      "regexCheck": "^\\w{3,20}$"
+    },
   "Discogs": {
     "errorType": "status_code",
     "url": "https://www.discogs.com/user/{}",


### PR DESCRIPTION
added support for the Digital Spy Forum. Digital Spy is a UK-based entertainment and media news website, known for covering television, movies, and celebrity news, as well as offering discussion forums for users.