### PR TITLE
Add 10 more websites to manage, clean JSON file

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -781,6 +781,13 @@
     "urlMain": "https://fosstodon.org/",
     "username_claimed": "blue"
   },
+  "Framapiaf": {
+    "errorType": "status_code",
+    "regexCheck": "^[a-zA-Z0-9_]{1,30}$",
+    "url": "https://framapiaf.org/@{}",
+    "urlMain": "https://framapiaf.org",
+    "username_claimed": "pylapp"
+  },  
   "Freelance.habr": {
     "errorMsg": "<div class=\"icon_user_locked\"></div>",
     "errorType": "message",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1299,6 +1299,12 @@
     "urlMain": "https://linktr.ee/",
     "username_claimed": "anne"
   },
+  "LinuxFR.org": {
+    "errorType": "status_code",
+    "url": "https://linuxfr.org/users/{}",
+    "urlMain": "https://linuxfr.org/",
+    "username_claimed": "pylapp"
+  },
   "Listed": {
     "errorType": "response_url",
     "errorUrl": "https://listed.to/@{}",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1582,7 +1582,7 @@
     "username_claimed": "blue"
   },
   "PayPal.me": {
-    "errorMsg": "We can't find this profile",
+    "errorMsg": "We can’t find this profile",
     "errorType": "message",
     "url": "https://www.paypal.com/paypalme/{}",
     "urlMain": "https://www.paypal.com/",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1554,6 +1554,13 @@
     "urlMain": "https://www.patreon.com/",
     "username_claimed": "blue"
   },
+  "PayPal.me": {
+    "errorMsg": "We can't find this profile",
+    "errorType": "message",
+    "url": "https://www.paypal.com/paypalme/{}",
+    "urlMain": "https://www.paypal.com/",
+    "username_claimed": "pylapp"
+  },  
   "PentesterLab": {
     "errorType": "status_code",
     "regexCheck": "^[\\w]{4,30}$",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1878,6 +1878,12 @@
     "urlMain": "https://soylentnews.org",
     "username_claimed": "adam"
   },
+  "SpeakerDeck": {
+    "errorType": "status_code",
+    "url": "https://speakerdeck.com/{}",
+    "urlMain": "https://speakerdeck.com/",
+    "username_claimed": "pylapp"
+  },
   "Speedrun.com": {
     "errorType": "status_code",
     "url": "https://speedrun.com/users/{}",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2736,6 +2736,12 @@
     "urlMain": "https://uid.me/",
     "username_claimed": "blue"
   },
+  "write.as": {
+    "errorType": "status_code",
+    "url": "https://write.as/{}",
+    "urlMain": "https://write.as",
+    "username_claimed": "pylapp"
+  },  
   "xHamster": {
     "errorType": "status_code",
     "isNSFW": true,

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -602,7 +602,7 @@
       "urlMain": "https://forums.digitalspy.com/",
       "username_claimed": "blue",
       "regexCheck": "^\\w{3,20}$"
-    },
+  },
   "Discogs": {
     "errorType": "status_code",
     "url": "https://www.discogs.com/user/{}",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1595,6 +1595,12 @@
     "urlMain": "https://www.pinkbike.com/",
     "username_claimed": "blue"
   },
+  "pixelfed.social": {
+    "errorType": "status_code",
+    "url": "https://pixelfed.social/{}/",
+    "urlMain": "https://pixelfed.social",
+    "username_claimed": "pylapp"
+  },
   "PlayStore": {
     "errorType": "status_code",
     "url": "https://play.google.com/store/apps/developer?id={}",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1540,6 +1540,13 @@
     "urlMain": "https://ourdjtalk.com/",
     "username_claimed": "steve"
   },
+  "Outgress": {
+    "errorMsg": "Outgress - Error",
+    "errorType": "message",
+    "url": "https://outgress.com/agents/{}",
+    "urlMain": "https://outgress.com/",
+    "username_claimed": "pylapp"
+  },  
   "PCGamer": {
     "errorMsg": "The specified member cannot be found. Please enter a member's entire name.",
     "errorType": "message",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1513,6 +1513,13 @@
     "urlMain": "https://nyaa.si/",
     "username_claimed": "blue"
   },
+  "Open Collective": {
+    "errorMsg": "Oops! Page not found",
+    "errorType": "message",
+    "url": "https://opencollective.com/{}",
+    "urlMain": "https://opencollective.com/",
+    "username_claimed": "pylapp"
+  },
   "OpenStreetMap": {
     "errorType": "status_code",
     "regexCheck": "^[^.]*?$",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -257,6 +257,13 @@
     "urlMain": "https://www.blogger.com/",
     "username_claimed": "blue"
   },
+  "Bluesky": {
+    "errorType": "status_code",
+    "url": "https://bsky.app/profile/{}.bsky.social",
+    "urlProbe": "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor={}.bsky.social",
+    "urlMain": "https://bsky.app/",
+    "username_claimed": "mcuban"
+  },  
   "BoardGameGeek": {
     "errorType": "message",
     "regexCheck": "^[a-zA-Z0-9_]*$",
@@ -2742,12 +2749,5 @@
     "url": "https://www.znanylekarz.pl/{}",
     "urlMain": "https://znanylekarz.pl",
     "username_claimed": "janusz-nowak"
-  },
-  "Bluesky": {
-    "errorType": "status_code",
-    "url": "https://bsky.app/profile/{}.bsky.social",
-    "urlProbe": "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor={}.bsky.social",
-    "urlMain": "https://bsky.app/",
-    "username_claimed": "mcuban"
   }
 }

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1339,6 +1339,13 @@
     "urlMain": "https://forums.mmorpg.com/",
     "username_claimed": "goku"
   },
+  "Mamot": {
+    "errorType": "status_code",
+    "regexCheck": "^[a-zA-Z0-9_]{1,30}$",
+    "url": "https://mamot.fr/@{}",
+    "urlMain": "https://mamot.fr/",
+    "username_claimed": "anciensEnssat"
+  },
   "Medium": {
     "errorMsg": "<body",
     "errorType": "message",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1641,6 +1641,13 @@
     "urlMain": "https://www.producthunt.com/",
     "username_claimed": "jenny"
   },
+  "programming.dev": {
+    "errorMsg": "Error!",
+    "errorType": "message",
+    "url": "https://programming.dev/u/{}",
+    "urlMain": "https://programming.dev",
+    "username_claimed": "pylapp"
+  },  
   "PromoDJ": {
     "errorType": "status_code",
     "url": "http://promodj.com/{}",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1271,7 +1271,6 @@
   },
   "LinkedIn": {
     "errorType": "status_code",
-
     "regexCheck": "^[a-zA-Z0-9]{3,100}$",
     "request_method": "GET",
     "url": "https://linkedin.com/in/{}",


### PR DESCRIPTION
This pull request brings new websites to manage for *sherlock*.

Here is the curated list of new websites, tested with my pseudonym or accounts I managed and debuggued with *curl* to ensure definitions are usable:
- framapiaf.org (Mastodon instance) (58760cb1e5fc79449f2c91695bbd7cc8824f59e8) #2421 
- speakerdeck.com (381ddc5208918c803c5b63cbb65ce6af44ba315d) #2429 
- write.as (WriteFreely instance) (fc937690505854c5714329040c257ab75028db51) #2422 
- PayPal.Me service (c9b4d92524afbb7a991238e1eead2797d18eabdf) #2428 
- programming.dev (Lemmy instance) (8621cd46ff963b2aa4437d3485abc3a9ec0be6c4) #2423
- mamot.fr (Mastodon instance) (41318758539f35f995d1327f73a8d05a3a07c71e) #2424 
- pixelfed.social (Pixelfed instance) (9f4755a0adb6d8f1fc292a4794881d74c16d4a2b) #2425
- linuxfr.org (461b99b4e619d9995ad2a22e2f338946508355a3) #2427
- opencollective.com (3c03de15a30371c80456c14781ea0e904c254af5) #2430 
- outgress.com (83beb68682e2ccc1a99254ee5af9a4eda3d93d54) #2426

Note also the JSON file has also been cleaned with removal of useless white spaces (14bec5d2bcb3c8d1c37c15d2fbc9a558a28c0352) and empty lines (3feedab1ef8eff5a1505341e96fe889b9590d608), and moving *Bluesky* to the suitable lcoation (I supposed the file was alphabetically ordered) (ac814e7a2a9a0df6e35a705d0de1772349b43352).

Commits have been designed to allow cherry-picking :)

Let's keep in touch!