### PR TITLE
fix: replace mutable default arguments and fix username_unclaimed assignment in sites.py

### DIFF
--- a/sherlock_project/sites.py
+++ b/sherlock_project/sites.py
@@ -13,7 +13,9 @@ EXCLUSIONS_URL = "https://raw.githubusercontent.com/sherlock-project/sherlock/re
 
 class SiteInformation:
     def __init__(self, name, url_home, url_username_format, username_claimed,
-                information, is_nsfw, username_unclaimed=secrets.token_urlsafe(10)):
+            information, is_nsfw, username_unclaimed=None):
+        if username_unclaimed is None:
+            username_unclaimed = secrets.token_urlsafe(10)
         """Create Site Information Object.
 
         Contains information about a specific website.
@@ -56,7 +58,7 @@ class SiteInformation:
         self.url_username_format = url_username_format
 
         self.username_claimed = username_claimed
-        self.username_unclaimed = secrets.token_urlsafe(32)
+        self.username_unclaimed = username_unclaimed
         self.information = information
         self.is_nsfw  = is_nsfw
 
@@ -77,11 +79,14 @@ class SiteInformation:
 
 class SitesInformation:
     def __init__(
-            self,
-            data_file_path: str|None = None,
-            honor_exclusions: bool = True,
-            do_not_exclude: list[str] = [],
-        ):
+        self,
+        data_file_path: str|None = None,
+        honor_exclusions: bool = True,
+        do_not_exclude: list[str] | None = None,
+    ):
+        if do_not_exclude is None:
+            do_not_exclude = []
+            
         """Create Sites Information Object.
 
         Contains information about all supported websites.
@@ -210,16 +215,16 @@ class SitesInformation:
 
         return
 
-    def remove_nsfw_sites(self, do_not_remove: list = []):
+    def remove_nsfw_sites(self, do_not_remove: list | None = None):
         """
         Remove NSFW sites from the sites, if isNSFW flag is true for site
-
         Keyword Arguments:
         self                   -- This object.
-
         Return Value:
         None
         """
+        if do_not_remove is None:
+            do_not_remove = []
         sites = {}
         do_not_remove = [site.casefold() for site in do_not_remove]
         for site in self.sites:


### PR DESCRIPTION
## Summary
This PR fixes 4 bugs in `sherlock_project/sites.py` related to
mutable default arguments and incorrect parameter assignment.

## Changes

### Bug 1 — `username_unclaimed` parameter silently overwritten
`SiteInformation.__init__` accepted `username_unclaimed` as a parameter
but immediately overwrote it with a new random token, meaning the
values defined in `data.json` were never actually used.

**Fix:** `self.username_unclaimed = username_unclaimed`

---

### Bug 2 — Default argument evaluated once at import time
`username_unclaimed=secrets.token_urlsafe(10)` in the function
signature is evaluated once when the module loads, so every
instance that relies on the default gets the exact same token.

**Fix:** Changed default to `None` and generate the token inside
the function body so it's unique per call.

---

### Bug 3 — Mutable default `[]` in `SitesInformation.__init__`
`do_not_exclude: list[str] = []` shares the same list object
across all callers that don't pass their own value. Mutations
would persist across calls.

**Fix:** Changed default to `None`, initialized to `[]` inside
the function body.

---

### Bug 4 — Mutable default `[]` in `remove_nsfw_sites`
Same issue as Bug 3 in a different method.

**Fix:** Changed default to `None`, initialized to `[]` inside
the function body.

## Files Changed
- `sherlock_project/sites.py`