### PR TITLE
Improved CTRL+C Exiting Speed (From 60s+ to around 15-30s)

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -17,7 +17,6 @@ except ImportError:
     sys.exit(1)
 
 import csv
-import signal
 import pandas as pd
 import os
 import re


### PR DESCRIPTION
Summary
---
The previous sherlock program took 60+ seconds (on my device) to exit with CTRL+C. I implemented a more effective and efficient way of handling CTRL+C that reduced the exiting time to around 15-30 seconds.

Solution
---
sherlock.py previously caught a SIGINT signal and exited gracefully with sys.exit(0) to handle CTRL+C. This method was slow because sys.exit(0) waited for all current and queued worker threads making I/O calls to finish or timeout. Instead, to exit more efficiently, I caught a KeyboardInterrupt exception and called session.shutdown(wait=False, cancel_futures=True) on each individual worker thread. This method is faster because it instructs each worker to terminate immediately after completing its current task (rather than finishing the thread) and cancels all threads in the queue. This drastically reduced the amount of time spent waiting on threads after pressing CTRL+C, allowing the program to exit much more quickly yet still gracefully.

Testing
---
Using a python virtual environment with WSL, I:
- Ran the original program several times with different usernames and pressed CTRL+C, estimating the time it took to exit with a stopwatch. Times were roughly around 60 to 75 seconds.
- Ran the modified program several times with different usernames and pressed CTRL+C, estimating the time it took to exit with a stopwatch. Times were roughly around 15 to 30 seconds.

Type of Change
---
- Optimization
- Hacktoberfest contribution