### PR TITLE
fix: false positive for Topcoder

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2194,7 +2194,7 @@
     "urlMain": "https://topcoder.com/",
     "username_claimed": "USER",
     "urlProbe": "https://api.topcoder.com/v5/members/{}",
-    "regexCheck": "[a-zA-Z0-9 ]"
+    "regexCheck": "^[a-zA-Z0-9_.]+$"
   },
   "TRAKTRAIN": {
     "errorType": "status_code",


### PR DESCRIPTION
The PR fixes the premature regex check for usernames on Topcoder to allow multiple occurrences of underscores and alphanumeric characters.
Fixes: #2669