### PR TITLE
feat: add PayPal.me site support to data.json (#2434)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1620,6 +1620,14 @@
     "urlMain": "https://www.patreon.com/",
     "username_claimed": "blue"
   },
+  "PayPal.me": {
+  "errorType": "status_code",
+  "url": "https://www.paypal.me/{}",
+  "urlMain": "https://www.paypal.me/",
+  "errorMsg": "Page Not Found",
+  "regexCheck": "^[A-Za-z0-9]{1,20}$",
+  "username_claimed": "blue"
+},
   "PentesterLab": {
     "errorType": "status_code",
     "regexCheck": "^[\\w]{4,30}$",


### PR DESCRIPTION
Added PayPal.me support to data.json (per #2434).
Verified functionality locally with dummy usernames and confirmed correct 404 handling.
JSON validated with python3 -m json.tool.
Thanks for maintaining this project — please let me know if any adjustments are needed!