### PR TITLE
Change the errorMsg for Librarything

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1289,7 +1289,7 @@
     "username_claimed": "blue"
   },
   "LibraryThing": {
-    "errorMsg": "Catalog your books online",
+    "errorMsg": "Error: This user doesn't exist",
     "errorType": "message",
     "url": "https://www.librarything.com/profile/{}",
     "urlMain": "https://www.librarything.com/",


### PR DESCRIPTION
Librarything which uses errorType as message has error message as "Catalog your books online" but the error Message of Librarything has changed as "Error: This user doesn't exist".
![Screenshot 2024-10-11 115054](https://github.com/user-attachments/assets/34f2673f-c257-4593-8f70-960e6948796d)
So the above PR made the following changes to change the error message of the data.json of Librarything