### PR TITLE
fix(sites): Remediate false positive for Wikidot

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2330,7 +2330,7 @@
     "username_claimed": "blue"
   },
   "Wikidot": {
-    "errorMsg": "User does not exist.",
+    "errorMsg": "User Information",
     "errorType": "message",
     "url": "http://www.wikidot.com/user:info/{}",
     "urlMain": "http://www.wikidot.com/",


### PR DESCRIPTION
This PR remediates the false positive for Wikidot by updating the detection logic to look for "User Information".