### PR TITLE
Remove ask.fm + fix instagram  middleware

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1126,7 +1126,7 @@
     "errorType": "status_code",
     "url": "https://instagram.com/{}",
     "urlMain": "https://instagram.com/",
-    "urlProbe": "https://www.picuki.com/profile/{}",
+    "urlProbe": "https://imginn.com/{}",
     "username_claimed": "instagram"
   },
   "Instructables": {

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -166,14 +166,6 @@
     "urlMain": "https://ask.fedoraproject.org/",
     "username_claimed": "red"
   },
-  "AskFM": {
-    "errorMsg": "Well, apparently not anymore.",
-    "errorType": "message",
-    "regexCheck": "^[a-zA-Z0-9_]{3,40}$",
-    "url": "https://ask.fm/{}",
-    "urlMain": "https://ask.fm/",
-    "username_claimed": "blue"
-  },
   "Atcoder": {
     "errorType": "status_code",
     "url": "https://atcoder.jp/users/{}",


### PR DESCRIPTION
ASKfm was officially shutdown 1 December 2024 due to an announcement made by their administrators.