### PR TITLE
Add Tumblr Support to Sherlock

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2711,6 +2711,12 @@
     "urlMain": "https://www.toster.ru/",
     "username_claimed": "adam"
   },
+  "tumblr": {
+    "errorType": "status_code",
+    "url": "https://{}.tumblr.com/",
+    "urlMain": "https://www.tumblr.com/",
+    "username_claimed": "goku"
+},
   "uid": {
     "errorType": "status_code",
     "url": "http://uid.me/{}",


### PR DESCRIPTION
PR adds support for detecting usernames on Tumblr.

Added Tumblr entry in sherlock/resources/data.json.

Detection uses status_code since Tumblr returns 200 for existing blogs and 404 for non-existing ones.

Closes #2505