### PR TITLE
fix(sites): Remediate false positive for Apple Discussions

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -115,7 +115,7 @@
     "username_claimed": "lio24d"
   },
   "Apple Discussions": {
-    "errorMsg": "The page you tried was not found. You may have used an outdated link or may have typed the address (URL) incorrectly.",
+    "errorMsg": "Looking for something in Apple Support Communities?",
     "errorType": "message",
     "url": "https://discussions.apple.com/profile/{}",
     "urlMain": "https://discussions.apple.com",


### PR DESCRIPTION
This PR remediates the false positive for Apple Discussions by updating the detection logic to look for "Looking for something in Apple Support Communities?".