### PR TITLE
Make urls clickable when saved to excel

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -925,8 +925,8 @@ def main():
                 {
                     "username": usernames,
                     "name": names,
-                    "url_main": url_main,
-                    "url_user": url_user,
+                    "url_main": [f'=HYPERLINK(\"{u}\")' for u in url_main],
+                    "url_user": [f'=HYPERLINK(\"{u}\")' for u in url_user],
                     "exists": exists,
                     "http_status": http_status,
                     "response_time_s": response_time_s,


### PR DESCRIPTION
This PR exports the site URLs as hyperlinks in excel instead of plain unclickable strings.

## Testing
- Manually using user `blue`

<img width="1023" height="165" alt="Screenshot from 2025-10-18 16-14-33" src="https://github.com/user-attachments/assets/38f4c306-5c80-433e-a13b-c6bbc21a614c" />
<img width="1023" height="150" alt="Screenshot from 2025-10-18 16-14-20" src="https://github.com/user-attachments/assets/6579cf81-9154-44b3-827e-8615eea8d331" />

---
Fixes: #2692
