### PR TITLE
feat: Add --filename-prefix argument

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -726,6 +726,12 @@ def main():
         default=False,
         help="Disable creation of a txt file",
     )
+    parser.add_argument(
+        "--filename-prefix",
+        "-fp",
+        dest="filename_prefix",
+        help="Add a prefix to the output file names.",
+    )
 
     args = parser.parse_args()
 
@@ -873,7 +879,10 @@ def main():
             os.makedirs(args.folderoutput, exist_ok=True)
             result_file = os.path.join(args.folderoutput, f"{username}.txt")
         else:
-            result_file = f"{username}.txt"
+            if args.filename_prefix:
+                result_file = f"{args.filename_prefix}{username}.txt"
+            else:
+                result_file = f"{username}.txt"
 
         if not args.no_txt:
             with open(result_file, "w", encoding="utf-8") as file:


### PR DESCRIPTION
This pull request adds a new `--filename-prefix` argument to allow users to add a prefix to the output file names. This makes it easier to organize results when performing multiple searches.

This resolves issue #2461.

### Example Usage

```bash
# Run Sherlock with a filename prefix
python3 -m sherlock_project user1 --filename-prefix my-test-

# Verify that the output file is created with the prefix
ls my-test-user1.txt