### PR TITLE
fix: upgrade site URLs from HTTP to HTTPS

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1068,8 +1068,8 @@
   "Gravatar": {
     "errorType": "status_code",
     "regexCheck": "^((?!\\.).)*$",
-    "url": "http://en.gravatar.com/{}",
-    "urlMain": "http://en.gravatar.com/",
+    "url": "https://en.gravatar.com/{}",
+    "urlMain": "https://en.gravatar.com/",
     "username_claimed": "blue"
   },
   "Gumroad": {
@@ -1992,8 +1992,8 @@
   },
   "PromoDJ": {
     "errorType": "status_code",
-    "url": "http://promodj.com/{}",
-    "urlMain": "http://promodj.com/",
+    "url": "https://promodj.com/{}",
+    "urlMain": "https://promodj.com/",
     "username_claimed": "blue"
   },
   "Pronouns.page": {
@@ -2714,8 +2714,8 @@
   "Wikidot": {
     "errorMsg": "User does not exist.",
     "errorType": "message",
-    "url": "http://www.wikidot.com/user:info/{}",
-    "urlMain": "http://www.wikidot.com/",
+    "url": "https://www.wikidot.com/user:info/{}",
+    "urlMain": "https://www.wikidot.com/",
     "username_claimed": "blue"
   },
   "Wikipedia": {
@@ -2833,8 +2833,8 @@
   },
   "authorSTREAM": {
     "errorType": "status_code",
-    "url": "http://www.authorstream.com/{}/",
-    "urlMain": "http://www.authorstream.com/",
+    "url": "https://www.authorstream.com/{}/",
+    "urlMain": "https://www.authorstream.com/",
     "username_claimed": "blue"
   },
   "babyblogRU": {
@@ -2872,8 +2872,8 @@
   },
   "datingRU": {
     "errorType": "status_code",
-    "url": "http://dating.ru/{}",
-    "urlMain": "http://dating.ru",
+    "url": "https://dating.ru/{}",
+    "urlMain": "https://dating.ru",
     "username_claimed": "blue"
   },
   "devRant": {

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1068,8 +1068,8 @@
   "Gravatar": {
     "errorType": "status_code",
     "regexCheck": "^((?!\\.).)*$",
-    "url": "https://en.gravatar.com/{}",
-    "urlMain": "https://en.gravatar.com/",
+    "url": "http://en.gravatar.com/{}",
+    "urlMain": "http://en.gravatar.com/",
     "username_claimed": "blue"
   },
   "Gumroad": {
@@ -2833,8 +2833,8 @@
   },
   "authorSTREAM": {
     "errorType": "status_code",
-    "url": "https://www.authorstream.com/{}/",
-    "urlMain": "https://www.authorstream.com/",
+    "url": "http://www.authorstream.com/{}/",
+    "urlMain": "http://www.authorstream.com/",
     "username_claimed": "blue"
   },
   "babyblogRU": {


### PR DESCRIPTION
Upgrades 5 site configurations from plain HTTP to HTTPS.

All 5 sites confirmed to support HTTPS:
- **Gravatar** (en.gravatar.com) → 302 redirect to HTTPS
- **PromoDJ** (promodj.com) → 200 OK on HTTPS
- **Wikidot** (www.wikidot.com) → 200 OK on HTTPS
- **authorSTREAM** (www.authorstream.com) → 200 OK on HTTPS
- **datingRU** (dating.ru) → 200 OK on HTTPS

Using plain HTTP leaks username queries on the wire and is vulnerable to MITM attacks. Two additional sites (igromania, uid.me) were left unchanged as their HTTPS endpoints were unreachable.