### PR TITLE
Fix Issue #2474: Added support for Blitz Tactics

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -250,6 +250,12 @@
     "urlMain": "https://www.blipfoto.com/",
     "username_claimed": "blue"
   },
+  "Blitz Tactics": {
+    "errorType": "status_code",
+    "url": "https://blitztactics.com/{}",
+    "urlMain": "https://blitztactics.com/",
+    "username_claimed": "Lance5500"
+  },
   "Blogger": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",


### PR DESCRIPTION
This PR adds support for https://blitztactics.com to the project as requested in #2474.

NOTE: I am still a relative beginner with contributing to open-source projects, so I would appreciate feedback that anyone can provide.

Closes #2474 