### PR TITLE
Add: Cracked.sh

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -584,9 +584,9 @@
     "Cracked Forum": {
     "errorMsg": "The member you specified is either invalid or doesn't exist",
     "errorType": "message",
-    "url": "https://cracked.sh/{}/",
+    "url": "https://cracked.sh/{}",
     "urlMain": "https://cracked.sh/",
-    "username_claimed": "blue"
+    "username_claimed": "Blue"
   },
   "Crevado": {
     "errorType": "status_code",


### PR DESCRIPTION
Add Cracked.sh - a popular skid hacker website

Examples of profiles:

Claimed: https://cracked.sh/Blue - gives status code of 200

Unclaimed: https://cracked.sh/noonewouldeverusethis7 - gives status code of 404

Closes #1438 as moot