### PR TITLE
Fix Issue #2492 and #2494 | Added support for Pychess | Remove TorrentGalaxy 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-<p align=center>
+<p align="center">
   <br>
   <a href="https://sherlock-project.github.io/" target="_blank"><img src="images/sherlock-logo.png"/></a>
   <br>
@@ -15,8 +15,7 @@
 </p>
 
 <p align="center">
-<img width="70%" height="70%" src="images/demo.png"/>
-</a>
+  <img width="70%" height="70%" src="images/demo.png"/>
 </p>
 
 
@@ -115,7 +114,7 @@ $ echo '{"usernames":["user123"]}' | apify call -so netmilk/sherlock
 }]
 ```
 
-Read more about the [Sherlock Actor](../.actor/README.md), including how to use it programmaticaly via the Apify [API](https://apify.com/netmilk/sherlock/api?fpr=sherlock), [CLI](https://docs.apify.com/cli/?fpr=sherlock) and [JS/TS and Python SDKs](https://docs.apify.com/sdk?fpr=sherlock).
+Read more about the [Sherlock Actor](../.actor/README.md), including how to use it programmatically via the Apify [API](https://apify.com/netmilk/sherlock/api?fpr=sherlock), [CLI](https://docs.apify.com/cli/?fpr=sherlock) and [JS/TS and Python SDKs](https://docs.apify.com/sdk?fpr=sherlock).
 
 ## Credits
 

--- a/docs/removed-sites.md
+++ b/docs/removed-sites.md
@@ -1982,3 +1982,16 @@ __2025-02-16 :__ Unsure if any way to view profiles exists now
     "username_claimed": "t3dotgg"
   }
 ```
+
+## TorrentGalaxy
+__2025-07-06 :__ Site appears to have gone offline in March and hasn't come back
+```json
+  "TorrentGalaxy": {
+    "errorMsg": "<title>TGx:Can't show details</title>",
+    "errorType": "message",
+    "regexCheck": "^[A-Za-z0-9]{3,15}$",
+    "url": "https://torrentgalaxy.to/profile/{}",
+    "urlMain": "https://torrentgalaxy.to/",
+    "username_claimed": "GalaxyRG"
+  },
+```

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2028,14 +2028,6 @@
     "urlMain": "https://www.tnaflix.com/",
     "username_claimed": "hacker"
   },
-  "TorrentGalaxy": {
-    "errorMsg": "<title>TGx:Can't show details</title>",
-    "errorType": "message",
-    "regexCheck": "^[A-Za-z0-9]{3,15}$",
-    "url": "https://torrentgalaxy.to/profile/{}",
-    "urlMain": "https://torrentgalaxy.to/",
-    "username_claimed": "GalaxyRG"
-  },
   "TradingView": {
     "errorType": "status_code",
     "request_method": "GET",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1621,6 +1621,13 @@
     "urlMain": "https://www.producthunt.com/",
     "username_claimed": "jenny"
   },
+  "Pychess": {
+  "errorType": "message",
+  "errorMsg": "404",
+  "url": "https://www.pychess.org/@/{}",
+  "urlMain": "https://www.pychess.org",
+  "username_claimed": "gbtami"
+  },
   "PromoDJ": {
     "errorType": "status_code",
     "url": "http://promodj.com/{}",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -367,7 +367,7 @@
     "errorType": "status_code",
     "url": "https://cash.app/${}",
     "urlMain": "https://cash.app",
-    "username_claimed": "hotdiggitydog",
+    "username_claimed": "hotdiggitydog"
   },
   "Championat": {
     "errorType": "status_code",


### PR DESCRIPTION
In regards to issue #2492. This PR adds support for Pychess.

![image](https://github.com/user-attachments/assets/2694635c-d196-4b65-afa5-1dd01730bf1c)
![image](https://github.com/user-attachments/assets/78bb5dd1-5e79-4799-8a28-cbaa8e7783e3)


fixes #2494 
fixes #2492 
fixes #2532 


```fixes #2495 seems like another merged PR already solves this will unlink```
