### PR TITLE
Add proxy URL validation with regex check

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -756,7 +756,12 @@ def main():
         print(f"A problem occurred while checking for an update: {error}")
 
     # Argument check
-    # TODO regex check on args.proxy
+    if args.proxy is not None:
+        # Validate proxy URL format
+        proxy_pattern = r'^(https?|socks[45])://[^\s/$.?#].[^\s]*$'
+        if not re.match(proxy_pattern, args.proxy):
+            raise ValueError(f"Invalid proxy URL format: {args.proxy}. Expected format: protocol://host:port (e.g., socks5://127.0.0.1:1080)")
+    
     if args.tor and (args.proxy is not None):
         raise Exception("Tor and Proxy cannot be set at the same time.")
 


### PR DESCRIPTION
# Add Proxy URL Validation

## Summary
Implements regex validation for the `--proxy` argument to catch malformed URLs early and provide better error messages.

## Changes
- Added proxy URL format validation in `sherlock_project/sherlock.py`
- Supports `http`, `https`, `socks4`, and `socks5` protocols
- Provides clear error messages with format examples
- Resolves TODO comment for proxy validation

## Benefits
- **Better UX**: Immediate feedback for invalid proxy URLs
- **Error Prevention**: Catches malformed URLs before runtime errors
- **Code Quality**: Addresses existing TODO

## Example
```bash
# Valid
sherlock --proxy "socks5://127.0.0.1:1080" username

# Invalid - shows helpful error
sherlock --proxy "invalid-url" username
# Error: Invalid proxy URL format: invalid-url. Expected format: protocol://host:port (e.g., socks5://127.0.0.1:1080)
```

## Testing
- ✅ Valid proxy URLs accepted
- ✅ Invalid URLs rejected with clear messages
- ✅ No breaking changes