### PR TITLE
hacktoberfest: Added sites support

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2324,6 +2324,12 @@
     "urlProbe": "https://ch.tetr.io/api/users/{}",
     "username_claimed": "osk"
   },
+  "TheMovieDB": {
+    "errorType": "status_code",
+    "url": "https://www.themoviedb.org/u/{}",
+    "urlMain": "https://www.themoviedb.org/",
+    "username_claimed": "blue"
+  },
   "TikTok": {
     "url": "https://www.tiktok.com/@{}",
     "urlMain": "https://www.tiktok.com",


### PR DESCRIPTION
Added:
1. Arduino Forum (official discussion forum for Arduino users and developers)
2. HackerSploit Forum (cybersecurity learning and discussion community)
3. n8n Community (official forum for n8n automation platform users and contributors)