### PR TITLE
Add support for velog

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2186,7 +2186,7 @@
   },
   "Velog": {
     "errorType": "status_code",
-    "url": "https://velog.io/{}/posts",
+    "url": "https://velog.io/@{}/posts",
     "urlMain": "https://velog.io/",
     "username_claimed": "nuung"
   },

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2188,7 +2188,7 @@
     "errorType": "status_code",
     "url": "https://velog.io/@{}/posts",
     "urlMain": "https://velog.io/",
-    "username_claimed": "nuung"
+    "username_claimed": "qlgks1"
   },
   "Velomania": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430.",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2184,6 +2184,12 @@
     "urlMain": "https://vsco.co/",
     "username_claimed": "blue"
   },
+  "Velog": {
+    "errorType": "status_code",
+    "url": "https://velog.io/{}/posts",
+    "urlMain": "https://velog.io/",
+    "username_claimed": "nuung"
+  },
   "Velomania": {
     "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430.",
     "errorType": "message",


### PR DESCRIPTION
> This PR addresses issue #2322 by adding support for detecting usernames on Velog.

1. I did `tox` testing by local after editing `data.json` file
2. and I ran `python -m sherlock_project qlgks1 nonewould_everuserthis7 --no-txt --site velog --local --print-all`

<img width="1097" alt="스크린샷 2024-10-09 오후 6 52 15" src="https://github.com/user-attachments/assets/d32bc791-dbb2-470c-a98d-853dc6854d44">
