### PR TITLE
Added Wakatime Support to Sherlock

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2232,6 +2232,13 @@
     "urlMain": "https://discourse.wicg.io/",
     "username_claimed": "stefano"
   },
+  "Wakatime": {
+    "errorType": "status_code",
+    "regexCheck": "^[@a-zA-Z0-9._-]{1,}$",
+    "url": "https://wakatime.com/@{username}",
+    "urlMain": "https://wakatime.com/",
+    "username_claimed": "Vikranth3140"
+  },
   "Warrior Forum": {
     "errorType": "status_code",
     "url": "https://www.warriorforum.com/members/{}.html",


### PR DESCRIPTION
This PR closes #2319 by adding support for detecting usernames on Wakatime. The following changes were made:
- Added Wakatime entry in `data.json` using the URL pattern `https://wakatime.com/@{username}`.
- Implemented `status_code` detection to check for 404 errors for non-existent usernames.
- Validated usernames using regex to allow letters, numbers, underscores, hyphens, and periods.

This enhances Sherlock's coverage by supporting Wakatime user profiles.

Let me know if any enhancements are needed :)