### PR TITLE
fix: allow uppercase letters in Chess.com username regex

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -447,7 +447,7 @@
   "Chess": {
     "errorMsg": "Username is valid",
     "errorType": "message",
-    "regexCheck": "^[a-z1-9]{3,25}$",
+    "regexCheck": "^[a-zA-Z0-9_]{3,25}$",
     "url": "https://www.chess.com/member/{}",
     "urlMain": "https://www.chess.com/",
     "urlProbe": "https://www.chess.com/callback/user/valid?username={}",


### PR DESCRIPTION
Fixes #2799

The `regexCheck` for Chess was `^[a-z1-9]{3,25}$`, which rejects any username containing uppercase letters (e.g., "SuperStar9389"). Chess.com usernames are case-insensitive and can contain uppercase letters, digits, and underscores.

Updated the regex to `^[a-zA-Z0-9_]{3,25}$` to match the actual Chess.com username rules.

**Before:** `sherlock SuperStar9389 --site Chess` → no results (rejected by regex)
**After:** `sherlock SuperStar9389 --site Chess` → correctly finds the profile

> This PR was created with AI assistance. Happy to make any adjustments!