### PR TITLE
Add "Package version" field to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -27,7 +27,7 @@ body:
         Knowing the version of the package you are using can help us diagnose your issue more quickly.
         You can find the version by running `sherlock --version`.
     validations:
-      required: false
+      required: true
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -19,6 +19,15 @@ body:
         - Other (indicate below)
     validations:
       required: true
+  - type: input
+    id: package-version
+    attributes:
+      label: Package version
+      description: |
+        Knowing the version of the package you are using can help us diagnose your issue more quickly.
+        You can find the version by running `sherlock --version`.
+    validations:
+      required: false
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
Adds a **required** "Package version" input field to the issue templates. This field has been added only to the "bug report" issue template, as it is the only template where the package version information would be useful. If you believe it should be included in all issue templates or that the field should not be required, please let me know, and I will make the necessary changes.

Here is a screenshot of the updated template:
![image](https://github.com/user-attachments/assets/35505561-905b-472c-b838-b182b01ebcd2)

As always, please feel free to provide feedback or request any changes if necessary.

---
Closes #2353