### PR TITLE
Add support for Discord.bio

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -678,6 +678,13 @@
     },
     "username_claimed": "blue"
   },
+  "Discord.bio": {
+    "errorType": "message",
+    "errorMsg": "<title>Server Error (500)</title>",
+    "url": "https://discords.com/api-v2/bio/details/{}",
+    "urlMain": "https://discord.bio/",
+    "username_claimed": "robert"
+  },
   "Discuss.Elastic.co": {
     "errorType": "status_code",
     "url": "https://discuss.elastic.co/u/{}",


### PR DESCRIPTION
This PR adds the support of website "Discord.bio" to Sherlock.

A PR related to this request was already opened in 2021 but owing to the drift in endpoint, its no longer valid. Hence, opening a new PR to implement the necessary changes.

Closes #965  