### PR TITLE
Fix site name formatting for CodeSandbox

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -539,7 +539,7 @@
     "urlMain": "https://coderwall.com",
     "username_claimed": "hacker"
   },
-  "Code Sandbox": {
+  "CodeSandbox": {
     "errorType": "message",
     "errorMsg": "Could not find user with username",
     "regexCheck": "^[a-zA-Z0-9_-]{3,30}$",


### PR DESCRIPTION
Description
---
This PR updates the site name from "Code Sandbox" to "CodeSandbox" in data.json to match the site's actual branding and URL structure. This is a minimal formatting fix that improves consistency across Sherlock’s site list.

Type of Change
---
- [x] Formatting fix
- [x] Hacktoberfest contribution