### PR TITLE
Fixed Twitter(X)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2142,7 +2142,7 @@
     "regexCheck": "^[a-zA-Z0-9_]{1,15}$",
     "url": "https://x.com/{}",
     "urlMain": "https://x.com/",
-    "urlProbe": "https://nitter.net/{}",
+    "urlProbe": "https://nitter.privacydev.net/{}",
     "username_claimed": "blue"
   },
   "Typeracer": {


### PR DESCRIPTION
Fixes #2317 

The Sherlock Project has always relied on [`nitter`](https://github.com/zedeus/nitter) for checking the availability of an username as it's impossible to use Twitter without JavaScript enabled & hence, can't be scraped easily.

Unfortunately **[nitter.net](https://nitter.net)** is down, which was being utilized for a long time & most of the alternate instances are behind a captcha or a browser integrity check page. Hence, I looked for an instance which can be accessed directly & updated the `urlProbe`.

List of instances can be found here - https://github.com/zedeus/nitter/wiki/Instances#public

![image](https://github.com/user-attachments/assets/2f615f9c-1fa4-45ab-b964-21cadbb96ec8)


