### PR TITLE
fix: provided username_unclaimed parameter instead of o…

### DIFF
--- a/sherlock_project/sites.py
+++ b/sherlock_project/sites.py
@@ -56,9 +56,10 @@ class SiteInformation:
         self.url_username_format = url_username_format
 
         self.username_claimed = username_claimed
-        self.username_unclaimed = secrets.token_urlsafe(32)
+        self.username_unclaimed = username_unclaimed or secrets.token_urlsafe(32)
         self.information = information
-        self.is_nsfw  = is_nsfw
+        self.is_nsfw = is_nsfw
+
 
         return
 


### PR DESCRIPTION

Previously, the SiteInformation constructor always replaced the `username_unclaimed` argument with a new random token, even when a valid value was explicitly passed in. This made the parameter effectively unusable and broke the expected behavior described in the docstring.

With this fix, the constructor now respects the provided value, improving reliability, testability, and prevents potential inconsistencies in all username checks.