### PR TITLE
Fix Minor Capitalization Issue in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -124,7 +124,7 @@ Thank you to everyone who has contributed to Sherlock! ❤️
   <img src="https://contrib.rocks/image?&columns=25&max=10000&&repo=sherlock-project/sherlock" alt="contributors"/>
 </a>
 
-## Star history
+## Star History
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=sherlock-project/sherlock&type=Date&theme=dark" />


### PR DESCRIPTION
Corrected capitalization from "Star history" to "Star History" in the README to match the proper name of the tool.