### PR TITLE
fix: XLSX response_time variable collision, folderoutput support, and notify counter

### DIFF
--- a/sherlock_project/notify.py
+++ b/sherlock_project/notify.py
@@ -7,8 +7,7 @@ from sherlock_project.result import QueryStatus
 from colorama import Fore, Style
 import webbrowser
 
-# Global variable to count the number of results.
-globvar = 0
+
 
 
 class QueryNotify:
@@ -136,6 +135,7 @@ class QueryNotifyPrint(QueryNotify):
         self.verbose = verbose
         self.print_all = print_all
         self.browse = browse
+        self.result_count = 0
 
         return
 
@@ -175,9 +175,8 @@ class QueryNotifyPrint(QueryNotify):
         Return Value:
         The number of results by the time we call the function.
         """
-        global globvar
-        globvar += 1
-        return globvar
+        self.result_count += 1
+        return self.result_count
 
     def update(self, result):
         """Notify Update.
@@ -270,7 +269,7 @@ class QueryNotifyPrint(QueryNotify):
         print(Style.BRIGHT + Fore.GREEN + "[" +
               Fore.YELLOW + "*" +
               Fore.GREEN + "] Search completed with" +
-              Fore.WHITE + f" {NumberOfResults} " +
+              Fore.WHITE + f" {self.result_count} " +
               Fore.GREEN + "results" + Style.RESET_ALL
               )
 

--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -910,10 +910,11 @@ def main():
                 ):
                     continue
 
-                if response_time_s is None:
+                query_time = results[site]["status"].query_time
+                if query_time is None:
                     response_time_s.append("")
                 else:
-                    response_time_s.append(results[site]["status"].query_time)
+                    response_time_s.append(query_time)
                 usernames.append(username)
                 names.append(site)
                 url_main.append(results[site]["url_main"])
@@ -932,7 +933,11 @@ def main():
                     "response_time_s": response_time_s,
                 }
             )
-            DataFrame.to_excel(f"{username}.xlsx", sheet_name="sheet1", index=False)
+            xlsx_file = f"{username}.xlsx"
+            if args.folderoutput:
+                os.makedirs(args.folderoutput, exist_ok=True)
+                xlsx_file = os.path.join(args.folderoutput, xlsx_file)
+            DataFrame.to_excel(xlsx_file, sheet_name="sheet1", index=False)
 
         print()
     query_notify.finish()


### PR DESCRIPTION
## Summary

Fixes three bugs found during code review:

### Bug 1: XLSX `response_time_s` variable collision (sherlock.py:913)

`response_time_s` is initialized as `[]` on line 903, then checked
with `is None` on line 913. A list is never `None`, so the condition
is dead code — `None` query times get appended as-is instead of
being converted to empty strings.

This matches the pattern already used in CSV output (line 882-884).

### Bug 2: XLSX ignores `--folderoutput` flag (sherlock.py:935)

CSV output correctly respects `--folderoutput` (lines 856-859),
but XLSX always writes to the current directory. Added the same
folder handling logic.

### Bug 3: Global mutable counter in notify.py

`globvar` is a module-level global that persists across multiple
username scans. Combined with `finish()` calling `countResults()`
(which increments) then subtracting 1, the reported count can be
wrong on multi-username runs. Replaced with an instance variable
on `QueryNotifyPrint`.