### PR TITLE
feat: add Codolio to supported sites

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -547,6 +547,14 @@
     "urlMain": "https://www.codewars.com",
     "username_claimed": "example"
   },
+  "Codolio": {
+    "errorType": "message",
+    "errorMsg": "<title>Page Not Found | Codolio</title>",
+    "url": "https://codolio.com/profile/{}",
+    "urlMain": "https://codolio.com/",
+    "username_claimed": "testuser",
+    "regexCheck": "^[a-zA-Z0-9_-]{3,30}$"
+  },
   "Coinvote": {
     "errorType": "status_code",
     "url": "https://coinvote.cc/profile/{}",


### PR DESCRIPTION
Add [Codolio](https://codolio.com/) (coding portfolio tracker) as a new site target for username detection.

Detection method: Message-based using title tag differences
- Existing profiles: '<title>Username | Codolio</title>'
- Non-existing profiles: '<title>Page Not Found | Codolio</title>'

Tested with multiple usernames to confirm accurate detection.