### PR TITLE
Fix Strava false positives

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2009,8 +2009,7 @@
     "username_claimed": "blue"
   },
   "Strava": {
-    "errorMsg": "Strava | Running, Cycling &amp; Hiking App - Train, Track &amp; Share",
-    "errorType": "message",
+    "errorType": "status_code",
     "regexCheck": "^[^.]*?$",
     "url": "https://www.strava.com/athletes/{}",
     "urlMain": "https://www.strava.com/",


### PR DESCRIPTION
This is one of the websites mentioned in #2374. After some experimentation, I discovered that Strava can now use a `status_code`.

Prior to my changes:
```sh
❯ ~/.local/bin/sherlock --local --site Strava blue this-username-doesnt-exist
[*] Checking username blue on:

[+] Strava: https://www.strava.com/athletes/blue

[*] Checking username this-username-doesnt-exist on:

[+] Strava: https://www.strava.com/athletes/this-username-doesnt-exist

[*] Search completed with 2 results
```

With my changes:

```sh
❯ ~/.local/bin/sherlock --local --site Strava blue this-username-doesnt-exist
[*] Checking username blue on:

[+] Strava: https://www.strava.com/athletes/blue

[*] Checking username this-username-doesnt-exist on:


[*] Search completed with 1 results
```