### PR TITLE
feat: add akniga site support

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -70,6 +70,12 @@
     "urlMain": "https://www.airliners.net/",
     "username_claimed": "yushinlin"
   },
+  "Akniga": {
+    "errorType": "status_code",
+    "url": "https://akniga.org/profile/{}",
+    "urlMain": "https://akniga.org/",
+    "username_claimed": "user123"
+  },
   "All Things Worn": {
     "errorMsg": "Sell Used Panties",
     "errorType": "message",


### PR DESCRIPTION
## Summary
- Adds akniga.org (Russian audiobook platform) site support to fix false negative reported in #2807
- URL pattern: `https://akniga.org/profile/{}`
- Detection method: `status_code` (existing users return 200, non-existing users return 404)

Fixes #2807

## Test plan
- Tested with known username `user123` — correctly detected profile at https://akniga.org/profile/user123
- Tested with non-existing username — correctly returned 0 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)