### PR TITLE
fix: bypass LinkedIn WAF blocking requests (HTTP 999)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1471,8 +1471,13 @@
     "urlMain": "https://lichess.org",
     "username_claimed": "john"
   },
-  "LinkedIn": {
+ "LinkedIn": {
     "errorType": "status_code",
+    "headers": {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      "Accept-Language": "en-US,en;q=0.9",
+      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+    },
     "regexCheck": "^[a-zA-Z0-9]{3,100}$",
     "request_method": "GET",
     "url": "https://linkedin.com/in/{}",


### PR DESCRIPTION
## What does this PR do?
Fixes a false negative where LinkedIn profile checks were returning an HTTP 999 Request Denied error due to WAF blocking the default python-requests User-Agent.

## How was this fixed?
Injected standard modern browser headers (Chrome/Windows) into the LinkedIn configuration block in `data.json` to bypass the basic bot detection.

## Testing
Tested locally using `--local --site LinkedIn [username]`. The request now successfully bypasses the WAF and returns a 200 OK with the correct profile URL.

Fixes #2652