### PR TITLE
Fix LessWrong detection Issue #2634

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1371,10 +1371,11 @@
     "username_claimed": "blue"
   },
   "LessWrong": {
-    "errorType": "status_code",
-    "url": "https://www.lesswrong.com/users/@{}",
+    "url": "https://www.lesswrong.com/users/{}",
     "urlMain": "https://www.lesswrong.com/",
-    "username_claimed": "blue"
+    "errorType": "response_url",
+    "errorUrl": "https://www.lesswrong.com/",
+    "username_claimed": "habryka"
   },
   "Letterboxd": {
     "errorMsg": "Sorry, we can\u2019t find the page you\u2019ve requested.",


### PR DESCRIPTION
# Description

This PR fixes false positives for the LessWrong site (Issue [#2634](https://github.com/sherlock-project/sherlock/issues/2634)
).

The previous configuration used "errorType": "status_code", which caused Sherlock to mark non-existent profiles as found because LessWrong returns a 308 Permanent Redirect or generic 200 page even when the user does not exist.

Changes Made

Replaced errorType: "status_code" with errorType: "response_url".

# Testing

✅ habryka → Found
✅ this_user_will_never_exist_123456 → Not Found
✅ Verified locally using Windows PowerShell and Sherlock CLI.


# Related Issue

Fixes #2634
(Addresses “False positive for LessWrong ”)