### PR TITLE
Add Odysee support

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1321,7 +1321,7 @@
     "username_claimed": "laurent"
   },
   "Jupyter Community Forum": {
-    "errorMsg": "Oops! That page doesn't exist or is private.",
+    "errorMsg": "Oops! That page doesn’t exist or is private.",
     "errorType": "message",
     "url": "https://discourse.jupyter.org/u/{}/summary",
     "urlMain": "https://discourse.jupyter.org",
@@ -1951,7 +1951,7 @@
     "username_claimed": "Blue"
   },
   "Python.org Discussions": {
-    "errorMsg": "Oops! That page doesn't exist or is private.",
+    "errorMsg": "Oops! That page doesn’t exist or is private.",
     "errorType": "message",
     "url": "https://discuss.python.org/u/{}/summary",
     "urlMain": "https://discuss.python.org",
@@ -2060,7 +2060,7 @@
     "username_claimed": "asuna-black"
   },
   "Ruby Forums": {
-    "errorMsg": "Oops! That page doesn't exist or is private.",
+    "errorMsg": "Oops! That page doesn’t exist or is private.",
     "errorType": "message",
     "url": "https://ruby-forum.com/u/{}/summary",
     "urlMain": "https://ruby-forums.com",


### PR DESCRIPTION
- Add Odysee platform to sherlock database- Uses canonical link detection for non-existent users- URL pattern: https://odysee.com/@\{username\}- Detects error via canonical redirect to main site