### PR TITLE
Fix Minecraft False Positives for Long Usernames

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1551,6 +1551,7 @@
   "Minecraft": {
     "errorMsg": "Couldn't find any profile with name",
     "errorType": "message",
+    "regexCheck": "^.{1,25}$",
     "url": "https://api.mojang.com/users/profiles/minecraft/{}",
     "urlMain": "https://minecraft.net/",
     "username_claimed": "blue"


### PR DESCRIPTION
Problem Overview
---
Minecraft returns false positives for all usernames over 25 characters.

Solution
---
Implement a simple regex check to ensure usernames are 1 to 25 characters long.

Details
---
- The Mojang API website returns a CONSTRAINT_VIOLATION error with message "getProfileName.name: Invalid profile name, getProfileName.name: size must be between 1 and 25"
- data.json checks for message "Couldn't find any profile with name"
- Since the actual message doesn't match the expected message, the condition is not met. Minecraft is not flagged as negative.
- Adding "regexCheck": "^.{1,25}$" prevents usernames over 25 characters from being sent to the website, thus preventing the false positive result.

Testing
---
Before implementing the fix, usernames over 25 characters would be returned as a match for Minecraft. However, clicking the link returned would reveal that the username was invalid.

Example screenshots for 26-character username 01234567890123456789012345
<img width="829" height="552" alt="MC False Positive - VSC" src="https://github.com/user-attachments/assets/8c2e3860-f2c5-45cd-8ef2-765b4faa1a21" />
<img width="1030" height="197" alt="MC False Positive - API" src="https://github.com/user-attachments/assets/80dd578c-2849-47d5-beff-b7cb54266a66" />

I tested and confirmed the false positive result for the following usernames:
- [x] 01234567890123456789012345
- [x] avieaiieaviaseivasiveiavjjvajejaejajsevjajev382823823
- [x] thisisaveryveryveryveryveryveryveryveryveryveryverylongname

After implementing the fix, Minecraft was no longer returned as a result. I tested and confirmed the fix for the following usernames (same set as before):
- [x] 01234567890123456789012345
- [x] avieaiieaviaseivasiveiavjjvajejaejajsevjajev382823823
- [x] thisisaveryveryveryveryveryveryveryveryveryveryverylongname