### PR TITLE
data: add Wowhead, Wago addons, CurseForge

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -3253,5 +3253,26 @@
       "\u0414\u043e\u0441\u0442\u0443\u043f \u0441 \u0432\u0430\u0448\u0435\u0433\u043e IP-\u0430\u0434\u0440\u0435\u0441\u0430 \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u043e \u043e\u0433\u0440\u0430\u043d\u0438\u0447\u0435\u043d"
     ],
     "username_claimed": "example"
+  },
+  "Wowhead": {
+    "url": "https://wowhead.com/user={}",
+    "urlMain": "https://wowhead.com/",
+    "errorType": "status_code",
+    "errorCode": 404,
+    "username_claimed": "blue"
+  },
+  "addons.wago.io": {
+    "url": "https://addons.wago.io/user/{}",
+    "urlMain": "https://addons.wago.io/",
+    "errorType": "status_code",
+    "errorCode": 404,
+    "username_claimed": "blue"
+  },
+  "CurseForge": {
+    "url": "https://www.curseforge.com/members/{}/projects",
+    "urlMain": "https://www.curseforge.com.",
+    "errorType": "status_code",
+    "errorCode": 404,
+    "username_claimed": "blue"
   }
 }


### PR DESCRIPTION
hello! this PR adds a few wow related sites: wowhead.com, addons.wago.io and curseforge.com! all respond with a 404 status if a username is not found