### PR TITLE
Add support for WakaTime

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2320,6 +2320,12 @@
     "urlMain": "https://discourse.wicg.io/",
     "username_claimed": "stefano"
   },
+  "Wakatime": {
+    "errorType": "status_code",
+    "url": "https://wakatime.com/@{}",
+    "urlMain": "https://wakatime.com/",
+    "username_claimed": "blue"
+  },
   "Warrior Forum": {
     "errorType": "status_code",
     "url": "https://www.warriorforum.com/members/{}.html",


### PR DESCRIPTION
As the title suggests, it adds the support of WakaTime (Automated time tracking softwares for developers) to Sherlock.

This PR closes Issue #2319 