### PR TITLE
Show closer matches for invalid site names

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -28,6 +28,7 @@ from typing import Optional
 
 import requests
 from requests_futures.sessions import FuturesSession
+from difflib import get_close_matches
 
 from sherlock_project.__init__ import (
     __longname__,
@@ -803,6 +804,12 @@ def main():
 
         if site_missing:
             print(f"Error: Desired sites not found: {', '.join(site_missing)}.")
+            
+            available_site_names =  [site.name for site in sites]
+            for m in site_missing:
+                matches = get_close_matches(m, available_site_names, n = 2, cutoff=0.4)
+                if matches:
+                    print(f"Did you mean: {', '.join(matches)}.")
 
         if not site_data:
             sys.exit(1)


### PR DESCRIPTION
This PR introduces fuzzy match for when a name is unsupported by Sherlock. 
It uses native `difflib` to get the closest two matches to what the user expected.

## Testing
- [x] No automated test
- Manually tested using `code` and `jlfdjfkl`
 
<img width="858" height="92" alt="Screenshot from 2025-10-18 16-16-19" src="https://github.com/user-attachments/assets/e96cd8b6-4fb4-4618-82e3-4492600893e4" />



---
Fixes: #2693