### PR TITLE
Add Lemon8 to supported sites

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1441,6 +1441,13 @@
     "urlMain": "https://lemmy.world",
     "username_claimed": "blue"
   },
+    "Lemon8": {
+    "errorType": "status_code",
+    "regexCheck": "^[a-zA-Z0-9._-]{2,30}$",
+    "url": "https://www.lemon8-app.com/@{}",
+    "urlMain": "https://www.lemon8-app.com/",
+    "username_claimed": "luniaa_0"
+  },
   "LessWrong": {
     "url": "https://www.lesswrong.com/users/{}",
     "urlMain": "https://www.lesswrong.com/",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1441,8 +1441,11 @@
     "urlMain": "https://lemmy.world",
     "username_claimed": "blue"
   },
-    "Lemon8": {
+     "Lemon8": {
     "errorType": "status_code",
+    "headers": {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+    },
     "regexCheck": "^[a-zA-Z0-9._-]{2,30}$",
     "url": "https://www.lemon8-app.com/@{}",
     "urlMain": "https://www.lemon8-app.com/",


### PR DESCRIPTION
## Description
Added Lemon8 to the supported sites list. Lemon8 is a growing lifestyle social media platform by ByteDance.

## Checklist
- [x] The site is not already in `data.json`.
- [x] The site is not a duplicate of another site.
- [x] The `url` and `urlMain` are correct.
- [x] The `errorType` is correctly identified (status_code).
- [x] A `username_claimed` is provided for testing.
- [x] The `regexCheck` is accurate for the platform's username rules.

## Testing
- Verified with existing user: `luniaa_0`
- Verified with non-existent user: `non_existent_user_123456789`
