### PR TITLE
Update aniworld.to's error message to title tag

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -112,7 +112,7 @@
     "username_claimed": "blue"
   },
   "AniWorld": {
-    "errorMsg": "Dieses Profil ist nicht verf\u00fcgbar",
+    "errorMsg": "<title>Profil | AniWorld.to - Animes gratis legal online ansehen</title>",
     "errorType": "message",
     "url": "https://aniworld.to/user/profil/{}",
     "urlMain": "https://aniworld.to/",


### PR DESCRIPTION
`Aniworld.to`'s old error message `"Dieses Profil ist nicht verf\u00fcgbar"` is not found in the response body; instead, `<title>Profil | AniWorld.to - Animes gratis legal online ansehen</title>` is found for **non-existing** profiles. Existing profiles have the title `<title>USERNAME Profil | AniWorld.to - Animes gratis legal online ansehen</title>`

I have updated the error message to reflect this.