### PR TITLE
Add AWS Skills Profile site to Sherlock

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -79,13 +79,13 @@
     "username_claimed": "pink"
   },
   "AllMyLinks": {
-  "errorMsg": "Page not found",
-  "errorType": "message",
-  "regexCheck": "^[a-z0-9][a-z0-9-]{2,32}$",
-  "url": "https://allmylinks.com/{}",
-  "urlMain": "https://allmylinks.com/",
-  "username_claimed": "blue"
-},
+    "errorMsg": "Page not found",
+    "errorType": "message",
+    "regexCheck": "^[a-z0-9][a-z0-9-]{2,32}$",
+    "url": "https://allmylinks.com/{}",
+    "urlMain": "https://allmylinks.com/",
+    "username_claimed": "blue"
+  },
   "AniWorld": {
     "errorMsg": "Dieses Profil ist nicht verf\u00fcgbar",
     "errorType": "message",
@@ -192,6 +192,13 @@
     "url": "https://www.avizo.cz/{}/",
     "urlMain": "https://www.avizo.cz/",
     "username_claimed": "blue"
+  },
+  "AWS Skills Profile": {
+    "errorType": "message",
+    "errorMsg": "shareProfileAccepted\":false",
+    "url": "https://skillsprofile.skillbuilder.aws/user/{}/",
+    "urlMain": "https://skillsprofile.skillbuilder.aws",
+    "username_claimed": "mayank04pant"
   },
   "BOOTH": {
     "errorType": "response_url",
@@ -614,21 +621,21 @@
     "urlMain": "https://www.dealabs.com/",
     "username_claimed": "blue"
   },
- "DeviantArt": {
-  "errorType": "message",
-  "errorMsg": "Llama Not Found",
-  "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
-  "url": "https://www.deviantart.com/{}",
-  "urlMain": "https://www.deviantart.com/",
-  "username_claimed": "blue"
-},
+  "DeviantArt": {
+    "errorType": "message",
+    "errorMsg": "Llama Not Found",
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
+    "url": "https://www.deviantart.com/{}",
+    "urlMain": "https://www.deviantart.com/",
+    "username_claimed": "blue"
+  },
   "DigitalSpy": {
-      "errorMsg": "The page you were looking for could not be found.",
-      "errorType": "message",
-      "url": "https://forums.digitalspy.com/profile/{}",
-      "urlMain": "https://forums.digitalspy.com/",
-      "username_claimed": "blue",
-      "regexCheck": "^\\w{3,20}$"
+    "errorMsg": "The page you were looking for could not be found.",
+    "errorType": "message",
+    "url": "https://forums.digitalspy.com/profile/{}",
+    "urlMain": "https://forums.digitalspy.com/",
+    "username_claimed": "blue",
+    "regexCheck": "^\\w{3,20}$"
   },
   "Discogs": {
     "errorType": "status_code",
@@ -684,7 +691,6 @@
   "Duolingo": {
     "errorMsg": "{\"users\":[]}",
     "errorType": "message",
-
     "url": "https://www.duolingo.com/profile/{}",
     "urlMain": "https://duolingo.com/",
     "urlProbe": "https://www.duolingo.com/2017-06-30/users?username={}",
@@ -1269,7 +1275,7 @@
     "username_claimed": "red"
   },
   "Laracast": {
-    "errorType":"status_code",
+    "errorType": "status_code",
     "url": "https://laracasts.com/@{}",
     "urlMain": "https://laracasts.com/",
     "regexCheck": "^[a-zA-Z0-9_-]{3,}$",
@@ -1447,12 +1453,12 @@
     "username_claimed": "blue"
   },
   "Mydramalist": {
-  "errorMsg": "The requested page was not found",
-  "errorType": "message",
-  "url": "https://www.mydramalist.com/profile/{}",
-  "urlMain": "https://mydramalist.com",
-  "username_claimed": "elhadidy12398"
-},
+    "errorMsg": "The requested page was not found",
+    "errorType": "message",
+    "url": "https://www.mydramalist.com/profile/{}",
+    "urlMain": "https://mydramalist.com",
+    "username_claimed": "elhadidy12398"
+  },
   "Myspace": {
     "errorType": "status_code",
     "url": "https://myspace.com/{}",
@@ -1728,11 +1734,11 @@
     "username_claimed": "pylapp"
   },
   "Pychess": {
-  "errorType": "message",
-  "errorMsg": "404",
-  "url": "https://www.pychess.org/@/{}",
-  "urlMain": "https://www.pychess.org",
-  "username_claimed": "gbtami"
+    "errorType": "message",
+    "errorMsg": "404",
+    "url": "https://www.pychess.org/@/{}",
+    "urlMain": "https://www.pychess.org",
+    "username_claimed": "gbtami"
   },
   "PromoDJ": {
     "errorType": "status_code",
@@ -2043,7 +2049,6 @@
   },
   "Spotify": {
     "errorType": "status_code",
-
     "url": "https://open.spotify.com/user/{}",
     "urlMain": "https://open.spotify.com/",
     "username_claimed": "blue"
@@ -2466,7 +2471,6 @@
   },
   "YouTube": {
     "errorType": "status_code",
-
     "url": "https://www.youtube.com/@{}",
     "urlMain": "https://www.youtube.com/",
     "username_claimed": "youtube"
@@ -2840,7 +2844,7 @@
     "url": "https://{}.tumblr.com/",
     "urlMain": "https://www.tumblr.com/",
     "username_claimed": "goku"
-},
+  },
   "uid": {
     "errorType": "status_code",
     "url": "http://uid.me/{}",


### PR DESCRIPTION
**PR description:**
This PR adds AWS Skills Profile to Sherlock’s supported sites in data.json. 

An AWS Skills Profile is a personalized, verifiable online profile on [AWS Skill Builder](https://skillbuilder.aws/) that allows individuals to showcase their AWS learning journey and achievements, including verified AWS certifications, learning milestones, and digital badges.

The configuration uses a unique substring (`shareProfileAccepted":false`) for reliable detection of non-existent usernames, addressing the challenge of JavaScript-rendered error messages.
- Site details and detection logic follow Sherlock’s contributing guidelines and Code of Conduct.
- No changes to core logic; only a new site entry.
- Reviewed for schema compliance and duplicate key cleanup as noted.