### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/exclusions.yml
+++ b/.github/workflows/exclusions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -30,9 +30,9 @@ jobs:
     # Linting is ran through tox to ensure that the same linter
     # is used by local runners
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up linting environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install tox and related dependencies
@@ -59,9 +59,9 @@ jobs:
           '3.13',
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up environment ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox and related dependencies
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Get version from pyproject.toml

--- a/.github/workflows/update-site-list.yml
+++ b/.github/workflows/update-site-list.yml
@@ -17,14 +17,14 @@ jobs:
     steps:
       # Check out the code at the specified pull request head commit
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       # Install Python 3
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/validate_modified_targets.yml
+++ b/.github/workflows/validate_modified_targets.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # Checkout the base branch but fetch all history to avoid a second fetch call
           ref: ${{ github.base_ref }}


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/update-site-list.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/regression.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/validate_modified_targets.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/exclusions.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/regression.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/update-site-list.yml`
