### PR TITLE
Add Docker build test to CI workflow (#2196)

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -11,6 +11,7 @@ on:
       - '**/*.py'
       - '**/*.ini'
       - '**/*.toml'
+      - 'Dockerfile'
   push:
     branches:
       - master
@@ -21,11 +22,13 @@ on:
       - '**/*.py'
       - '**/*.ini'
       - '**/*.toml'
+      - 'Dockerfile'
 
 jobs:
   tox-lint:
-    # Linting is ran through tox to ensure that the same linter is used by local runners
     runs-on: ubuntu-latest
+    # Linting is ran through tox to ensure that the same linter
+    # is used by local runners
     steps:
       - uses: actions/checkout@v4
       - name: Set up linting environment
@@ -41,7 +44,8 @@ jobs:
   tox-matrix:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false # We want to know what specicic versions it fails on
+      # We want to know what specicic versions it fails on
+      fail-fast: false
       matrix:
         os: [
           ubuntu-latest,
@@ -67,3 +71,22 @@ jobs:
           pip install tox-gh-actions
       - name: Run tox
         run: tox
+  docker-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Get version from pyproject.toml
+        id: get-version
+        run: |
+          VERSION=$(grep -m1 'version = ' pyproject.toml | cut -d'"' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg VERSION_TAG=${{ steps.get-version.outputs.version }} \
+            -t sherlock-test:latest .
+      - name: Test Docker image runs
+        run: docker run --rm sherlock-test:latest --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
   # 3. Build image with BOTH latest and version tags
     # i.e. `docker build -t sherlock/sherlock:0.16.0 -t sherlock/sherlock:latest .`
 
-FROM python:3.12-slim-bullseye as build
+FROM python:3.12-slim-bullseye AS build
 WORKDIR /sherlock
 
 RUN pip3 install --no-cache-dir --upgrade pip


### PR DESCRIPTION
## Description
Adds automated testing for Docker image builds on merge/push to master and release branches.

## Changes
- Added `docker-build-test` job to `.github/workflows/regression.yml`
- Extracts `VERSION_TAG` from `pyproject.toml` dynamically
- Builds Docker image with proper version tag
- Validates the built image runs correctly with `--version` flag
- Resolves Dockerfile syntax warnings

## Testing
- ✅ Tested locally with `act` - all steps passed
- ✅ Docker builds successfully with VERSION_TAG=0.16.0
- ✅ Container runs and displays correct version

## Related Issue
Closes #2196

## Checklist
- [x] Informative PR title
- [x] Added Docker build test to CI
- [x] Tested locally with act
- [x] All existing tests still pass
- [x] Follows project conventions

## Code of Conduct
- [x] I agree to follow this project's Code of Conduct