### PR TITLE
fix: handle result file write errors gracefully with clear user message

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -835,7 +835,14 @@ def main():
         elif args.folderoutput:
             # The usernames results should be stored in a targeted folder.
             # If the folder doesn't exist, create it first
-            os.makedirs(args.folderoutput, exist_ok=True)
+            try:
+                os.makedirs(args.folderoutput, exist_ok=True)
+            except OSError as err:
+                print(f"ERROR: Could not create output folder '{args.folderoutput}': {err}. Please ensure you are running in a directory with write permission.")
+                if args.verbose:
+                    import traceback
+                    traceback.print_exc()
+                continue  # skip this username
             result_file = os.path.join(args.folderoutput, f"{username}.txt")
         else:
             result_file = f"{username}.txt"
@@ -860,10 +867,17 @@ def main():
         if args.csv:
     result_file = f"{username}.csv"
     if args.folderoutput:
-        # The usernames results should be stored in a targeted folder.
-        # If the folder doesn't exist, create it first
+    # The usernames results should be stored in a targeted folder.
+    # If the folder doesn't exist, create it first
+    try:
         os.makedirs(args.folderoutput, exist_ok=True)
-        result_file = os.path.join(args.folderoutput, result_file)
+    except OSError as err:
+        print(f"ERROR: Could not create output folder '{args.folderoutput}': {err}. Please ensure you are running in a directory with write permission.")
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+        continue  # skip this username/output
+    result_file = os.path.join(args.folderoutput, result_file)
 
     try:
         with open(result_file, "w", newline="", encoding="utf-8") as csv_report:

--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -841,67 +841,42 @@ def main():
             result_file = f"{username}.txt"
 
         if args.output_txt:
-            with open(result_file, "w", encoding="utf-8") as file:
-                exists_counter = 0
-                for website_name in results:
-                    dictionary = results[website_name]
-                    if dictionary.get("status").status == QueryStatus.CLAIMED:
-                        exists_counter += 1
-                        file.write(dictionary["url_user"] + "\n")
-                file.write(f"Total Websites Username Detected On : {exists_counter}\n")
+    try:
+        with open(result_file, "w", encoding="utf-8") as file:
+            exists_counter = 0
+            for website_name in results:
+                dictionary = results[website_name]
+                if dictionary.get("status").status == QueryStatus.CLAIMED:
+                    exists_counter += 1
+                    file.write(dictionary["url_user"] + "\n")
+            file.write(f"Total Websites Username Detected On : {exists_counter}\n")
+    except OSError as err:
+        print(f"ERROR: Could not write result file '{result_file}': {err}. Please ensure you are running in a directory with write permission.")
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+    # Do not use continue since not in loop, just proceed.
 
         if args.csv:
-            result_file = f"{username}.csv"
-            if args.folderoutput:
-                # The usernames results should be stored in a targeted folder.
-                # If the folder doesn't exist, create it first
-                os.makedirs(args.folderoutput, exist_ok=True)
-                result_file = os.path.join(args.folderoutput, result_file)
+    result_file = f"{username}.csv"
+    if args.folderoutput:
+        # The usernames results should be stored in a targeted folder.
+        # If the folder doesn't exist, create it first
+        os.makedirs(args.folderoutput, exist_ok=True)
+        result_file = os.path.join(args.folderoutput, result_file)
 
-            with open(result_file, "w", newline="", encoding="utf-8") as csv_report:
-                writer = csv.writer(csv_report)
-                writer.writerow(
-                    [
-                        "username",
-                        "name",
-                        "url_main",
-                        "url_user",
-                        "exists",
-                        "http_status",
-                        "response_time_s",
-                    ]
-                )
-                for site in results:
-                    if (
-                        args.print_found
-                        and not args.print_all
-                        and results[site]["status"].status != QueryStatus.CLAIMED
-                    ):
-                        continue
-
-                    response_time_s = results[site]["status"].query_time
-                    if response_time_s is None:
-                        response_time_s = ""
-                    writer.writerow(
-                        [
-                            username,
-                            site,
-                            results[site]["url_main"],
-                            results[site]["url_user"],
-                            str(results[site]["status"].status),
-                            results[site]["http_status"],
-                            response_time_s,
-                        ]
-                    )
-        if args.xlsx:
-            usernames = []
-            names = []
-            url_main = []
-            url_user = []
-            exists = []
-            http_status = []
-            response_time_s = []
-
+    try:
+        with open(result_file, "w", newline="", encoding="utf-8") as csv_report:
+            writer = csv.writer(csv_report)
+            writer.writerow([
+                "username",
+                "name",
+                "url_main",
+                "url_user",
+                "exists",
+                "http_status",
+                "response_time_s",
+            ])
             for site in results:
                 if (
                     args.print_found
@@ -910,29 +885,69 @@ def main():
                 ):
                     continue
 
+                response_time_s = results[site]["status"].query_time
                 if response_time_s is None:
-                    response_time_s.append("")
-                else:
-                    response_time_s.append(results[site]["status"].query_time)
-                usernames.append(username)
-                names.append(site)
-                url_main.append(results[site]["url_main"])
-                url_user.append(results[site]["url_user"])
-                exists.append(str(results[site]["status"].status))
-                http_status.append(results[site]["http_status"])
+                    response_time_s = ""
+                writer.writerow([
+                    username,
+                    site,
+                    results[site]["url_main"],
+                    results[site]["url_user"],
+                    str(results[site]["status"].status),
+                    results[site]["http_status"],
+                    response_time_s,
+                ])
+    except OSError as err:
+        print(f"ERROR: Could not write result file '{result_file}': {err}. Please ensure you are running in a directory with write permission.")
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+if args.xlsx:
+    usernames = []
+    names = []
+    url_main = []
+    url_user = []
+    exists = []
+    http_status = []
+    response_time_s = []
 
-            DataFrame = pd.DataFrame(
-                {
-                    "username": usernames,
-                    "name": names,
-                    "url_main": [f'=HYPERLINK(\"{u}\")' for u in url_main],
-                    "url_user": [f'=HYPERLINK(\"{u}\")' for u in url_user],
-                    "exists": exists,
-                    "http_status": http_status,
-                    "response_time_s": response_time_s,
-                }
-            )
-            DataFrame.to_excel(f"{username}.xlsx", sheet_name="sheet1", index=False)
+    for site in results:
+        if (
+            args.print_found
+            and not args.print_all
+            and results[site]["status"].status != QueryStatus.CLAIMED
+        ):
+            continue
+
+        if response_time_s is None:
+            response_time_s.append("")
+        else:
+            response_time_s.append(results[site]["status"].query_time)
+        usernames.append(username)
+        names.append(site)
+        url_main.append(results[site]["url_main"])
+        url_user.append(results[site]["url_user"])
+        exists.append(str(results[site]["status"].status))
+        http_status.append(results[site]["http_status"])
+
+    DataFrame = pd.DataFrame(
+        {
+            "username": usernames,
+            "name": names,
+            "url_main": [f'=HYPERLINK("{u}")' for u in url_main],
+            "url_user": [f'=HYPERLINK("{u}")' for u in url_user],
+            "exists": exists,
+            "http_status": http_status,
+            "response_time_s": response_time_s,
+        }
+    )
+    try:
+        DataFrame.to_excel(f"{username}.xlsx", sheet_name="sheet1", index=False)
+    except OSError as err:
+        print(f"ERROR: Could not write result file '{username}.xlsx': {err}. Please ensure you are running in a directory with write permission.")
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
 
         print()
     query_notify.finish()


### PR DESCRIPTION
Wrap all output file writes in sherlock.py (TXT, CSV, XLSX) with try/except for OSError. If a write fails, print a clear actionable message describing the permissions issue and how to fix it. Suppress the stack trace unless verbose mode is enabled.