### PR TITLE
Fix UnicodeDecodeError crash with special characters in usernames

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -133,6 +133,9 @@ def get_response(request_future, error_type, social_network):
     except requests.exceptions.Timeout as errt:
         error_context = "Timeout Error"
         exception_text = str(errt)
+    except UnicodeDecodeError as erru:
+        error_context = "Encoding Error"
+        exception_text = str(erru)
     except requests.exceptions.RequestException as err:
         error_context = "Unknown Error"
         exception_text = str(err)


### PR DESCRIPTION
Fixes #2730. The UnicodeDecodeError is raised by the requests library during redirect handling when a server returns a URL with invalid encoding. This exception was not caught in the get_response function, causing the entire program to crash. Added UnicodeDecodeError to the exception handlers to properly catch and report this error.