### PR TITLE
new Replit user added

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1808,12 +1808,14 @@
     "urlMain": "https://www.reisefrage.net/",
     "username_claimed": "reisefrage"
   },
-  "Replit.com": {
+  "Replit": {
     "errorType": "status_code",
+    "regexCheck": "^[A-Za-z0-9_-]{2,30}$",
     "url": "https://replit.com/@{}",
     "urlMain": "https://replit.com/",
-    "username_claimed": "blue"
+    "username_claimed": "guruprasadpand"
   },
+
   "ResearchGate": {
     "errorType": "response_url",
     "errorUrl": "https://www.researchgate.net/directory/profiles",


### PR DESCRIPTION
Added support for Replit user profiles:
- URL format: https://replit.com/@{username}
- Tested with: https://replit.com/@guruprasadpand
- Returns 404 for invalid usernames.
