### PR TITLE
feat(ci): Add duplicate site check to validation workflow

### DIFF
--- a/.github/workflows/validate_modified_targets.yml
+++ b/.github/workflows/validate_modified_targets.yml
@@ -87,6 +87,64 @@ jobs:
         run: |
           poetry run pytest tests/test_manifest.py::test_validate_manifest_against_local_schema
 
+      - name: Check for duplicate sites
+        id: check-duplicates
+        if: steps.discover-modified.outputs.changed_targets != ''
+        run: |
+          COMMENT_BODY=$(
+            python - <<'EOF'
+          import json
+          import sys
+          try:
+              with open("data.json.base", "r", encoding="utf-8") as f: base = json.load(f)
+              with open("data.json.head", "r", encoding="utf-8") as f: head = json.load(f)
+          except (FileNotFoundError, json.JSONDecodeError) as e:
+              sys.exit(0)
+
+          base_keys = set(base.keys())
+          head_keys = set(head.keys())
+
+          new_sites = head_keys - base_keys
+
+          if not new_sites:
+              print("##Site Uniqueness Check Passed\n\nNo new sites were added. Skipping duplicate check.")
+              sys.exit(0)
+
+          existing_sites_lower = {k.lower(): k for k in base_keys}
+
+          duplicates = []
+          for site in new_sites:
+              if site.lower() in existing_sites_lower:
+                  original_site_casing = existing_sites_lower[site.lower()]
+                  duplicates.append(f"- Proposed: `{site}` (already exists as `{original_site_casing}`)")
+
+          if duplicates:
+              print("##Duplicate Sites Found\n")
+              print("The following proposed sites appear to be duplicates of existing ones. Site names must be unique (case-insensitive).\n")
+              print("\n".join(sorted(duplicates)))
+              print("\nPlease remove them from your pull request to proceed.")
+          else:
+              print("##Site Uniqueness Check Passed\n")
+              print("All newly proposed sites are unique.")
+          EOF
+          )
+          echo "comment_body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$COMMENT_BODY" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Announce duplicate check results
+        if: steps.check-duplicates.outputs.comment_body != ''
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = `${{ steps.check-duplicates.outputs.comment_body }}`;
+            await github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body,
+            });
+
       # --- The rest of the steps below are unchanged ---
 
       - name: Validate modified targets


### PR DESCRIPTION
## Description

This pull request addresses the need to prevent duplicate site entries from being added to `sherlock/resources/data.json`. The current CI workflow for validating new sites checks for `F+` and `F-` responses but does not verify if a proposed site already exists.

This change introduces a new step into the `validate_modified_targets.yml` GitHub Actions workflow to perform a uniqueness check on newly proposed sites.

### Key Changes:

-   **Added `Check for duplicate sites` step:** A new step is added to the CI workflow that runs when `data.json` is modified.
-   **Case-Insensitive Logic:** The check is case-insensitive to prevent similar entries (e.g., `Github` and `github`).
-   **Focus on New Sites Only:** The logic correctly identifies and checks only *newly added* sites, ignoring modifications to existing ones.
-   **PR Commenting:** The workflow now posts a clear comment on the pull request, immediately notifying the contributor if all new sites are unique or if duplicates were found.

This ensures that all contributions to the site list maintain data integrity and reduces the burden on maintainers to manually check for duplicates.

### How it Works

1.  The workflow compares the `data.json` from the PR (`head`) against the base branch.
2.  A Python script identifies any keys (site names) that are new in the `head` version.
3.  It then checks if these new site names, when converted to lowercase, match any existing site names (also converted to lowercase).
4.  A status comment is posted to the PR. 

### Testing Done

The new workflow logic was tested locally using dummy files to simulate three scenarios:
-   `A pull request with a new, unique site.`
-   `A pull request with a duplicate site (case-insensitive).`
-  `A pull request that only modifies an existing site (no new sites added).`

All local tests passed as expected.

Fixes #2653