### PR TITLE
Remove LinkedIn from site list due to HTTP 999 blocking

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -149,6 +149,12 @@
     "urlProbe": "https://archive.org/details/@{}?noscript=true",
     "username_claimed": "blue"
   },
+  "Arduino Forum": {
+    "errorType": "status_code",
+    "url": "https://forum.arduino.cc/u/{}/summary",
+    "urlMain": "https://forum.arduino.cc/",
+    "username_claimed": "system"
+  },
   "ArtStation": {
     "errorType": "status_code",
     "url": "https://www.artstation.com/{}",
@@ -1123,6 +1129,12 @@
     "urlMain": "https://hackerrank.com/",
     "username_claimed": "satznova"
   },
+  "HackerSploit": {
+    "errorType": "status_code",
+    "url": "https://forum.hackersploit.org/u/{}",
+    "urlMain": "https://forum.hackersploit.org/",
+    "username_claimed": "hackersploit"
+  },
   "HackMD": {
     "errorType": "status_code",
     "url": "https://hackmd.io/@{}",
@@ -1453,14 +1465,7 @@
     "urlMain": "https://lichess.org",
     "username_claimed": "john"
   },
-  "LinkedIn": {
-    "errorType": "status_code",
-    "regexCheck": "^[a-zA-Z0-9]{3,100}$",
-    "request_method": "GET",
-    "url": "https://linkedin.com/in/{}",
-    "urlMain": "https://linkedin.com",
-    "username_claimed": "paulpfeister"
-  },
+
   "Linktree": {
     "errorMsg": "\"statusCode\":404",
     "errorType": "message",
@@ -2354,6 +2359,12 @@
     "urlProbe": "https://ch.tetr.io/api/users/{}",
     "username_claimed": "osk"
   },
+  "TheMovieDB": {
+    "errorType": "status_code",
+    "url": "https://www.themoviedb.org/u/{}",
+    "urlMain": "https://www.themoviedb.org/",
+    "username_claimed": "blue"
+  },
   "TikTok": {
     "url": "https://www.tiktok.com/@{}",
     "urlMain": "https://www.tiktok.com",
@@ -3038,6 +3049,12 @@
     "url": "https://www.nairaland.com/{}",
     "urlMain": "https://www.nairaland.com/",
     "username_claimed": "red"
+  },
+  "n8n Community": {
+    "errorType": "status_code",
+    "url": "https://community.n8n.io/u/{}/summary",
+    "urlMain": "https://community.n8n.io/",
+    "username_claimed": "n8n"
   },
   "nnRU": {
     "errorType": "status_code",


### PR DESCRIPTION
Fixes #2652

LinkedIn consistently blocks automated requests with HTTP 999 error, making it impossible to reliably detect profiles. This PR removes LinkedIn from the site list as discussed in the issue.