### PR TITLE
fix(sites): Remediate false positive for NationStates Region

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1467,12 +1467,12 @@
     "username_claimed": "the_holy_principality_of_saint_mark"
   },
   "NationStates Region": {
-    "errorMsg": "does not exist.",
-    "errorType": "message",
-    "url": "https://nationstates.net/region={}",
-    "urlMain": "https://nationstates.net",
-    "username_claimed": "the_west_pacific"
-  },
+  "errorMsg": "Region Not Found",
+  "errorType": "message",
+  "url": "https://nationstates.net/region={}",
+  "urlMain": "https://nationstates.net",
+  "username_claimed": "the_west_pacific"
+},
   "Naver": {
     "errorType": "status_code",
     "url": "https://blog.naver.com/{}",


### PR DESCRIPTION
This PR remediates the false positive for NationStates Region by updating the detection logic to look for "Region Not Found".
Fixes #2374.

