### PR TITLE
fix: false positive for kaskus

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1271,7 +1271,9 @@
   "kaskus": {
     "errorType": "status_code",
     "url": "https://www.kaskus.co.id/@{}",
-    "urlMain": "https://www.kaskus.co.id/",
+    "urlMain": "https://www.kaskus.co.id",
+    "urlProbe": "https://www.kaskus.co.id/api/users?username={}",
+    "request_method": "GET",
     "username_claimed": "l0mbart"
   },
   "Keybase": {


### PR DESCRIPTION
## The solution
- Rely on another endpoint `/api/users` that is only concerned with user data.

## QA screenshot after fix
<img width="923" height="144" alt="Screenshot from 2025-10-10 07-48-03" src="https://github.com/user-attachments/assets/57c4f886-395a-4071-b94a-2cfd9be8ae1d" />

Fixes: #2637
