### PR TITLE
fix: remove npm due to Cloudflare WAF blocking all requests

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -87,7 +87,7 @@
     "username_claimed": "blue"
   },
   "AniWorld": {
-    "errorMsg": "Dieses Profil ist nicht verf\u00fcgbar",
+    "errorMsg": "Dieses Profil ist nicht verfügbar",
     "errorType": "message",
     "url": "https://aniworld.to/user/profil/{}",
     "urlMain": "https://aniworld.to/",
@@ -405,7 +405,7 @@
     "username_claimed": "jenny"
   },
   "Career.habr": {
-    "errorMsg": "<h1>\u041e\u0448\u0438\u0431\u043a\u0430 404</h1>",
+    "errorMsg": "<h1>Ошибка 404</h1>",
     "errorType": "message",
     "url": "https://career.habr.com/{}",
     "urlMain": "https://career.habr.com/",
@@ -430,7 +430,7 @@
     "username_claimed": "ordnung"
   },
   "Chatujme.cz": {
-    "errorMsg": "Neexistujic\u00ed profil",
+    "errorMsg": "Neexistujicí profil",
     "errorType": "message",
     "regexCheck": "^[a-zA-Z][a-zA-Z1-9_-]*$",
     "url": "https://profil.chatujme.cz/{}",
@@ -717,7 +717,10 @@
     "url": "https://discord.com",
     "urlMain": "https://discord.com/",
     "urlProbe": "https://discord.com/api/v9/unique-username/username-attempt-unauthed",
-    "errorMsg": ["{\"taken\":false}", "The resource is being rate limited"],
+    "errorMsg": [
+      "{\"taken\":false}",
+      "The resource is being rate limited"
+    ],
     "request_method": "POST",
     "request_payload": {
       "username": "{}"
@@ -876,7 +879,7 @@
     "username_claimed": "blue"
   },
   "Football": {
-    "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u0441 \u0442\u0430\u043a\u0438\u043c \u0438\u043c\u0435\u043d\u0435\u043c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
+    "errorMsg": "Пользователь с таким именем не найден",
     "errorType": "message",
     "url": "https://www.rusfootball.info/user/{}/",
     "urlMain": "https://www.rusfootball.info/",
@@ -1114,7 +1117,10 @@
   },
   "HackerNews": {
     "__comment__": "First errMsg invalid, second errMsg rate limited. Not ideal. Adjust for better rate limit filtering.",
-    "errorMsg": ["No such user.", "Sorry."],
+    "errorMsg": [
+      "No such user.",
+      "Sorry."
+    ],
     "errorType": "message",
     "url": "https://news.ycombinator.com/user?id={}",
     "urlMain": "https://news.ycombinator.com/",
@@ -1449,7 +1455,7 @@
     "username_claimed": "habryka"
   },
   "Letterboxd": {
-    "errorMsg": "Sorry, we can\u2019t find the page you\u2019ve requested.",
+    "errorMsg": "Sorry, we can’t find the page you’ve requested.",
     "errorType": "message",
     "url": "https://letterboxd.com/{}",
     "urlMain": "https://letterboxd.com/",
@@ -1471,7 +1477,7 @@
     "urlMain": "https://lichess.org",
     "username_claimed": "john"
   },
- "LinkedIn": {
+  "LinkedIn": {
     "errorType": "status_code",
     "headers": {
       "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -2191,7 +2197,7 @@
     "username_claimed": "blue"
   },
   "Signal": {
-    "errorMsg": "Oops! That page doesn\u2019t exist or is private.",
+    "errorMsg": "Oops! That page doesn’t exist or is private.",
     "errorType": "message",
     "url": "https://community.signalusers.org/u/{}",
     "urlMain": "https://community.signalusers.org",
@@ -2546,7 +2552,6 @@
     "urlMain": "https://www.twitch.tv",
     "username_claimed": "xqc"
   },
-
   "Trovo": {
     "errorMsg": "Uh Ohhh...",
     "errorType": "message",
@@ -2619,14 +2624,16 @@
     "username_claimed": "qlgks1"
   },
   "Velomania": {
-    "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430.",
+    "errorMsg": "Пользователь не зарегистрирован и не имеет профиля для просмотра.",
     "errorType": "message",
     "url": "https://forum.velomania.ru/member.php?username={}",
     "urlMain": "https://forum.velomania.ru/",
     "username_claimed": "red"
   },
   "Venmo": {
-    "errorMsg": ["Venmo | Page Not Found"],
+    "errorMsg": [
+      "Venmo | Page Not Found"
+    ],
     "errorType": "message",
     "headers": {
       "Host": "account.venmo.com"
@@ -2789,8 +2796,8 @@
   "YandexMusic": {
     "__comment__": "The first and third errorMsg relate to geo-restrictions and bot detection/captchas.",
     "errorMsg": [
-      "\u041e\u0448\u0438\u0431\u043a\u0430 404",
-      "<meta name=\"description\" content=\"\u041e\u0442\u043a\u0440\u044b\u0432\u0430\u0439\u0442\u0435 \u043d\u043e\u0432\u0443\u044e \u043c\u0443\u0437\u044b\u043a\u0443 \u043a\u0430\u0436\u0434\u044b\u0439 \u0434\u0435\u043d\u044c.",
+      "Ошибка 404",
+      "<meta name=\"description\" content=\"Открывайте новую музыку каждый день.",
       "<input type=\"submit\" class=\"CheckboxCaptcha-Button\""
     ],
     "errorType": "message",
@@ -2954,14 +2961,14 @@
     "username_claimed": "blue"
   },
   "hunting": {
-    "errorMsg": "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0434\u0440\u0443\u0433\u043e\u0435 \u0438\u043c\u044f.",
+    "errorMsg": "Указанный пользователь не найден. Пожалуйста, введите другое имя.",
     "errorType": "message",
     "url": "https://www.hunting.ru/forum/members/?username={}",
     "urlMain": "https://www.hunting.ru/forum/",
     "username_claimed": "red"
   },
   "igromania": {
-    "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430.",
+    "errorMsg": "Пользователь не зарегистрирован и не имеет профиля для просмотра.",
     "errorType": "message",
     "url": "http://forum.igromania.ru/member.php?username={}",
     "urlMain": "http://forum.igromania.ru/",
@@ -3100,12 +3107,6 @@
     "urlMain": "https://note.com/",
     "username_claimed": "blue"
   },
-  "npm": {
-    "errorType": "status_code",
-    "url": "https://www.npmjs.com/~{}",
-    "urlMain": "https://www.npmjs.com/",
-    "username_claimed": "kennethsweezy"
-  },
   "omg.lol": {
     "errorMsg": "\"available\": true",
     "errorType": "message",
@@ -3115,7 +3116,7 @@
     "username_claimed": "adam"
   },
   "opennet": {
-    "errorMsg": "\u0418\u043c\u044f \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e",
+    "errorMsg": "Имя участника не найдено",
     "errorType": "message",
     "regexCheck": "^[^-]*$",
     "url": "https://www.opennet.ru/~{}",
@@ -3129,7 +3130,7 @@
     "username_claimed": "blue"
   },
   "phpRU": {
-    "errorMsg": "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0434\u0440\u0443\u0433\u043e\u0435 \u0438\u043c\u044f.",
+    "errorMsg": "Указанный пользователь не найден. Пожалуйста, введите другое имя.",
     "errorType": "message",
     "url": "https://php.ru/forum/members/?username={}",
     "urlMain": "https://php.ru/forum/",
@@ -3254,8 +3255,8 @@
     "urlMain": "https://www.baby.ru/",
     "errorType": "message",
     "errorMsg": [
-      "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430, \u043a\u043e\u0442\u043e\u0440\u0443\u044e \u0432\u044b \u0438\u0441\u043a\u0430\u043b\u0438, \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430",
-      "\u0414\u043e\u0441\u0442\u0443\u043f \u0441 \u0432\u0430\u0448\u0435\u0433\u043e IP-\u0430\u0434\u0440\u0435\u0441\u0430 \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u043e \u043e\u0433\u0440\u0430\u043d\u0438\u0447\u0435\u043d"
+      "Страница, которую вы искали, не найдена",
+      "Доступ с вашего IP-адреса временно ограничен"
     ],
     "username_claimed": "example"
   },


### PR DESCRIPTION
## Problem

npm (npmjs.com) now uses Cloudflare WAF challenge protection that returns HTTP 403 for all profile page requests, regardless of whether the username exists. This causes consistent false negatives — Sherlock can never detect an npm profile.

```
$ curl -sI 'https://www.npmjs.com/~kennethsweezy'
HTTP/2 403
cf-mitigated: challenge
```

Both existing (`~kennethsweezy`) and non-existing usernames receive identical 403 responses with `cf-mitigated: challenge` headers.

## Fix

Remove the `npm` entry from `data.json`. The Cloudflare challenge requires browser-level JavaScript execution that can't be solved with simple HTTP requests.

This is the same pattern as 1337x and Giphy (see #2835).

Fixes #2628