### PR TITLE
Remove CodersRank from data.json and add to removed-sites.md (with corrected name)

### DIFF
--- a/docs/removed-sites.md
+++ b/docs/removed-sites.md
@@ -1995,3 +1995,16 @@ __2025-07-06 :__ Site appears to have gone offline in March and hasn't come back
     "username_claimed": "GalaxyRG"
   },
 ```
+
+## CodersRank
+__2025-10-25 :__ Site fails to load all user profiles and only returns negatives
+```json
+  "CodersRank": {
+    "errorMsg": "not a registered member",
+    "errorType": "message",
+    "regexCheck": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$",
+    "url": "https://profile.codersrank.io/user/{}/",
+    "urlMain": "https://codersrank.io/",
+    "username_claimed": "rootkit7628"
+  },
+```

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -518,14 +518,6 @@
     "urlMain": "https://codepen.io/",
     "username_claimed": "blue"
   },
-  "Coders Rank": {
-    "errorMsg": "not a registered member",
-    "errorType": "message",
-    "regexCheck": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$",
-    "url": "https://profile.codersrank.io/user/{}/",
-    "urlMain": "https://codersrank.io/",
-    "username_claimed": "rootkit7628"
-  },
   "Coderwall": {
     "errorType": "status_code",
     "url": "https://coderwall.com/{}",


### PR DESCRIPTION
Summary
---
CodersRank fails to load all user profiles and only returns negatives. I removed CodersRank from data.json and added it to removed-sites.md.

Details
---
- [x] Removed CodersRank from data.json
- [x] Added CodersRank to removed-sites.md
- [x] Fixed minor formatting issue (from "Coders Rank" to "CodersRank")

Tests
---
I visited https://profile.codersrank.io/user/{}/ for several usernames. CodersRank failed to load any of the profiles.

Example error screen:
<img width="1919" height="1140" alt="image" src="https://github.com/user-attachments/assets/98a45ba2-6709-4a3c-845b-e661c8e270c8" />

Usernames tested:
 - [x] username (https://profile.codersrank.io/user/username/)
 - [x] test (https://profile.codersrank.io/user/test/)
 - [x] john_doe (https://profile.codersrank.io/user/john_doe/)
 - [x] hello123 (https://profile.codersrank.io/user/hello123/)
 - [x] asdkfjas332kdfjaskdjfaks112djfkasjdfk (https://profile.codersrank.io/user/asdkfjas332kdfjaskdjfaks112djfkasjdfk/)