### PR TITLE
feat: Add some popular website in Korea

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1465,6 +1465,12 @@
     "urlMain": "https://www.native-instruments.com/forum/",
     "username_claimed": "jambert"
   },
+  "namuwiki": {
+    "errorType": "status_code",
+    "url": "https://namu.wiki/w/%EC%82%AC%EC%9A%A9%EC%9E%90:{}",
+    "urlMain": "https://namu.wiki/",
+    "username_claimed": "namu"
+  },
   "NationStates Nation": {
     "errorMsg": "Was this your nation? It may have ceased to exist due to inactivity, but can rise again!",
     "errorType": "message",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2138,6 +2138,12 @@
     "urlMain": "https://themeforest.net/",
     "username_claimed": "user"
   },
+  "tistory": {
+    "errorType": "status_code",
+    "url": "https://{}.tistory.com/",
+    "urlMain": "https://www.tistory.com/",
+    "username_claimed": "notice"
+  },
   "TnAFlix": {
     "errorType": "status_code",
     "isNSFW": true,

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1964,6 +1964,13 @@
     "urlMain": "https://www.snapchat.com",
     "username_claimed": "teamsnapchat"
   },
+  "SOOP": {
+    "errorType": "status_code",
+    "url": "https://www.sooplive.co.kr/station/{}",
+    "urlMain": "https://www.sooplive.co.kr/",
+    "urlProbe": "https://api-channel.sooplive.co.kr/v1.1/channel/{}/station",
+    "username_claimed": "udkn"
+  },
   "SoundCloud": {
     "errorType": "status_code",
     "url": "https://soundcloud.com/{}",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -600,6 +600,12 @@
     "urlMain": "https://www.dailymotion.com/",
     "username_claimed": "blue"
   },
+  "dcinside": {
+    "errorType": "status_code",
+    "url": "https://gallog.dcinside.com/{}",
+    "urlMain": "https://www.dcinside.com/",
+    "username_claimed": "anrbrb"
+  },
   "Dealabs": {
     "errorMsg": "La page que vous essayez",
     "errorType": "message",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1466,6 +1466,7 @@
     "username_claimed": "jambert"
   },
   "namuwiki": {
+    "__comment__": "This is a Korean site and it's expected to return false negatives in certain other regions.",
     "errorType": "status_code",
     "url": "https://namu.wiki/w/%EC%82%AC%EC%9A%A9%EC%9E%90:{}",
     "urlMain": "https://namu.wiki/",


### PR DESCRIPTION
namuwiki is ranked 5th in Top Websites Ranking in Korea by similarweb.
dcinside is ranked 7th, tistory is ranked 11th, soop is ranked 28th.