### PR TITLE
Added Turkish sites: 1000Kitap, Eksi Sozluk, Uludag Sozluk, KizlarSor…

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1,8 +1,7 @@
 {
   "$schema": "data.schema.json",
   "1000Kitap": {
-    "errorType": "message",
-    "errorMsg": "Kay\u0131t bulunamad\u0131.",
+    "errorType": "status_code",
     "url": "https://1000kitap.com/{}",
     "urlMain": "https://1000kitap.com/",
     "username_claimed": "1000Kitap"
@@ -266,8 +265,7 @@
     "username_claimed": "blue"
   },
   "Bionluk": {
-    "errorType": "message",
-    "errorMsg": "Kullan\u0131c\u0131 art\u0131k aktif de\u011fil.",
+    "errorType": "status_code",
     "url": "https://bionluk.com/{}",
     "urlMain": "https://bionluk.com/",
     "username_claimed": "bionluk"
@@ -805,16 +803,6 @@
     "url": "https://community.eintracht.de/fans/{}",
     "urlMain": "https://community.eintracht.de/",
     "username_claimed": "mmammu"
-  },
-  "EksiSozluk": {
-    "errorType": "message",
-    "errorMsg": "b\u00f6yle bir yazar yok",
-    "url": "https://eksisozluk.com/biri/{}",
-    "urlMain": "https://eksisozluk.com/",
-    "headers": {
-      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    },
-    "username_claimed": "ssg"
   },
   "Empretienda AR": {
     "__comment__": "Note that Error Connecting responses may be indicative of unclaimed handles",
@@ -1421,16 +1409,6 @@
     "urlMain": "http://kik.me/",
     "urlProbe": "https://ws2.kik.com/user/{}",
     "username_claimed": "blue"
-  },
-  "KizlarSoruyor": {
-    "errorType": "message",
-    "errorMsg": "Sayfa bulunamad\u0131, \u00f6z\u00fcr dileriz.",
-    "url": "https://www.kizlarsoruyor.com/uye/{}",
-    "urlMain": "https://www.kizlarsoruyor.com/",
-    "headers": {
-      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    },
-    "username_claimed": "ksbence"
   },
   "Kongregate": {
     "errorType": "status_code",
@@ -2635,16 +2613,6 @@
     "url": "https://ultimate-guitar.com/u/{}",
     "urlMain": "https://ultimate-guitar.com/",
     "username_claimed": "blue"
-  },
-  "UludagSozluk": {
-    "errorType": "message",
-    "errorMsg": "The requested URL was not found on this server.",
-    "url": "https://www.uludagsozluk.com/yazar/{}",
-    "urlMain": "https://www.uludagsozluk.com/",
-    "headers": {
-      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    },
-    "username_claimed": "zall"
   },
   "Unsplash": {
     "errorType": "status_code",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -4,6 +4,9 @@
     "errorType": "status_code",
     "url": "https://1000kitap.com/{}",
     "urlMain": "https://1000kitap.com/",
+    "headers": {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+    },
     "username_claimed": "1000Kitap"
   },
   "1337x": {
@@ -265,9 +268,13 @@
     "username_claimed": "blue"
   },
   "Bionluk": {
-    "errorType": "status_code",
+    "errorType": "message",
+    "errorMsg": "Yetenekli Freelancer Platformu | Bionluk",
     "url": "https://bionluk.com/{}",
     "urlMain": "https://bionluk.com/",
+    "headers": {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+    },
     "username_claimed": "bionluk"
   },
   "BitBucket": {

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2,7 +2,7 @@
   "$schema": "data.schema.json",
   "1000Kitap": {
     "errorType": "message",
-    "errorMsg": "Kayıt bulunamadı.",
+    "errorMsg": "Kay\u0131t bulunamad\u0131.",
     "url": "https://1000kitap.com/{}",
     "urlMain": "https://1000kitap.com/",
     "username_claimed": "1000Kitap"
@@ -267,7 +267,7 @@
   },
   "Bionluk": {
     "errorType": "message",
-    "errorMsg": "Kullanıcı artık aktif değil.",
+    "errorMsg": "Kullan\u0131c\u0131 art\u0131k aktif de\u011fil.",
     "url": "https://bionluk.com/{}",
     "urlMain": "https://bionluk.com/",
     "username_claimed": "bionluk"
@@ -808,7 +808,7 @@
   },
   "EksiSozluk": {
     "errorType": "message",
-    "errorMsg": "böyle bir kullanıcı yok",
+    "errorMsg": "b\u00f6yle bir kullan\u0131c\u0131 yok",
     "url": "https://eksisozluk.com/biri/{}",
     "urlMain": "https://eksisozluk.com/",
     "headers": {
@@ -1425,7 +1425,7 @@
   },
   "KizlarSoruyor": {
     "errorType": "message",
-    "errorMsg": "Böyle Bir Üye Yok",
+    "errorMsg": "B\u00f6yle Bir \u00dcye Yok",
     "url": "https://www.kizlarsoruyor.com/uye/{}",
     "urlMain": "https://www.kizlarsoruyor.com/",
     "headers": {
@@ -2640,7 +2640,7 @@
   },
   "UludagSozluk": {
     "errorType": "message",
-    "errorMsg": "böyle bir yazar yok",
+    "errorMsg": "b\u00f6yle bir yazar yok",
     "url": "https://www.uludagsozluk.com/yazar/{}",
     "urlMain": "https://www.uludagsozluk.com/",
     "headers": {

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -808,10 +808,14 @@
   },
   "EksiSozluk": {
     "errorType": "message",
-    "errorMsg": "böyle bir yazar yok",
+    "errorMsg": "böyle bir kullanıcı yok",
     "url": "https://eksisozluk.com/biri/{}",
     "urlMain": "https://eksisozluk.com/",
-    "username_claimed": "ssg"
+    "headers": {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    },
+    "username_claimed": "ssg",
+    "username_unclaimed": "bu-kullanici-yok-12345"
   },
   "Empretienda AR": {
     "__comment__": "Note that Error Connecting responses may be indicative of unclaimed handles",
@@ -1421,10 +1425,14 @@
   },
   "KizlarSoruyor": {
     "errorType": "message",
-    "errorMsg": "Sayfa bulunamadı, özür dileriz",
+    "errorMsg": "Böyle Bir Üye Yok",
     "url": "https://www.kizlarsoruyor.com/uye/{}",
     "urlMain": "https://www.kizlarsoruyor.com/",
-    "username_claimed": "ksbence"
+    "headers": {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    },
+    "username_claimed": "ksbence",
+    "username_unclaimed": "bu-kullanici-yok-123456"
   },
   "Kongregate": {
     "errorType": "status_code",
@@ -2631,10 +2639,15 @@
     "username_claimed": "blue"
   },
   "UludagSozluk": {
-    "errorType": "status_code",
+    "errorType": "message",
+    "errorMsg": "böyle bir yazar yok",
     "url": "https://www.uludagsozluk.com/yazar/{}",
     "urlMain": "https://www.uludagsozluk.com/",
-    "username_claimed": "zall"
+    "headers": {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    },
+    "username_claimed": "zall",
+    "username_unclaimed": "bu-kullanici-yok-123456"
   },
   "Unsplash": {
     "errorType": "status_code",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -808,14 +808,13 @@
   },
   "EksiSozluk": {
     "errorType": "message",
-    "errorMsg": "b\u00f6yle bir kullan\u0131c\u0131 yok",
+    "errorMsg": "b\u00f6yle bir yazar yok",
     "url": "https://eksisozluk.com/biri/{}",
     "urlMain": "https://eksisozluk.com/",
     "headers": {
       "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     },
-    "username_claimed": "ssg",
-    "username_unclaimed": "bu-kullanici-yok-12345"
+    "username_claimed": "ssg"
   },
   "Empretienda AR": {
     "__comment__": "Note that Error Connecting responses may be indicative of unclaimed handles",
@@ -1425,14 +1424,13 @@
   },
   "KizlarSoruyor": {
     "errorType": "message",
-    "errorMsg": "B\u00f6yle Bir \u00dcye Yok",
+    "errorMsg": "Sayfa bulunamad\u0131, \u00f6z\u00fcr dileriz.",
     "url": "https://www.kizlarsoruyor.com/uye/{}",
     "urlMain": "https://www.kizlarsoruyor.com/",
     "headers": {
       "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     },
-    "username_claimed": "ksbence",
-    "username_unclaimed": "bu-kullanici-yok-123456"
+    "username_claimed": "ksbence"
   },
   "Kongregate": {
     "errorType": "status_code",
@@ -2640,14 +2638,13 @@
   },
   "UludagSozluk": {
     "errorType": "message",
-    "errorMsg": "b\u00f6yle bir yazar yok",
+    "errorMsg": "The requested URL was not found on this server.",
     "url": "https://www.uludagsozluk.com/yazar/{}",
     "urlMain": "https://www.uludagsozluk.com/",
     "headers": {
       "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     },
-    "username_claimed": "zall",
-    "username_unclaimed": "bu-kullanici-yok-123456"
+    "username_claimed": "zall"
   },
   "Unsplash": {
     "errorType": "status_code",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1,5 +1,12 @@
 {
   "$schema": "data.schema.json",
+  "1000Kitap": {
+    "errorType": "message",
+    "errorMsg": "Kayıt bulunamadı.",
+    "url": "https://1000kitap.com/{}",
+    "urlMain": "https://1000kitap.com/",
+    "username_claimed": "1000Kitap"
+  },
   "1337x": {
     "errorMsg": [
       "<title>Error something went wrong.</title>",
@@ -257,6 +264,13 @@
     "url": "https://forum.dangerousthings.com/u/{}",
     "urlMain": "https://forum.dangerousthings.com/",
     "username_claimed": "blue"
+  },
+  "Bionluk": {
+    "errorType": "message",
+    "errorMsg": "Kullanıcı artık aktif değil.",
+    "url": "https://bionluk.com/{}",
+    "urlMain": "https://bionluk.com/",
+    "username_claimed": "bionluk"
   },
   "BitBucket": {
     "errorType": "status_code",
@@ -791,6 +805,13 @@
     "url": "https://community.eintracht.de/fans/{}",
     "urlMain": "https://community.eintracht.de/",
     "username_claimed": "mmammu"
+  },
+  "EksiSozluk": {
+    "errorType": "message",
+    "errorMsg": "böyle bir yazar yok",
+    "url": "https://eksisozluk.com/biri/{}",
+    "urlMain": "https://eksisozluk.com/",
+    "username_claimed": "ssg"
   },
   "Empretienda AR": {
     "__comment__": "Note that Error Connecting responses may be indicative of unclaimed handles",
@@ -1397,6 +1418,13 @@
     "urlMain": "http://kik.me/",
     "urlProbe": "https://ws2.kik.com/user/{}",
     "username_claimed": "blue"
+  },
+  "KizlarSoruyor": {
+    "errorType": "message",
+    "errorMsg": "Sayfa bulunamadı, özür dileriz",
+    "url": "https://www.kizlarsoruyor.com/uye/{}",
+    "urlMain": "https://www.kizlarsoruyor.com/",
+    "username_claimed": "ksbence"
   },
   "Kongregate": {
     "errorType": "status_code",
@@ -2601,6 +2629,12 @@
     "url": "https://ultimate-guitar.com/u/{}",
     "urlMain": "https://ultimate-guitar.com/",
     "username_claimed": "blue"
+  },
+  "UludagSozluk": {
+    "errorType": "status_code",
+    "url": "https://www.uludagsozluk.com/yazar/{}",
+    "urlMain": "https://www.uludagsozluk.com/",
+    "username_claimed": "zall"
   },
   "Unsplash": {
     "errorType": "status_code",


### PR DESCRIPTION
Hi team,

I have added support for popular Turkish social media and community platforms to expand Sherlock's coverage in this region.

**Added Sites:**
- **1000Kitap:** A popular book tracking and review community.
- **Ekşi Sözlük:** One of the largest collaborative dictionaries/communities in Turkey.
- **Uludağ Sözlük:** Another major community dictionary platform.
- **KizlarSoruyor:** A popular Q&A community platform.
- **Bionluk:** A freelance services marketplace.

**Testing:**
I have locally tested all added sites using `data.json` with known valid usernames (e.g., official accounts or founders like `zall`, `ssg`, `ksbence`). All sites returned positive results (`[+] Found`) and valid profile URLs.

Thank you!

<img width="1060" height="1132" alt="TerminalSS" src="https://github.com/user-attachments/assets/f210f904-6e32-4598-805e-12aadbec658b" />
