### PR TITLE
Fix stray character typo in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -112,7 +112,7 @@ $ echo '{"usernames":["user123"]}' | apify call -so netmilk/sherlock
     "https://www.1337x.to/user/user123/",
     ...
   ]
-}]s
+}]
 ```
 
 Read more about the [Sherlock Actor](../.actor/README.md), including how to use it programmaticaly via the Apify [API](https://apify.com/netmilk/sherlock/api?fpr=sherlock), [CLI](https://docs.apify.com/cli/?fpr=sherlock) and [JS/TS and Python SDKs](https://docs.apify.com/sdk?fpr=sherlock).


### PR DESCRIPTION
This PR removes a stray character `s` from the end of a code block in the Apify section of the README (located at docs/README.md).