### PR TITLE
Add: OGUser.com

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1636,7 +1636,6 @@
    "urlMain": "https://oguser.com",
    "username_claimed": "blue",
    "request_method": "GET"
-}
   },
   "Open Collective": {
     "errorType": "status_code",


### PR DESCRIPTION
Add in OGU aka OGUser Forum - a popular cybercrime forum

https://oguser.com/blue = valid user

https://oguser.com/asdfasdfaaeww = not valid and displays "The member you specified is either invalid or doesn't exist"