### PR TITLE
Fix UnicodeDecodeError crash when handling redirects with non-UTF-8 encoding

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -133,6 +133,9 @@ def get_response(request_future, error_type, social_network):
     except requests.exceptions.Timeout as errt:
         error_context = "Timeout Error"
         exception_text = str(errt)
+    except UnicodeDecodeError as erru:
+        error_context = "Encoding Error"
+        exception_text = str(erru)
     except requests.exceptions.RequestException as err:
         error_context = "Unknown Error"
         exception_text = str(err)


### PR DESCRIPTION
Fixes #2730. When scanning usernames with special characters, some servers send redirect URLs with non-UTF-8 encoding. The requests library raises UnicodeDecodeError during redirect handling, which was not caught by the existing exception handlers. Added a specific handler for UnicodeDecodeError to treat it as a connection error, allowing the scan to continue gracefully.