### PR TITLE
fix: catch UnicodeDecodeError on special character usernames

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -136,6 +136,9 @@ def get_response(request_future, error_type, social_network):
     except requests.exceptions.RequestException as err:
         error_context = "Unknown Error"
         exception_text = str(err)
+    except (UnicodeEncodeError, UnicodeDecodeError) as err:
+        error_context = "Encoding Error"
+        exception_text = str(err)
 
     return response, error_context, exception_text
 


### PR DESCRIPTION
## Problem

When scanning usernames containing non-ASCII characters (e.g. `Émile`), Sherlock crashes with a `UnicodeDecodeError`:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 0: invalid continuation byte
```

This happens because some sites return HTTP redirect `Location` headers encoded in Latin-1 (ISO-8859-1) rather than UTF-8. The `requests` library raises `UnicodeDecodeError` when trying to decode these headers during redirect resolution.

## Fix

Add `UnicodeEncodeError` and `UnicodeDecodeError` to the exception handlers in `get_response()`, alongside the existing `requests` exception handlers. This allows Sherlock to gracefully skip the problematic site (marking it as an error) and continue scanning the remaining targets instead of crashing.

## Testing

Before (crashes midway through scan):
```
$ sherlock 'Émile'
[*] Checking username Émile on:
...
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 ...
```

After (completes full scan, skipping sites with encoding issues):
```
$ sherlock 'Émile'
[*] Checking username Émile on:
...
[*] Search completed with 75 results
```

Fixes #2730