### PR TITLE
fix: remove Cloudflare-blocked sites (1337x, Giphy)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1,16 +1,5 @@
 {
   "$schema": "data.schema.json",
-  "1337x": {
-    "errorMsg": [
-      "<title>Error something went wrong.</title>",
-      "<head><title>404 Not Found</title></head>"
-    ],
-    "errorType": "message",
-    "regexCheck": "^[A-Za-z0-9]{4,12}$",
-    "url": "https://www.1337x.to/user/{}/",
-    "urlMain": "https://www.1337x.to/",
-    "username_claimed": "FitGirl"
-  },
   "2Dimensions": {
     "errorType": "status_code",
     "url": "https://2Dimensions.com/a/{}",
@@ -988,13 +977,6 @@
     "url": "https://www.giantbomb.com/profile/{}/",
     "urlMain": "https://www.giantbomb.com/",
     "username_claimed": "bob"
-  },
-  "Giphy": {
-    "errorType": "message",
-    "errorMsg": "<title> GIFs - Find &amp; Share on GIPHY</title>",
-    "url": "https://giphy.com/{}",
-    "urlMain": "https://giphy.com/",
-    "username_claimed": "red"
   },
   "GitBook": {
     "errorType": "status_code",


### PR DESCRIPTION
## Summary

Removes two sites that are now fully behind Cloudflare challenge pages, causing 100% false positives.

## Changes

- **Remove 1337x** — Fixes #2815. The site returns HTTP 403 with a Cloudflare JS challenge for all requests, making it impossible to distinguish between existing and non-existing users.
- **Remove Giphy** — Fixes #2734. Same issue: HTTP 403 Cloudflare challenge on all requests regardless of username validity.

## Verification

Both sites tested via `curl` with standard User-Agent headers:

```
# 1337x - both return 403 Cloudflare challenge
curl -s -o /dev/null -w '%{http_code}' 'https://www.1337x.to/user/FitGirl/'    → 403
curl -s -o /dev/null -w '%{http_code}' 'https://www.1337x.to/user/fakeuser999/' → 403

# Giphy - both return 403 Cloudflare challenge  
curl -s -o /dev/null -w '%{http_code}' 'https://giphy.com/red'        → 403
curl -s -o /dev/null -w '%{http_code}' 'https://giphy.com/fakeuser99' → 403
```

Since both real and fake usernames return identical responses, these entries cannot provide accurate results and should be removed.