### PR TITLE
Removed duplicate Bluesky entry in data.json

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2840,13 +2840,6 @@
     "urlMain": "https://znanylekarz.pl",
     "username_claimed": "janusz-nowak"
   },
-  "Bluesky": {
-    "errorType": "status_code",
-    "url": "https://bsky.app/profile/{}.bsky.social",
-    "urlProbe": "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor={}.bsky.social",
-    "urlMain": "https://bsky.app/",
-    "username_claimed": "mcuban"
-  },
   "Platzi": {
     "errorType": "status_code",
     "errorCode": 404,


### PR DESCRIPTION
This PR removes the duplicate Bluesky entry in data.json. While not a critical fix, it improves code cleanliness and resolves a linting error.