### PR TITLE
fix(sites): Update BoardGameGeek URL structure and detection method

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -291,6 +291,14 @@
     "urlMain": "https://www.bookcrossing.com/",
     "username_claimed": "blue"
   },
+  "BoardGameGeek": {
+    "errorMsg": "\"isValid\":true",
+    "errorType": "message",
+    "url": "https://boardgamegeek.com/user/{}",
+    "urlMain": "https://boardgamegeek.com/",
+    "urlProbe": "https://api.geekdo.com/api/accounts/validate/username?username={}",
+    "username_claimed": "blue"
+  },
   "BraveCommunity": {
     "errorType": "status_code",
     "url": "https://community.brave.com/u/{}/",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -279,10 +279,9 @@
     "username_claimed": "mcuban"
   },
   "BoardGameGeek": {
-    "errorType": "message",
+    "errorType": "status_code",
     "regexCheck": "^[a-zA-Z0-9_]*$",
-    "errorMsg": "User not found",
-    "url": "https://boardgamegeek.com/user/{}",
+    "url": "https://boardgamegeek.com/profile/{}",
     "urlMain": "https://boardgamegeek.com",
     "username_claimed": "blue"
   },

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -278,6 +278,15 @@
     "urlMain": "https://bsky.app/",
     "username_claimed": "mcuban"
   },
+  "BoardGameGeek": {
+    "errorMsg": "[]",
+    "errorType": "message",
+    "regexCheck": "^[a-zA-Z0-9_]*$",
+    "url": "https://boardgamegeek.com/profile/{}",
+    "urlMain": "https://boardgamegeek.com",
+    "urlProbe": "https://api.geekdo.com/api/users?username={}",
+    "username_claimed": "blue"
+  },
   "BongaCams": {
     "errorType": "status_code",
     "isNSFW": true,

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -278,15 +278,6 @@
     "urlMain": "https://bsky.app/",
     "username_claimed": "mcuban"
   },
-  "BoardGameGeek": {
-    "errorMsg": "[]",
-    "errorType": "message",
-    "regexCheck": "^[a-zA-Z0-9_]*$",
-    "url": "https://boardgamegeek.com/profile/{}",
-    "urlMain": "https://boardgamegeek.com",
-    "urlProbe": "https://api.geekdo.com/api/users?username={}",
-    "username_claimed": "blue"
-  },
   "BongaCams": {
     "errorType": "status_code",
     "isNSFW": true,

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -278,13 +278,6 @@
     "urlMain": "https://bsky.app/",
     "username_claimed": "mcuban"
   },
-  "BoardGameGeek": {
-    "errorType": "status_code",
-    "regexCheck": "^[a-zA-Z0-9_]*$",
-    "url": "https://boardgamegeek.com/profile/{}",
-    "urlMain": "https://boardgamegeek.com",
-    "username_claimed": "blue"
-  },
   "BongaCams": {
     "errorType": "status_code",
     "isNSFW": true,


### PR DESCRIPTION
fixed , BoardGameGeek changed from /user/{} to /profile/{} URL structure. Also updated from message to status_code detection as the site no longer returns clear error messages for non-existent users.