### PR TITLE
[FIX] Formatting error in data.json for CashApp entry

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -367,7 +367,7 @@
     "errorType": "status_code",
     "url": "https://cash.app/${}",
     "urlMain": "https://cash.app",
-    "username_claimed": "hotdiggitydog",
+    "username_claimed": "hotdiggitydog"
   },
   "Championat": {
     "errorType": "status_code",


### PR DESCRIPTION
- Deletes trailing comma which prevented sherlock from running.