### PR TITLE
feat: Add site Coomer (OnlyFans) 

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2880,5 +2880,17 @@
     "urlMain": "https://platzi.com/",
     "username_claimed": "freddier",
     "request_method": "GET"
+  },
+  "Coomer (OnlyFans)": {
+    "errorType": "status_code",
+    "isNSFW": true,
+    "url": "https://coomer.st/onlyfans/user/{}",
+    "urlMain": "https://coomer.st/",
+    "urlProbe": "https://coomer.st/api/v1/onlyfans/user/{}/profile",
+    "headers": {
+      "Accept": "text/css"
+    },
+    "username_claimed": "belledelphine",
+    "__comment__": "username_unclaimed was excluded due to schema validation failure (Additional properties not allowed)"
   }
 }


### PR DESCRIPTION
Adds support for checking usernames on Coomer (OnlyFans) via  **coomer.st**.

- Uses the API endpoint (`urlProbe`) for accurate detection of claimed usernames.
- Includes the custom `Accept: text/css` header to bypass the site's DDoS-Guard protection.
- Excludes the `username_unclaimed` field to satisfy the schema validator.
- Marked as NSFW with `isNSFW: true`.
- All tests pass successfully.
