### PR TITLE
Fix(sites): Remove unreliable Lush Stories site check

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1365,13 +1365,7 @@
     "urlMain": "https://lottiefiles.com/",
     "username_claimed": "lottiefiles"
   },
-  "LushStories": {
-    "errorType": "status_code",
-    "isNSFW": true,
-    "url": "https://www.lushstories.com/profile/{}",
-    "urlMain": "https://www.lushstories.com/",
-    "username_claimed": "chris_brown"
-  },
+  
   "MMORPG Forum": {
     "errorType": "status_code",
     "url": "https://forums.mmorpg.com/profile/{}",


### PR DESCRIPTION
This pull request resolves an issue where the site check for Lush Stories was producing false positives for non-existent usernames.

Problem:
The site redirects both valid and invalid profile URLs to a login page for unauthenticated users. This made it impossible for Sherlock to distinguish between a found and not-found profile, causing any username check to be reported as a success.

Solution:
After attempting several detection methods (`status_code`, `response_url`), it was determined that a reliable check is not possible without being logged in.

To improve the overall accuracy of the tool and prevent future false positives, this commit completely removes the Lush Stories site from `data.json`.

This fixes the issue reported by the user in the initial problem description.