### PR TITLE
Fix dailykos F+

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2510,7 +2510,7 @@
   },
   "dailykos": {
     "errorMsg": "{\"result\":true,\"message\":null}",
-    "errorType": "message",
+    "errorType": ["message", "status_code"],
     "url": "https://www.dailykos.com/user/{}",
     "urlMain": "https://www.dailykos.com",
     "urlProbe": "https://www.dailykos.com/signup/check_nickname?nickname={}",


### PR DESCRIPTION
dailykos uses CloudFront geo-restrictions that return 403 errors for blocked regions, causing false positives in username detection. Added comment to document this known issue.