### PR TITLE
Mark multiple sites as false positive (#2547)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -299,7 +299,8 @@
     "url": "https://boardgamegeek.com/user/{}",
     "urlMain": "https://boardgamegeek.com/",
     "urlProbe": "https://api.geekdo.com/api/accounts/validate/username?username={}",
-    "username_claimed": "blue"
+    "username_claimed": "blue",
+    "isProblematic": true
   },
   "BraveCommunity": {
     "errorType": "status_code",
@@ -1434,7 +1435,9 @@
     "errorType": "message",
     "url": "https://api.mojang.com/users/profiles/minecraft/{}",
     "urlMain": "https://minecraft.net/",
-    "username_claimed": "blue"
+    "username_claimed": "blue",
+    "isProblematic": true
+
   },
   "MixCloud": {
     "errorType": "status_code",
@@ -2574,7 +2577,8 @@
     "url": "https://www.dailykos.com/user/{}",
     "urlMain": "https://www.dailykos.com",
     "urlProbe": "https://www.dailykos.com/signup/check_nickname?nickname={}",
-    "username_claimed": "blue"
+    "username_claimed": "blue",
+    "isProblematic": true
   },
   "datingRU": {
     "errorType": "status_code",
@@ -2735,7 +2739,8 @@
     "errorType": "status_code",
     "url": "https://mastodon.cloud/@{}",
     "urlMain": "https://mastodon.cloud/",
-    "username_claimed": "TheAdmin"
+    "username_claimed": "TheAdmin",
+    "isProblematic": true
   },
   "mastodon.social": {
     "errorType": "status_code",
@@ -2806,7 +2811,8 @@
     "url": "https://{}.omg.lol",
     "urlMain": "https://home.omg.lol",
     "urlProbe": "https://api.omg.lol/address/{}/availability",
-    "username_claimed": "adam"
+    "username_claimed": "adam",
+    "isProblematic": true
   },
   "opennet": {
     "errorMsg": "\u0418\u043c\u044f \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e",


### PR DESCRIPTION
# Mark Multiple Sites as False Positive (#2547)

This PR adds the following sites to the false positive list as they return incorrect matches when testing non-existent usernames:

- BoardGameGeek
- Minecraft
- dailykos
- mastodon.cloud
- omg.lol

Relates to umbrella issue #2547 (False Positive Remediation).

These sites are now marked with `"isProblematic": true` in `data.json` to prevent false positives in Sherlock searches.

### Rationale for BoardGameGeek F+ failure

Note: BoardGameGeek fails the F+ CI check because it is a false-positive site for non-existent usernames.
This is intentional; we are marking it as `"isProblematic": true` to prevent false positives (#2547).

<img width="1576" height="350" alt="Screenshot 2025-10-08 171835" src="https://github.com/user-attachments/assets/f06045f0-a82b-4ffe-ac83-f6f6dcf7046a" />


