### PR TITLE
Fix BoardGameGeek false-positive using API validation

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -294,11 +294,11 @@
     "username_claimed": "blue"
   },
   "BoardGameGeek": {
-    "errorMsg": "\"isValid\":true",
+    "errorMsg": "[]",
     "errorType": "message",
-    "url": "https://boardgamegeek.com/user/{}",
+    "url": "https://boardgamegeek.com/profile/{}",
     "urlMain": "https://boardgamegeek.com/",
-    "urlProbe": "https://api.geekdo.com/api/accounts/validate/username?username={}",
+    "urlProbe": "https://api.geekdo.com/api/users?username={}",
     "username_claimed": "blue"
   },
   "BraveCommunity": {


### PR DESCRIPTION
### Description

This PR fixes a false-positive detection for BoardGameGeek in Sherlock.

Previously, non-existent usernames were incorrectly marked as found because Sherlock only checked the profile page URL. Now, it uses the BoardGameGeek API (`urlProbe`) to verify the username:

- Existing usernames return a JSON object.
- Non-existent usernames return an empty list (`[]`).

### Changes

- Updated `BoardGameGeek` entry in `sherlock_project/resources/data.json` to use `urlProbe`.
- Set `"errorMsg": "[]"` and `"errorType": "message"` to correctly detect invalid usernames.

### Testing

Tested locally with postman 
curl --location 'https://api.geekdo.com/api/users?username=username_that_does_not_exist_9999'
result:
[]

2) 
curl --location 'https://api.geekdo.com/api/users?username=vivekgaddam'
[
    {
        "type": "users",
        "id": "4382477",
        "userid": 4382477,
        "username": "vivekgaddam",
        "href": "/profile/vivekgaddam",
        "firstname": "",
        "lastname": "",
        "city": "",
        "state": "",
        "country": "",
        "isocountry": "",
        "regdate": "2025-10-08",
        "designerid": 0,
        "publisherid": 0,
        "hideSupporter": false,
        "adminBadges": [],
        "userMicrobadges": [],
        "supportYears": [],
        "hideName": false,
        "links": [
            {
                "rel": "self",
                "uri": "/api/users/4382477"
            }
        ],
        "canonical_link": "https://boardgamegeek.com/profile/vivekgaddam"
    }
]