### PR TITLE
Add support for Pronouns.page (#2418)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1627,6 +1627,12 @@
     "urlMain": "http://promodj.com/",
     "username_claimed": "blue"
   },
+  "Pronouns.page": {
+    "errorType": "status_code",
+    "url": "https://en.pronouns.page/@{}",
+    "urlMain": "https://en.pronouns.page/",
+    "username_claimed": "andrea"
+  },
   "PyPi": {
     "errorType": "status_code",
     "url": "https://pypi.org/user/{}",


### PR DESCRIPTION
This PR adds support for [pronouns.page](https://en.pronouns.page/) to Sherlock.