### PR TITLE
feat: add omg.lol site support

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1734,6 +1734,12 @@
     "urlMain": "https://observablehq.com/",
     "username_claimed": "mbostock"
   },
+  "omg.lol": {
+    "errorType": "status_code",
+    "url": "https://omg.lol/{}",
+    "urlMain": "https://omg.lol/",
+    "username_claimed": "adam"
+  },
   "Open Collective": {
     "errorType": "status_code",
     "url": "https://opencollective.com/{}",


### PR DESCRIPTION
## Summary
- Adds omg.lol site support to fix false negative
- omg.lol profiles return HTTP 404 for non-existing users, making `status_code` detection reliable

Fixes #2808

## Test plan
- Tested with known username `adam` — correctly detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)