### PR TITLE
fix(sites): Fix Roblox false positive detection

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1823,8 +1823,7 @@
     "username_claimed": "blue"
   },
   "Roblox": {
-    "errorMsg": "Page cannot be found or no longer exists",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://www.roblox.com/user.aspx?username={}",
     "urlMain": "https://www.roblox.com/",
     "username_claimed": "bluewolfekiller"


### PR DESCRIPTION
Roblox error message detection was failing because the site no longer displays 'Page cannot be found or no longer exists' message.

Updated to use status_code detection instead:
- Invalid users: Returns 404
- Valid users: Returns 200

Tested with:
- Invalid user (impossibleuser12345): Correctly not found
- Valid user (bluewolfekiller): Correctly found

This fixes the false positive issue where non-existent Roblox users were being reported as found.