### PR TITLE
Fix parsing error in data.json

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,10 @@
 | `docker run -it --rm sherlock/sherlock` |
 | `dnf install sherlock-project` | |
 
+**For HydraPWK user**
+```
+sudo apt install sherlock
+```
 Community-maintained packages are available for Debian (>= 13), Ubuntu (>= 22.10), Homebrew, Kali, and BlackArch. These packages are not directly supported or maintained by the Sherlock Project.
 
 See all alternative installation methods [here](https://sherlockproject.xyz/installation)

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -367,7 +367,7 @@
     "errorType": "status_code",
     "url": "https://cash.app/${}",
     "urlMain": "https://cash.app",
-    "username_claimed": "hotdiggitydog",
+    "username_claimed": "hotdiggitydog"
   },
   "Championat": {
     "errorType": "status_code",


### PR DESCRIPTION
ERROR:  Problem parsing json contents at 'https://raw.githubusercontent.com/sherlock-project/sherlock/master/sherlock_project/resources/data.json':  Expecting property name enclosed in double quotes: line 371 column 3 (char 11312).


```
  "CashApp": {
    "errorType": "status_code",
    "url": "https://cash.app/${}",
    "urlMain": "https://cash.app",
    "username_claimed": "hotdiggitydog",
  },
```
Del coma

```
  "CashApp": {
    "errorType": "status_code",
    "url": "https://cash.app/${}",
    "urlMain": "https://cash.app",
    "username_claimed": "hotdiggitydog"
  },
```