### PR TITLE
Add Warframe Market support

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -18,14 +18,6 @@
     "urlMain": "https://forums.terraria.org/index.php",
     "username_claimed": "blue"
   },
-  "Warframe Market": {
-  "errorType": "status_code",
-  "request_method": "GET",
-  "url": "https://warframe.market/profile/{}",
-  "urlMain": "https://warframe.market/",
-  "urlProbe": "https://api.warframe.market/v2/user/{}",
-  "username_claimed": "kaiallalone",
-},
   "2Dimensions": {
     "errorType": "status_code",
     "url": "https://2Dimensions.com/a/{}",
@@ -1002,6 +994,14 @@
     "urlMain": "https://www.github.com/",
     "username_claimed": "blue"
   },
+  "Warframe Market": {
+  "errorType": "status_code",
+  "request_method": "GET",
+  "url": "https://warframe.market/profile/{}",
+  "urlMain": "https://warframe.market/",
+  "urlProbe": "https://api.warframe.market/v2/user/{}",
+  "username_claimed": "kaiallalone"
+},
   "GitLab": {
     "errorMsg": "[]",
     "errorType": "message",


### PR DESCRIPTION
# Add Warframe Market support

## Description
This PR adds support for **Warframe Market** username lookups to Sherlock.

[Warframe Market](https://warframe.market/) is a popular peer-to-peer trading platform for the game Warframe, with a large active community of players buying and selling in-game items. Adding this platform enhances Sherlock's coverage of gaming and trading communities.Modt of the players playing the game have their accounts here too.

## Changes
- Added Warframe Market configuration to `sherlock_data.json`
- Uses the official Warframe Market API v2 (`/v2/user/{slug}`) for reliable username verification
- Validates usernames via status code detection

## Testing
Tested with:
- ✅ Valid username: `kaiallalone` (returns 200)
- ✅ Invalid username: returns 404 status code

## Type of Contribution
- [x] New site addition
- [x] Hacktoberfest contribution 🎃

---
**Hacktoberfest 2024**: This contribution is part of Hacktoberfest and adds valuable functionality to help identify user profiles across the gaming community ecosystem.

## Checklist
- [x] Tested with valid usernames
- [x] Tested with invalid usernames
- [x] Follows existing JSON structure in `sherlock_data.json`
- [x] API endpoint is publicly accessible
- [x] No authentication required for username lookup