### PR TITLE
fix: add additional error message check for archive.org downtime

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -159,7 +159,8 @@
     "__comment__": "'The resource could not be found' relates to archive downtime",
     "errorMsg": [
       "could not fetch an account with user item identifier",
-      "The resource could not be found"
+      "The resource could not be found",
+      "Other Internet Archive services are temporarily offline"
     ],
     "errorType": "message",
     "url": "https://archive.org/details/@{}",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -160,7 +160,7 @@
     "errorMsg": [
       "could not fetch an account with user item identifier",
       "The resource could not be found",
-      "Other Internet Archive services are temporarily offline"
+      "Internet Archive services are temporarily offline"
     ],
     "errorType": "message",
     "url": "https://archive.org/details/@{}",


### PR DESCRIPTION
This pull request addresses the issue where Sherlock consistently returns a false positive for `archive.org` due to the site being temporarily down and returning a `503` (Service Temporarily Unavailable) status code. The site also displays a specific message indicating the downtime.

**Changes:**
- Added an additional error message check for `archive.org` in `sherlock/sherlock_project/resources/data.json` to verify if the response contains the string "Other Internet Archive services are temporarily offline."

This change will help prevent false positives for `archive.org` by ensuring that Sherlock correctly identifies the downtime message and treats it as an invalid response.

Please review the changes and let me know if any further modifications are needed.

Fixes #2338 