### PR TITLE
feat: GitHub Actions - Validate Remote Manifest Against Local Schema Before Running `Validate Modified Targets` Test Suite

### DIFF
--- a/.github/workflows/validate_modified_targets.yml
+++ b/.github/workflows/validate_modified_targets.yml
@@ -74,10 +74,10 @@ jobs:
               print(f"Error: Could not decode JSON from a file - {e}", file=sys.stderr)
               sys.exit(1)
           except jsonschema.exceptions.SchemaError  as e:
-              print(f"Error: Could not locate valid JSON schema for data.json - {e}", file=sys.stderr)
+              print(f"Error: Could not locate local JSON schema for validation - {e}", file=sys.stderr)
               sys.exit(1)
           except jsonschema.exceptions.ValidationError  as e:
-              print(f"Error: Could not validate JSON against schema - {e}", file=sys.stderr)
+              print(f"Error: Could not validate remote manifest against local schema - {e}", file=sys.stderr)
               sys.exit(1)
 
           changed = []


### PR DESCRIPTION
This PR updates the `validate_modified_targets.yml` GitHub Actions workflow to validate the PR head `data.json` file against the base data schema before running any further validation test suites, resulting in a fail if it is non-compliant due to any of the `jsonschema` exceptions that validation might raise.

Closes #2612.