### PR TITLE
fix:  false positive for hackerearth

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1041,8 +1041,7 @@
     "username_claimed": "blazezaria"
   },
   "HackerEarth": {
-    "errorMsg": "404. URL not found.",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://hackerearth.com/@{}",
     "urlMain": "https://hackerearth.com/",
     "username_claimed": "naveennamani877"


### PR DESCRIPTION
This PR relies on `status_code` check for verifying user identity on HackerEarth.
Fixes: #2642
