### PR TITLE
Add MuseScore site (clean version)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1433,6 +1433,12 @@
     "urlMain": "https://www.motorradfrage.net/",
     "username_claimed": "gutefrage"
   },
+  "MuseScore": {
+  "errorType": "status_code",
+  "url": "https://musescore.com/{}",
+  "urlMain": "https://musescore.com/",
+  "username_claimed": "musescore"
+},
   "MyAnimeList": {
     "errorType": "status_code",
     "url": "https://myanimelist.net/profile/{}",


### PR DESCRIPTION
Added MuseScore support to data.json.
Validated JSON locally (python3 -m json.tool) — no syntax errors.
MuseScore pages return dynamic content, so username detection may currently return zero results, but the structure is correct and ready for future improvements.

This is a clean version of the earlier PR (#2600), created directly from master with no test HTML files or unintended PayPal changes.