### PR TITLE
Fix: resolve false positives for BoardGameGeek detection

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -312,7 +312,9 @@
     "username_claimed": "blue"
   },
   "BoardGameGeek": {
-    "errorMsg": "\"isValid\":true",
+    "errorMsg": [
+      "\"isValid\":true",
+      "\"message\":\"Username must start with a letter and may contain letters, numbers, and _.\""],
     "errorType": "message",
     "url": "https://boardgamegeek.com/user/{}",
     "urlMain": "https://boardgamegeek.com/",


### PR DESCRIPTION
BoardGameGeek detection was producing false positives due to ambiguous responses from the username validation API.

Resolves #2803 

The endpoint returns:
- "isValid": true → username available (user does not exist)
- "isValid": false → either username already exists OR username is invalid

Previously, only one condition was checked, causing invalid usernames to be incorrectly marked as existing users.

This change updates detection to handle both "not found" cases:
- available usernames ("isValid": true)
- invalid usernames (validation error message)

This ensures:
- existing users are correctly detected
- non-existent and invalid usernames are not falsely marked as found

Tested with:
- existing username
- valid non-existing username
- invalid username