### PR TITLE
Fix: False positive for Cracked.sh (#2818)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -596,9 +596,9 @@
   },
   "Cracked": {
     "errorType": "message",
-    "errorMsg": "https://www.cracked.com/",
-    "url": "https://www.cracked.com/members/{}",
-    "urlMain": "https://www.cracked.com/",
+    "errorMsg": "404 Not Found",
+    "url": "https://www.cracked.sh/user/{}",
+    "urlMain": "https://www.cracked.sh/",
     "username_claimed": "blue"
   },
   "Cracked Forum": {

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -596,8 +596,8 @@
   },
   "Cracked": {
     "errorType": "message",
-    "errorMsg": "404 Not Found",
-    "url": "https://www.cracked.com/user/{}",
+    "errorMsg": "https://www.cracked.com/",
+    "url": "https://www.cracked.com/members/{}",
     "urlMain": "https://www.cracked.com/",
     "username_claimed": "blue"
   },

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -602,8 +602,7 @@
     "username_claimed": "blue"
   },
   "Cracked.sh": {
-    "errorMsg": "404 Not Found",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://cracked.sh/user/{}",
     "urlMain": "https://cracked.sh/",
     "username_claimed": "admin"

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -595,11 +595,18 @@
     "username_claimed": "mbozzi"
   },
   "Cracked": {
-    "errorType": "message",
-    "errorMsg": "404 Not Found",
-    "url": "https://www.cracked.sh/user/{}",
-    "urlMain": "https://www.cracked.sh/",
+    "errorType": "response_url",
+    "errorUrl": "https://www.cracked.com/",
+    "url": "https://www.cracked.com/members/{}/",
+    "urlMain": "https://www.cracked.com/",
     "username_claimed": "blue"
+  },
+  "Cracked.sh": {
+    "errorMsg": "404 Not Found",
+    "errorType": "message",
+    "url": "https://cracked.sh/user/{}",
+    "urlMain": "https://cracked.sh/",
+    "username_claimed": "admin"
   },
   "Cracked Forum": {
     "errorMsg": "The member you specified is either invalid or doesn't exist",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -595,9 +595,9 @@
     "username_claimed": "mbozzi"
   },
   "Cracked": {
-    "errorType": "response_url",
-    "errorUrl": "https://www.cracked.com/",
-    "url": "https://www.cracked.com/members/{}/",
+    "errorType": "message",
+    "errorMsg": "404 Not Found",
+    "url": "https://www.cracked.com/user/{}",
     "urlMain": "https://www.cracked.com/",
     "username_claimed": "blue"
   },

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -603,9 +603,9 @@
   },
   "Cracked.sh": {
     "errorType": "status_code",
-    "url": "https://cracked.sh/user/{}",
+    "url": "https://cracked.sh/{}",
     "urlMain": "https://cracked.sh/",
-    "username_claimed": "admin"
+    "username_claimed": "Hacker"
   },
   "Cracked Forum": {
     "errorMsg": "The member you specified is either invalid or doesn't exist",


### PR DESCRIPTION
Hi Sherlock team! I'm soft-meo Owner from Beatrix Labs.

I've investigated issue #2818 where cracked.sh returns a false positive. The site currently returns a standard nginx 404 page for non-existent users. I have updated the errorMsg in data.json to match '404 Not Found' with errorType: message to fix this.

This ensures accurate detection for this platform. Thanks!