### PR TITLE
Add support for omg.lol

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2719,6 +2719,14 @@
     "urlMain": "https://www.npmjs.com/",
     "username_claimed": "kennethsweezy"
   },
+  "omg.lol": {
+    "errorMsg": "\"available\": true",
+    "errorType": "message",
+    "url": "https://{}.omg.lol",
+    "urlMain": "https://home.omg.lol",
+    "urlProbe": "https://api.omg.lol/address/{}/availability",
+    "username_claimed": "adam"
+  },
   "opennet": {
     "errorMsg": "\u0418\u043c\u044f \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e",
     "errorType": "message",


### PR DESCRIPTION
Tested via the following command:

```sh
❯ ~/.local/bin/sherlock adam account-that-doesnt-exist --local --site omg.lol --print-all
[*] Checking username adam on:

[+] omg.lol: https://adam.omg.lol

[*] Checking username account-that-doesnt-exist on:

[-] omg.lol: Not Found!

[*] Search completed with 1 results
```

API documentation is available at: https://api.omg.lol/#noauth-get-address-retrieve-address-availability

The `adam` account is owned by the owner of the service, so it should be safe as the claimed username.

I just discovered this project today. Let me know if I need to do anything else.