### PR TITLE
Add TikTok (tiktok.com) to supported sites

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2146,13 +2146,14 @@
     "username_claimed": "osk"
   },
   
-"TikTok": {
-    "url": "https://www.tiktok.com/@{}",
-    "urlMain": "https://www.tiktok.com",
-    "errorType": "message",
-    "errorMsg": "\"statusCode\":10221",
-    "username_claimed": "charlidamelio"
-},
+  "TikTok": {
+      "url": "https://www.tiktok.com/@{}",
+      "urlMain": "https://www.tiktok.com",
+      "errorType": "message",
+      "errorMsg": ["\"statusCode\":10221","Govt. of India decided to block 59 apps"],
+      "username_claimed": "charlidamelio"
+  },
+
 
 
   "Tiendanube": {


### PR DESCRIPTION
This PR adds TikTok support to Sherlock's data.json.

- Site: TikTok (tiktok.com)
- URL pattern: https://www.tiktok.com/@{username}
- Detection method: looks for message "statusCode:10221" on invalid profiles
- Tested manually with a known username (charlidamelio) and a non-existent one
- No core logic changes — data.json entry only
- Tested via VPN (since TikTok is restricted in India)

Closes #2519 as moot