### PR TITLE
Add Hono REST API for Sherlock CLI with Docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,47 @@
-# Release instructions:
-  # 1. Update the version tag in the Dockerfile to match the version in sherlock/__init__.py
-  # 2. Update the VCS_REF tag to match the tagged version's FULL commit hash
-  # 3. Build image with BOTH latest and version tags
-    # i.e. `docker build -t sherlock/sherlock:0.16.0 -t sherlock/sherlock:latest .`
+# ── Stage 1: build the TypeScript API ─────────────────────────────────────────
+FROM node:22-slim AS node-build
 
-FROM python:3.12-slim-bullseye AS build
-WORKDIR /sherlock
+WORKDIR /build/api
+COPY api/package*.json ./
+RUN npm ci
+COPY api/ ./
+RUN npm run build
 
-RUN pip3 install --no-cache-dir --upgrade pip
+# ── Stage 2: final runtime image ──────────────────────────────────────────────
+FROM python:3.12-slim
 
-FROM python:3.12-slim-bullseye
-WORKDIR /sherlock
+# Install Node.js runtime (no build tools needed)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
-ARG VCS_REF= # CHANGE ME ON UPDATE
-ARG VCS_URL="https://github.com/sherlock-project/sherlock"
-ARG VERSION_TAG= # CHANGE ME ON UPDATE
+WORKDIR /app
 
-ENV SHERLOCK_ENV=docker
+# ── Python dependencies (sherlock) ─────────────────────────────────────────────
+COPY sherlock_project/ ./sherlock_project/
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir \
+        tomli \
+        requests \
+        requests-futures \
+        colorama \
+        pandas \
+        openpyxl \
+        PySocks \
+        certifi
 
-LABEL org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url=$VCS_URL \
-      org.label-schema.name="Sherlock" \
-      org.label-schema.version=$VERSION_TAG \
-      website="https://sherlockproject.xyz"
+# ── Python bridge script ───────────────────────────────────────────────────────
+COPY sherlock_bridge.py ./
 
-RUN pip3 install --no-cache-dir sherlock-project==$VERSION_TAG
+# ── Node.js API (compiled JS + production node_modules) ───────────────────────
+COPY --from=node-build /build/api/dist ./api/dist
+COPY api/package*.json ./api/
+RUN cd api && npm ci --omit=dev
 
-WORKDIR /sherlock
+# Railway injects PORT at runtime; default to 3000 for local runs.
+ENV PORT=3000
+EXPOSE 3000
 
-ENTRYPOINT ["sherlock"]
+CMD ["node", "api/dist/index.js"]

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,23 @@
+# ── Server ────────────────────────────────────────────────────────────────────
+PORT=3000
+
+# ── CORS ──────────────────────────────────────────────────────────────────────
+# Comma-separated list of allowed origins. Use * to allow all (not recommended
+# for production). Example: https://app.example.com,https://admin.example.com
+ALLOWED_ORIGINS=*
+
+# ── Authentication ────────────────────────────────────────────────────────────
+# Optional static API key. When set every request must carry the header:
+#   X-API-Key: <value>
+# Leave blank to disable key enforcement.
+API_KEY=
+
+# ── Python ────────────────────────────────────────────────────────────────────
+# Path or command used to invoke the sherlock bridge script.
+PYTHON_EXECUTABLE=python3
+
+# ── Rate limiting ─────────────────────────────────────────────────────────────
+# Maximum requests allowed per window per IP address.
+RATE_LIMIT_MAX=30
+# Window size in milliseconds (default: 60 000 = 1 minute).
+RATE_LIMIT_WINDOW_MS=60000

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,47 @@
+# ── Stage 1: build the TypeScript API ─────────────────────────────────────────
+FROM node:22-slim AS node-build
+
+WORKDIR /build/api
+COPY api/package*.json ./
+RUN npm ci
+COPY api/ ./
+RUN npm run build
+
+# ── Stage 2: final runtime image ──────────────────────────────────────────────
+FROM python:3.12-slim
+
+# Install Node.js runtime (no build tools needed)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# ── Python dependencies (sherlock) ─────────────────────────────────────────────
+COPY sherlock_project/ ./sherlock_project/
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir \
+        tomli \
+        requests \
+        requests-futures \
+        colorama \
+        pandas \
+        openpyxl \
+        PySocks \
+        certifi
+
+# ── Python bridge script ───────────────────────────────────────────────────────
+COPY sherlock_bridge.py ./
+
+# ── Node.js API (compiled JS + production node_modules) ───────────────────────
+COPY --from=node-build /build/api/dist ./api/dist
+COPY api/package*.json ./api/
+RUN cd api && npm ci --omit=dev
+
+# Railway injects PORT at runtime; default to 3000 for local runs.
+ENV PORT=3000
+EXPOSE 3000
+
+CMD ["node", "api/dist/index.js"]

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,639 @@
+{
+  "name": "sherlock-hono-api",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sherlock-hono-api",
+      "version": "1.0.0",
+      "dependencies": {
+        "@hono/node-server": "^1.13.7",
+        "@hono/zod-validator": "^0.4.3",
+        "hono": "^4.7.4",
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.13.10",
+        "tsx": "^4.19.3",
+        "typescript": "^5.8.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@hono/zod-validator": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.4.3.tgz",
+      "integrity": "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "hono": ">=3.9.0",
+        "zod": "^3.19.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "sherlock-hono-api",
+  "version": "1.0.0",
+  "description": "Professional REST API for Sherlock username-search using the Hono framework",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "@hono/zod-validator": "^0.4.3",
+    "hono": "^4.7.4",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,0 +1,105 @@
+/**
+ * Sherlock Hono API
+ *
+ * Entry point. Configures middleware, mounts routes, and starts the server.
+ *
+ * Environment variables (see .env.example):
+ *   PORT                  TCP port (default: 3000)
+ *   ALLOWED_ORIGINS       Comma-separated CORS origins (default: *)
+ *   API_KEY               Static API key; leave blank to disable auth
+ *   PYTHON_EXECUTABLE     Python binary path (default: python3)
+ *   RATE_LIMIT_MAX        Max requests per window per IP (default: 30)
+ *   RATE_LIMIT_WINDOW_MS  Window in ms (default: 60000)
+ */
+
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { secureHeaders } from "hono/secure-headers";
+import { logger } from "hono/logger";
+import { prettyJSON } from "hono/pretty-json";
+import { requestId } from "hono/request-id";
+
+import { rateLimit } from "./middleware/rateLimit.js";
+import { apiKeyAuth } from "./middleware/apiKey.js";
+import { healthRouter } from "./routes/health.js";
+import { versionRouter } from "./routes/version.js";
+import { sitesRouter } from "./routes/sites.js";
+import { searchRouter } from "./routes/search.js";
+
+const app = new Hono();
+
+// ── Global middleware ──────────────────────────────────────────────────────────
+
+app.use("*", requestId());
+app.use("*", logger());
+app.use("*", secureHeaders());
+app.use(
+  "*",
+  cors({
+    origin: process.env.ALLOWED_ORIGINS?.split(",").map((o) => o.trim()) ?? "*",
+    allowMethods: ["GET", "POST", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization", "X-API-Key"],
+    exposeHeaders: [
+      "X-RateLimit-Limit",
+      "X-RateLimit-Remaining",
+      "X-RateLimit-Reset",
+      "X-Request-Id",
+    ],
+  })
+);
+app.use("*", prettyJSON());
+
+// Rate limiting applied before auth so the rate counter always increments.
+app.use("*", rateLimit({}));
+
+// Optional API-key authentication (skip the health endpoint).
+app.use("/api/*", apiKeyAuth());
+
+// ── Routes ─────────────────────────────────────────────────────────────────────
+
+app.route("/health", healthRouter);
+app.route("/api/v1/version", versionRouter);
+app.route("/api/v1/sites", sitesRouter);
+app.route("/api/v1/search", searchRouter);
+
+// Root redirect to docs hint
+app.get("/", (c) =>
+  c.json({
+    name: "sherlock-api",
+    description: "REST API for Sherlock username search",
+    version: "1.0.0",
+    endpoints: {
+      health: "GET /health",
+      version: "GET /api/v1/version",
+      sites: "GET /api/v1/sites",
+      search: "POST /api/v1/search",
+    },
+    docs: "See README.md for full API documentation.",
+  })
+);
+
+// ── Error handlers ─────────────────────────────────────────────────────────────
+
+app.notFound((c) =>
+  c.json({ success: false, error: `Route not found: ${c.req.method} ${c.req.path}` }, 404)
+);
+
+app.onError((err, c) => {
+  console.error("[error]", err);
+  return c.json({ success: false, error: "Internal server error." }, 500);
+});
+
+// ── Server bootstrap ───────────────────────────────────────────────────────────
+
+const port = parseInt(process.env.PORT ?? "3000", 10);
+
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(`\nSherlock API listening on http://localhost:${info.port}`);
+  console.log(`  Health : http://localhost:${info.port}/health`);
+  console.log(`  Version: http://localhost:${info.port}/api/v1/version`);
+  console.log(`  Sites  : http://localhost:${info.port}/api/v1/sites`);
+  console.log(`  Search : POST http://localhost:${info.port}/api/v1/search\n`);
+});
+
+export default app;

--- a/api/src/middleware/apiKey.ts
+++ b/api/src/middleware/apiKey.ts
@@ -1,0 +1,31 @@
+/**
+ * Optional static API-key authentication middleware.
+ *
+ * When the API_KEY environment variable is set, every request must carry:
+ *   X-API-Key: <value>
+ *
+ * When API_KEY is empty / not set, authentication is disabled entirely.
+ */
+
+import type { MiddlewareHandler } from "hono";
+
+export function apiKeyAuth(): MiddlewareHandler {
+  return async (c, next) => {
+    const requiredKey = process.env.API_KEY;
+    if (!requiredKey) {
+      // Auth not configured – let the request through.
+      await next();
+      return;
+    }
+
+    const provided = c.req.header("x-api-key");
+    if (!provided || provided !== requiredKey) {
+      return c.json(
+        { success: false, error: "Unauthorized: missing or invalid API key." },
+        401
+      );
+    }
+
+    await next();
+  };
+}

--- a/api/src/middleware/rateLimit.ts
+++ b/api/src/middleware/rateLimit.ts
@@ -1,0 +1,71 @@
+/**
+ * Simple in-memory rate limiter middleware for Hono.
+ *
+ * Tracks request counts per IP address within a sliding window.
+ * Not suitable for multi-process deployments; for those, swap out the
+ * backing store for Redis / Upstash.
+ */
+
+import type { MiddlewareHandler } from "hono";
+
+interface Window {
+  count: number;
+  resetAt: number;
+}
+
+const store = new Map<string, Window>();
+
+// Periodically evict stale entries so the map doesn't grow forever.
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, win] of store) {
+    if (win.resetAt < now) store.delete(key);
+  }
+}, 60_000);
+
+export function rateLimit(opts: {
+  max?: number;
+  windowMs?: number;
+}): MiddlewareHandler {
+  const max = opts.max ?? parseInt(process.env.RATE_LIMIT_MAX ?? "30", 10);
+  const windowMs =
+    opts.windowMs ??
+    parseInt(process.env.RATE_LIMIT_WINDOW_MS ?? "60000", 10);
+
+  return async (c, next) => {
+    // Prefer X-Forwarded-For when running behind a reverse proxy.
+    const ip =
+      c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+      c.req.header("x-real-ip") ??
+      "unknown";
+
+    const now = Date.now();
+    let win = store.get(ip);
+
+    if (!win || win.resetAt < now) {
+      win = { count: 0, resetAt: now + windowMs };
+      store.set(ip, win);
+    }
+
+    win.count++;
+
+    c.res.headers.set("X-RateLimit-Limit", String(max));
+    c.res.headers.set(
+      "X-RateLimit-Remaining",
+      String(Math.max(0, max - win.count))
+    );
+    c.res.headers.set("X-RateLimit-Reset", String(Math.ceil(win.resetAt / 1000)));
+
+    if (win.count > max) {
+      return c.json(
+        {
+          success: false,
+          error: "Too many requests. Please slow down.",
+        },
+        429
+      );
+    }
+
+    await next();
+  };
+}

--- a/api/src/routes/health.ts
+++ b/api/src/routes/health.ts
@@ -1,0 +1,11 @@
+import { Hono } from "hono";
+
+export const healthRouter = new Hono();
+
+healthRouter.get("/", (c) =>
+  c.json({
+    status: "ok",
+    service: "sherlock-api",
+    timestamp: new Date().toISOString(),
+  })
+);

--- a/api/src/routes/search.ts
+++ b/api/src/routes/search.ts
@@ -1,0 +1,185 @@
+/**
+ * POST /api/v1/search
+ *
+ * Run a Sherlock username search across social networks.
+ *
+ * Body (JSON):
+ * {
+ *   "usernames": ["john", "jane"],   // 1–5 usernames per request
+ *   "options": {
+ *     "sites":   ["GitHub","Twitter"],  // limit to specific sites
+ *     "timeout": 60,                    // seconds (5–120, default 60)
+ *     "proxy":   "socks5://...",        // optional proxy URL
+ *     "nsfw":    false,                 // include NSFW sites
+ *     "local":   true,                  // use bundled data.json (faster)
+ *     "jsonFile": "https://..."         // custom site-data URL
+ *   }
+ * }
+ */
+
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { runSherlock } from "../utils/bridge.js";
+import { getSiteNames } from "../utils/sites.js";
+import type {
+  ClaimedSite,
+  ErroredSite,
+  UsernameSearchResult,
+} from "../types.js";
+
+// Usernames may include {?} placeholders (sherlock's fuzzy mode).
+const USERNAME_RE = /^[a-zA-Z0-9._\-{}? ]+$/;
+
+// Very loose proxy validation – sherlock itself will reject bad values.
+const PROXY_RE = /^(https?|socks[45]):\/\/.+/;
+
+const BodySchema = z.object({
+  usernames: z
+    .array(
+      z
+        .string()
+        .min(1, "Username must not be empty.")
+        .max(50, "Username must be at most 50 characters.")
+        .regex(USERNAME_RE, "Username contains invalid characters.")
+    )
+    .min(1, "Provide at least one username.")
+    .max(5, "At most 5 usernames per request."),
+
+  options: z
+    .object({
+      sites: z
+        .array(z.string().min(1).max(100))
+        .max(100, "At most 100 sites per request.")
+        .optional()
+        .default([]),
+
+      timeout: z
+        .number({ invalid_type_error: "timeout must be a number." })
+        .int()
+        .min(5, "Minimum timeout is 5 seconds.")
+        .max(120, "Maximum timeout is 120 seconds.")
+        .optional()
+        .default(60),
+
+      proxy: z
+        .string()
+        .regex(PROXY_RE, "Invalid proxy URL. Must start with http://, https://, socks4://, or socks5://.")
+        .optional(),
+
+      nsfw: z.boolean().optional().default(false),
+
+      local: z.boolean().optional().default(true),
+
+      jsonFile: z
+        .string()
+        .url("jsonFile must be a valid URL.")
+        .optional(),
+    })
+    .optional()
+    .default({}),
+});
+
+export const searchRouter = new Hono();
+
+searchRouter.post(
+  "/",
+  zValidator("json", BodySchema, (result, c) => {
+    if (!result.success) {
+      const messages = result.error.issues.map(
+        (i) => `${i.path.join(".") || "body"}: ${i.message}`
+      );
+      return c.json({ success: false, error: messages }, 400);
+    }
+  }),
+  async (c) => {
+  const { usernames, options } = c.req.valid("json");
+
+  // Validate that any requested sites actually exist in our data set.
+  if (options.sites && options.sites.length > 0) {
+    const knownSites = new Set(getSiteNames(true));
+    const unknown = options.sites.filter((s) => !knownSites.has(s));
+    if (unknown.length > 0) {
+      return c.json(
+        {
+          success: false,
+          error: `Unknown site(s): ${unknown.join(", ")}. Use GET /api/v1/sites to see valid names.`,
+        },
+        400
+      );
+    }
+  }
+
+  let bridgeResponse;
+  try {
+    bridgeResponse = await runSherlock({
+      usernames,
+      options: {
+        sites: options.sites,
+        timeout: options.timeout,
+        proxy: options.proxy,
+        nsfw: options.nsfw,
+        local: options.local,
+        jsonFile: options.jsonFile,
+      },
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown bridge error.";
+    return c.json({ success: false, error: msg }, 500);
+  }
+
+  if (!bridgeResponse.success) {
+    return c.json({ success: false, error: bridgeResponse.error }, 500);
+  }
+
+  // ── Transform raw bridge output into the structured API response ────────────
+  const data: Record<string, UsernameSearchResult> = {};
+
+  for (const [username, siteResults] of Object.entries(
+    bridgeResponse.results ?? {}
+  )) {
+    const found: ClaimedSite[] = [];
+    const notFound: string[] = [];
+    const errors: ErroredSite[] = [];
+
+    for (const [site, result] of Object.entries(siteResults)) {
+      if (site === "_error") continue;
+
+      switch (result.status) {
+        case "Claimed":
+          found.push({
+            site,
+            url: result.url,
+            responseTimeMs: result.responseTimeMs,
+          });
+          break;
+        case "Available":
+          notFound.push(site);
+          break;
+        default:
+          errors.push({
+            site,
+            status: result.status,
+            context: result.context,
+          });
+      }
+    }
+
+    // Sort found sites by response time (fastest first) for readability.
+    found.sort((a, b) => (a.responseTimeMs ?? 0) - (b.responseTimeMs ?? 0));
+
+    data[username] = {
+      foundCount: found.length,
+      totalChecked: found.length + notFound.length + errors.length,
+      found,
+      notFound,
+      errors,
+    };
+  }
+
+  return c.json({
+    success: true,
+    data,
+    meta: bridgeResponse.meta,
+  });
+});

--- a/api/src/routes/sites.ts
+++ b/api/src/routes/sites.ts
@@ -1,0 +1,65 @@
+/**
+ * GET /api/v1/sites
+ *
+ * Returns the list of supported social-network sites.
+ *
+ * Query parameters:
+ *   nsfw=true          Include NSFW sites (default: false)
+ *   filter=<string>    Case-insensitive substring search on site name
+ *   page=<number>      Page number (1-based, default: 1)
+ *   limit=<number>     Page size (1–200, default: 100)
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { getSites } from "../utils/sites.js";
+
+const QuerySchema = z.object({
+  nsfw: z
+    .enum(["true", "false", "1", "0"])
+    .optional()
+    .transform((v) => v === "true" || v === "1"),
+  filter: z.string().max(100).optional(),
+  page: z
+    .string()
+    .optional()
+    .transform((v) => Math.max(1, parseInt(v ?? "1", 10) || 1)),
+  limit: z
+    .string()
+    .optional()
+    .transform((v) => Math.min(200, Math.max(1, parseInt(v ?? "100", 10) || 100))),
+});
+
+export const sitesRouter = new Hono();
+
+sitesRouter.get(
+  "/",
+  zValidator("query", QuerySchema, (result, c) => {
+    if (!result.success) {
+      const messages = result.error.issues.map(
+        (i) => `${i.path.join(".") || "query"}: ${i.message}`
+      );
+      return c.json({ success: false, error: messages }, 400);
+    }
+  }),
+  (c) => {
+  const { nsfw, filter, page, limit } = c.req.valid("query");
+
+  const all = getSites({ nsfw, filter });
+  const total = all.length;
+  const totalPages = Math.ceil(total / limit);
+  const offset = (page - 1) * limit;
+  const items = all.slice(offset, offset + limit);
+
+  return c.json({
+    success: true,
+    data: items,
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages,
+    },
+  });
+});

--- a/api/src/routes/version.ts
+++ b/api/src/routes/version.ts
@@ -1,0 +1,66 @@
+/**
+ * GET /api/v1/version
+ *
+ * Returns sherlock version and a list of direct Python dependencies by
+ * reading pyproject.toml without spawning Python.
+ */
+
+import { Hono } from "hono";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const PYPROJECT_PATH = path.resolve(
+  __dirname,
+  "../../../pyproject.toml"
+);
+
+function readVersion(): { version: string; dependencies: string[] } {
+  try {
+    const raw = readFileSync(PYPROJECT_PATH, "utf-8");
+
+    // Extract version from [tool.poetry] section
+    const poetrySection = raw.match(/\[tool\.poetry\]([\s\S]*?)(?=\[|$)/)?.[1] ?? "";
+    const versionMatch = poetrySection.match(/^version\s*=\s*"([^"]+)"/m);
+    const version = versionMatch?.[1] ?? "unknown";
+
+    // Extract runtime dependency names from [tool.poetry.dependencies]
+    const depsMatch = raw.match(
+      /\[tool\.poetry\.dependencies\]([\s\S]*?)(?=\[|$)/
+    );
+    const dependencies: string[] = [];
+    if (depsMatch) {
+      const block = depsMatch[1];
+      for (const line of block.split("\n")) {
+        const dep = line.match(/^([A-Za-z][\w-]*)\s*=/);
+        if (dep && dep[1].toLowerCase() !== "python") {
+          dependencies.push(dep[1]);
+        }
+      }
+    }
+
+    return { version, dependencies };
+  } catch {
+    return { version: "unknown", dependencies: [] };
+  }
+}
+
+export const versionRouter = new Hono();
+
+versionRouter.get("/", (c) => {
+  const { version, dependencies } = readVersion();
+  return c.json({
+    success: true,
+    data: {
+      name: "Sherlock: Find Usernames Across Social Networks",
+      version,
+      pythonDependencies: dependencies,
+      api: {
+        version: "1.0.0",
+        framework: "Hono",
+      },
+    },
+  });
+});

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -1,0 +1,72 @@
+/** Raw result entry from the Python bridge for a single (username, site) pair. */
+export interface RawSiteResult {
+  status: "Claimed" | "Available" | "Unknown" | "Illegal" | "WAF";
+  url: string;
+  responseTimeMs: number | null;
+  context: string | null;
+}
+
+/** Raw dict keyed by site name, as returned by the Python bridge per username. */
+export type RawUsernameResults = Record<string, RawSiteResult>;
+
+/** Top-level envelope returned by the Python bridge. */
+export interface BridgeResponse {
+  success: boolean;
+  error?: string;
+  results?: Record<string, RawUsernameResults>;
+  meta?: {
+    totalSites: number;
+    elapsedSeconds: number;
+    usernames: string[];
+  };
+}
+
+/** Config object sent to the Python bridge via stdin. */
+export interface BridgeConfig {
+  usernames: string[];
+  options: {
+    nsfw?: boolean;
+    local?: boolean;
+    sites?: string[];
+    proxy?: string;
+    timeout?: number;
+    jsonFile?: string;
+  };
+}
+
+// ── Structured API response types ─────────────────────────────────────────────
+
+export interface ClaimedSite {
+  site: string;
+  url: string;
+  responseTimeMs: number | null;
+}
+
+export interface ErroredSite {
+  site: string;
+  status: string;
+  context: string | null;
+}
+
+export interface UsernameSearchResult {
+  foundCount: number;
+  totalChecked: number;
+  found: ClaimedSite[];
+  notFound: string[];
+  errors: ErroredSite[];
+}
+
+export interface SearchResponseData {
+  success: true;
+  data: Record<string, UsernameSearchResult>;
+  meta: {
+    totalSites: number;
+    elapsedSeconds: number;
+    usernames: string[];
+  };
+}
+
+export interface ErrorResponse {
+  success: false;
+  error: string;
+}

--- a/api/src/utils/bridge.ts
+++ b/api/src/utils/bridge.ts
@@ -1,0 +1,79 @@
+/**
+ * Sherlock Python bridge utility.
+ *
+ * Spawns `sherlock_bridge.py` as a child process, writes JSON config to its
+ * stdin, and reads the JSON result from stdout.
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { BridgeConfig, BridgeResponse } from "../types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// sherlock_bridge.py lives two levels above api/src/utils/
+const BRIDGE_SCRIPT = path.resolve(__dirname, "../../../sherlock_bridge.py");
+
+// Hard wall-clock limit for the entire bridge invocation (all usernames).
+// Per-username timeout is enforced inside the Python script.
+const PROCESS_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+export function runSherlock(config: BridgeConfig): Promise<BridgeResponse> {
+  return new Promise((resolve, reject) => {
+    const python = process.env.PYTHON_EXECUTABLE ?? "python3";
+
+    const proc = spawn(python, [BRIDGE_SCRIPT], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    const killer = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Sherlock bridge process timed out after 5 minutes."));
+    }, PROCESS_TIMEOUT_MS);
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on("close", () => {
+      clearTimeout(killer);
+
+      const raw = stdout.trim();
+      if (!raw) {
+        reject(
+          new Error(
+            `Sherlock bridge produced no output. stderr: ${stderr.slice(0, 500)}`
+          )
+        );
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(raw) as BridgeResponse);
+      } catch {
+        reject(
+          new Error(
+            `Failed to parse bridge output. stdout: ${raw.slice(0, 300)} | stderr: ${stderr.slice(0, 300)}`
+          )
+        );
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(killer);
+      reject(new Error(`Failed to start sherlock bridge: ${err.message}`));
+    });
+
+    // Write config to bridge and close stdin to signal EOF.
+    proc.stdin.write(JSON.stringify(config));
+    proc.stdin.end();
+  });
+}

--- a/api/src/utils/sites.ts
+++ b/api/src/utils/sites.ts
@@ -1,0 +1,72 @@
+/**
+ * Site list utility.
+ *
+ * Reads the bundled sherlock data.json directly (pure Node.js, no Python),
+ * so the /sites endpoint is fast and has zero Python startup overhead.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const DATA_JSON_PATH = path.resolve(
+  __dirname,
+  "../../../sherlock_project/resources/data.json"
+);
+
+export interface SiteEntry {
+  name: string;
+  urlMain: string;
+  url: string;
+  errorType: string;
+  isNSFW: boolean;
+  tags?: string[];
+}
+
+let _cache: SiteEntry[] | null = null;
+
+function load(): SiteEntry[] {
+  if (_cache) return _cache;
+
+  const raw = readFileSync(DATA_JSON_PATH, "utf-8");
+  const data = JSON.parse(raw) as Record<string, Record<string, unknown>>;
+
+  _cache = Object.entries(data)
+    .filter(([key]) => key !== "$schema")
+    .map(([name, info]) => ({
+      name,
+      urlMain: String(info.urlMain ?? ""),
+      url: String(info.url ?? ""),
+      errorType: String(info.errorType ?? ""),
+      isNSFW: Boolean(info.isNSFW ?? false),
+      tags: Array.isArray(info.tags)
+        ? (info.tags as string[])
+        : undefined,
+    }));
+
+  return _cache;
+}
+
+export function getSites(opts: {
+  nsfw?: boolean;
+  filter?: string;
+}): SiteEntry[] {
+  let sites = load();
+
+  if (!opts.nsfw) {
+    sites = sites.filter((s) => !s.isNSFW);
+  }
+
+  if (opts.filter) {
+    const q = opts.filter.toLowerCase();
+    sites = sites.filter((s) => s.name.toLowerCase().includes(q));
+  }
+
+  return sites;
+}
+
+export function getSiteNames(nsfw = false): string[] {
+  return getSites({ nsfw }).map((s) => s.name);
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,10 @@
+[build]
+# Build from the api/ Dockerfile which bundles Python + Node.js
+dockerfilePath = "api/Dockerfile"
+
+[deploy]
+startCommand = "node api/dist/index.js"
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3

--- a/railway.toml
+++ b/railway.toml
@@ -1,7 +1,3 @@
-[build]
-# Build from the api/ Dockerfile which bundles Python + Node.js
-dockerfilePath = "api/Dockerfile"
-
 [deploy]
 startCommand = "node api/dist/index.js"
 healthcheckPath = "/health"

--- a/sherlock_bridge.py
+++ b/sherlock_bridge.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Sherlock JSON Bridge
+
+Reads a JSON config from stdin, runs sherlock searches, and writes
+structured JSON results to stdout. Used by the Hono API layer to
+interface with the sherlock Python module without a long-running process.
+
+Usage:
+    echo '{"usernames":["john"],"options":{}}' | python3 sherlock_bridge.py
+"""
+
+import json
+import os
+import sys
+import time
+
+from sherlock_project.sherlock import sherlock
+from sherlock_project.sites import SitesInformation
+from sherlock_project.result import QueryStatus
+from sherlock_project.notify import QueryNotify
+
+_LOCAL_DATA_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "sherlock_project",
+    "resources",
+    "data.json",
+)
+
+MAX_TIMEOUT = 120  # Hard cap on per-request timeout (seconds)
+MAX_USERNAMES = 10  # Hard cap on usernames per call
+
+
+class QueryNotifyCollect(QueryNotify):
+    """Silently collect every query result into a plain dict."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.results: dict = {}
+
+    def start(self, message: str) -> None:  # noqa: D401
+        pass
+
+    def update(self, result) -> None:  # noqa: D401
+        response_ms = (
+            round(result.query_time * 1000) if result.query_time is not None else None
+        )
+        self.results[result.site_name] = {
+            "status": result.status.value,
+            "url": result.site_url_user,
+            "responseTimeMs": response_ms,
+            "context": result.context,
+        }
+
+    def finish(self, message=None) -> None:  # noqa: D401
+        pass
+
+
+def _fail(message: str) -> None:
+    """Print a failure envelope and exit non-zero."""
+    print(json.dumps({"success": False, "error": message}), flush=True)
+    sys.exit(1)
+
+
+def main() -> None:
+    # ── Read config from stdin ────────────────────────────────────────────────
+    try:
+        config = json.loads(sys.stdin.read())
+    except json.JSONDecodeError as exc:
+        _fail(f"Invalid JSON on stdin: {exc}")
+
+    usernames: list[str] = config.get("usernames", [])
+    options: dict = config.get("options", {})
+
+    if not usernames:
+        _fail("No usernames provided.")
+
+    if len(usernames) > MAX_USERNAMES:
+        _fail(f"Too many usernames (max {MAX_USERNAMES}).")
+
+    include_nsfw: bool = bool(options.get("nsfw", False))
+    use_local: bool = bool(options.get("local", True))
+    sites_filter: list[str] = options.get("sites", [])
+    proxy: str | None = options.get("proxy")
+    timeout: int = min(int(options.get("timeout", 60)), MAX_TIMEOUT)
+    json_file: str | None = options.get("jsonFile")
+
+    # ── Load site data ────────────────────────────────────────────────────────
+    try:
+        if json_file:
+            # Custom JSON file / URL supplied by caller
+            sites_info = SitesInformation(json_file, honor_exclusions=False)
+        elif use_local:
+            # Prefer the bundled data.json (fast, no network)
+            sites_info = SitesInformation(_LOCAL_DATA_PATH, honor_exclusions=False)
+        else:
+            # Fetch the latest manifest from GitHub (slower)
+            sites_info = SitesInformation()
+
+        if not include_nsfw:
+            sites_info.remove_nsfw_sites()
+
+        if sites_filter:
+            site_data = {
+                site.name: site.information
+                for site in sites_info
+                if site.name in sites_filter
+            }
+        else:
+            site_data = {site.name: site.information for site in sites_info}
+
+    except Exception as exc:  # noqa: BLE001
+        _fail(f"Failed to load site data: {exc}")
+
+    if not site_data:
+        _fail("No sites matched the given filter.")
+
+    # ── Run searches ──────────────────────────────────────────────────────────
+    results: dict = {}
+    wall_start = time.monotonic()
+
+    for username in usernames:
+        notifier = QueryNotifyCollect()
+        try:
+            sherlock(
+                username=username,
+                site_data=site_data,
+                query_notify=notifier,
+                proxy=proxy,
+                timeout=timeout,
+            )
+            results[username] = notifier.results
+        except Exception as exc:  # noqa: BLE001
+            results[username] = {"_error": str(exc)}
+
+    elapsed = round(time.monotonic() - wall_start, 3)
+
+    # ── Emit JSON result ──────────────────────────────────────────────────────
+    print(
+        json.dumps(
+            {
+                "success": True,
+                "results": results,
+                "meta": {
+                    "totalSites": len(site_data),
+                    "elapsedSeconds": elapsed,
+                    "usernames": usernames,
+                },
+            }
+        ),
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a new TypeScript-based REST API for Sherlock using the Hono framework, along with a modernized Docker build process for both the API and the Python backend. The changes add a production-ready, rate-limited, and optionally authenticated HTTP API for Sherlock username searches, with endpoints for health checks, version info, supported sites, and search queries. The Docker setup is updated to build and serve both the Python and Node.js components together.

Key changes are:

**API Implementation and Structure**

* Added a new `api` directory implementing a REST API using TypeScript and the Hono framework, featuring endpoints for health, version, supported sites, and username search, with middleware for CORS, logging, security headers, rate limiting, and optional API-key authentication. (`api/src/index.ts` [[1]](diffhunk://#diff-c7daeed68470fce500b64961dc1986f90d3c903d7679f553701de7aed7aa72a6R1-R105) `api/package.json` [[2]](diffhunk://#diff-d0ab9c1cc78fba971b5270314ad877706d340d099b42f46a406fc5de6a32fdf0R1-R26) `api/src/routes/health.ts` [[3]](diffhunk://#diff-79ac6779ec903f590de30ab7363ecabfe54e0184dc6c36206a793570c1fc8198R1-R11) `api/src/routes/version.ts` [[4]](diffhunk://#diff-4eccbb1b0aa2fbf6180e7731e385dfcc02651434f47169646a2141cdd397ebbeR1-R66) `api/src/routes/sites.ts` [[5]](diffhunk://#diff-03479b87177265ab4914a1f33188a913d62bc28be4cbf6397678952dc7633ebaR1-R65) `api/src/routes/search.ts` [[6]](diffhunk://#diff-2a919ea337f0801205a895b5681066ec09f43fbc2dd4881f39b3b00d71a176e7R1-R185) `api/src/types.ts` [[7]](diffhunk://#diff-3f2176b5a38c04bd649d28488df1c9804b92e8924f773f745feb173a99ef57e6R1-R72)

**Middleware and Security**

* Implemented in-memory rate limiting and optional static API-key authentication middleware for the API, providing basic abuse protection and access control. (`api/src/middleware/rateLimit.ts` [[1]](diffhunk://#diff-89f32ae4767cfc38c98ee0924d8469d04b9a621a4904d141e5c15dafe49c7aceR1-R71) `api/src/middleware/apiKey.ts` [[2]](diffhunk://#diff-fbcb493b8376c5f4bb5011abca357a4b0c52d3900af86bda6942b347354b48c8R1-R31)

**Configuration and Environment**

* Added `.env.example` to document and configure environment variables for port, allowed origins, API key, Python executable, and rate limiting. (`api/.env.example` [api/.env.exampleR1-R23](diffhunk://#diff-2fdd31c8eaeb05db626d15ffa6f31b34be3044212e22d6831e976afbab90cc86R1-R23))
* Updated `.gitignore` to exclude Node.js build artifacts and environment files. (`api/.gitignore` [api/.gitignoreR1-R3](diffhunk://#diff-29170f7d39ee9a02f2f12814848e5e109bb0c0d48e9ac643e1e22dd5683cc72bR1-R3))

**Dockerization and Build Process**

* Replaced the legacy Dockerfile with a new multi-stage build that compiles the TypeScript API, installs both Node.js and Python dependencies, and serves the unified app, supporting both local and Railway deployment. (`Dockerfile` [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R47) `api/Dockerfile` [[2]](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47R1-R47)

These changes collectively enable Sherlock to be deployed as a modern, secure, and scalable HTTP API service.