### PR TITLE
8tracks.com: fixed the errorType from message to status_code

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -31,8 +31,7 @@
     "username_claimed": "blue"
   },
   "8tracks": {
-    "errorType": "message",
-    "errorMsg": "\"available\":true",
+    "errorType": "status_code",
     "headers": {
       "Accept-Language": "en-US,en;q=0.5"
     },


### PR DESCRIPTION
I fixed the 8tracks link from the issue #2363 The response code is 403 but the data.json expects an error message. 