### PR TITLE
Fixed Minecraft

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1341,8 +1341,8 @@
     "username_claimed": "blue"
   },
   "Minecraft": {
-    "errorCode": 204,
-    "errorType": "status_code",
+    "errorMsg": "Couldn't find any profile with name",
+    "errorType": "message",
     "url": "https://api.mojang.com/users/profiles/minecraft/{}",
     "urlMain": "https://minecraft.net/",
     "username_claimed": "blue"


### PR DESCRIPTION
Fixes #2458 
HTTP status code isn't working for Minecraft, so used `message` error type instead.

Sample response for claimed username:
```json
{
  "id" : "bb83bdc4e8674dccb6568b49ad783596",
  "name" : "Blue"
}
```

Sample response for unclaimed username:
```json
{
  "path" : "/users/profiles/minecraft/blue475487563745",
  "errorMessage" : "Couldn't find any profile with name blue475487563745"
}
```