### PR TITLE
fix(sites): Remediate false positive for Blitz Tactics

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -259,7 +259,8 @@
     "username_claimed": "blue"
   },
   "Blitz Tactics": {
-    "errorType": "status_code",
+    "errorMsg": "That page doesn't exist",
+    "errorType": "message",
     "url": "https://blitztactics.com/{}",
     "urlMain": "https://blitztactics.com/",
     "username_claimed": "Lance5500"
@@ -279,7 +280,7 @@
     "username_claimed": "mcuban"
   },
   "BoardGameGeek": {
-    "errorType": "message",
+    "errorType": "status_code",
     "regexCheck": "^[a-zA-Z0-9_]*$",
     "errorMsg": "User not found",
     "url": "https://boardgamegeek.com/user/{}",


### PR DESCRIPTION
This PR remediates the false positive for Blitz Tactics by updating the detection logic to look for "That page doesn't exist".