### PR TITLE
Remove TorrentGalaxy from data.json

### DIFF
--- a/docs/removed-sites.md
+++ b/docs/removed-sites.md
@@ -1982,3 +1982,16 @@ __2025-02-16 :__ Unsure if any way to view profiles exists now
     "username_claimed": "t3dotgg"
   }
 ```
+
+## TorrentGalaxy
+__2025-07-01 :__ TorrentGalaxy seems to have gone offline sometime in March 2025 and has not come online since. 
+```json
+ "TorrentGalaxy": {
+    "errorMsg": "<title>TGx:Can't show details</title>",
+    "errorType": "message",
+    "regexCheck": "^[A-Za-z0-9]{3,15}$",
+    "url": "https://torrentgalaxy.to/profile/{}",
+    "urlMain": "https://torrentgalaxy.to/",
+    "username_claimed": "GalaxyRG"
+  },
+```

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2021,14 +2021,6 @@
     "urlMain": "https://www.tnaflix.com/",
     "username_claimed": "hacker"
   },
-  "TorrentGalaxy": {
-    "errorMsg": "<title>TGx:Can't show details</title>",
-    "errorType": "message",
-    "regexCheck": "^[A-Za-z0-9]{3,15}$",
-    "url": "https://torrentgalaxy.to/profile/{}",
-    "urlMain": "https://torrentgalaxy.to/",
-    "username_claimed": "GalaxyRG"
-  },
   "TradingView": {
     "errorType": "status_code",
     "request_method": "GET",


### PR DESCRIPTION
TorrentGalaxy appears to have gone offline sometime in March 2025 and has not come back. Currently July 1, 2025 and still offline.

### Article written mid March documenting the site being offline which it still currently is 
[TorrentGalaxy staff fear the worst as site stays dark and upload‑bots fail](https://torrentfreak.com/torrentgalaxy-staff-fear-the-worst-as-site-stays-dark-and-upload-bots-fail-250314/)

### Photo showing today's status :(
![image](https://github.com/user-attachments/assets/6b498064-4e28-447a-9f3b-50af8fc8ab9c)
