### PR TITLE
fix: resolve GeeksforGeeks false positive

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -952,8 +952,9 @@
     "username_claimed": "blue"
   },
   "GeeksforGeeks": {
-    "errorType": "status_code",
-    "url": "https://auth.geeksforgeeks.org/user/{}",
+    "errorMsg": "<title>false",
+    "errorType": "message",
+    "url": "https://www.geeksforgeeks.org/user/{}/",
     "urlMain": "https://www.geeksforgeeks.org/",
     "username_claimed": "adam"
   },


### PR DESCRIPTION
## Summary
Fixes: #2782

GeeksforGeeks changed their profile URL structure. The old URL (`auth.geeksforgeeks.org/user/{}`) now redirects to a profile page that returns HTTP 200 for **all** usernames, including non-existent ones.

## Root Cause
The page returns `<title>false   | GeeksforGeeks Profile</title>` for non-existent users, so `status_code` detection no longer works.

## Changes
- Updated URL to `www.geeksforgeeks.org/user/{}/` (current canonical)
- Changed `errorType` from `status_code` to `message`
- Added `errorMsg`: `<title>false` to detect non-existent profiles

## Testing
```
# Before fix (false positive):
sherlock --site GeeksforGeeks thisisafakeuser999xyz
[+] GeeksforGeeks: https://auth.geeksforgeeks.org/user/thisisafakeuser999xyz  # WRONG

# After fix:
sherlock --site GeeksforGeeks --local thisisafakeuser999xyz
[*] Search completed with 0 results  # CORRECT

sherlock --site GeeksforGeeks --local adam
[+] GeeksforGeeks: https://www.geeksforgeeks.org/user/adam/  # CORRECT
```