### PR TITLE
fix: remove Discord target that always returns homepage URL

### DIFF
--- a/docs/removed-sites.md
+++ b/docs/removed-sites.md
@@ -1995,3 +1995,26 @@ __2025-07-06 :__ Site appears to have gone offline in March and hasn't come back
     "username_claimed": "GalaxyRG"
   },
 ```
+
+## Discord
+__2026-04-01 :__ Probe only verifies username availability and does not map to a stable public profile URL.
+```json
+"Discord": {
+    "errorType": "message",
+    "url": "https://discord.com",
+    "urlMain": "https://discord.com/",
+    "urlProbe": "https://discord.com/api/v9/unique-username/username-attempt-unauthed",
+    "errorMsg": [
+      "{\"taken\":false}",
+      "The resource is being rate limited"
+    ],
+    "request_method": "POST",
+    "request_payload": {
+      "username": "{}"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "username_claimed": "blue"
+  }
+```

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -712,21 +712,6 @@
     "urlMain": "https://www.discogs.com/",
     "username_claimed": "blue"
   },
-  "Discord": {
-    "errorType": "message",
-    "url": "https://discord.com",
-    "urlMain": "https://discord.com/",
-    "urlProbe": "https://discord.com/api/v9/unique-username/username-attempt-unauthed",
-    "errorMsg": ["{\"taken\":false}", "The resource is being rate limited"],
-    "request_method": "POST",
-    "request_payload": {
-      "username": "{}"
-    },
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "username_claimed": "blue"
-  },
   "Discord.bio": {
     "errorType": "message",
     "errorMsg": "<title>Server Error (500)</title>",


### PR DESCRIPTION
## Summary
- remove `Discord` from `data.json` because probe only verifies username availability
- document Discord in `docs/removed-sites.md`

## Why
The current Discord target reports claimed usernames with `https://discord.com`, which is not a user profile URL.

Fixes #2732