### PR TITLE
fix: pin 4 unpinned action(s)

### DIFF
--- a/.github/workflows/exclusions.yml
+++ b/.github/workflows/exclusions.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v4
+        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4
         with:
           poetry-version: 'latest'
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Get version from pyproject.toml
         id: get-version
         run: |

--- a/.github/workflows/update-site-list.yml
+++ b/.github/workflows/update-site-list.yml
@@ -33,7 +33,7 @@ jobs:
         run: python devel/site-list.py
 
       - name: Pushes to another repository
-        uses: sdushantha/github-action-push-to-another-repository@main
+        uses: sdushantha/github-action-push-to-another-repository@c3194624a23d419e5d1fff6d01b611b27029931d # main
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/validate_modified_targets.yml
+++ b/.github/workflows/validate_modified_targets.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v4
+        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4
         with:
           poetry-version: "latest"
 


### PR DESCRIPTION
Re-submission of #2839. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags.

- Pin 4 unpinned actions to full 40-character SHAs
- Add version comments for readability

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3`, original version preserved as comment
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)