### PR TITLE
tests: avoid shell parsing in CLI helper

### DIFF
--- a/tests/sherlock_interactives.py
+++ b/tests/sherlock_interactives.py
@@ -1,38 +1,37 @@
 import os
-import platform
 import re
+import shlex
 import subprocess
+import sys
+
 
 class Interactives:
-    def run_cli(args:str = "") -> str:
-        """Pass arguments to Sherlock as a normal user on the command line"""
-        # Adapt for platform differences (Windows likes to be special)
-        if platform.system() == "Windows":
-            command:str = f"py -m sherlock_project {args}"
-        else:
-            command:str = f"sherlock {args}"
+    def run_cli(args: str = "") -> str:
+        """Pass arguments to Sherlock as a normal user on the command line."""
+        command: list[str] = [sys.executable, "-m", "sherlock_project"]
+        if args:
+            command.extend(shlex.split(args, posix=(os.name != "nt")))
 
-        proc_out:str = ""
         try:
-            proc_out = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+            proc_out = subprocess.check_output(command, stderr=subprocess.STDOUT)
             return proc_out.decode()
         except subprocess.CalledProcessError as e:
             raise InteractivesSubprocessError(e.output.decode())
 
-
     def walk_sherlock_for_files_with(pattern: str) -> list[str]:
-        """Check all files within the Sherlock package for matching patterns"""
-        pattern:re.Pattern = re.compile(pattern)
-        matching_files:list[str] = []
+        """Check all files within the Sherlock package for matching patterns."""
+        pattern: re.Pattern = re.compile(pattern)
+        matching_files: list[str] = []
         for root, dirs, files in os.walk("sherlock_project"):
             for file in files:
-                file_path = os.path.join(root,file)
+                file_path = os.path.join(root, file)
                 if "__pycache__" in file_path:
                     continue
                 with open(file_path, 'r', errors='ignore') as f:
                     if pattern.search(f.read()):
                         matching_files.append(file_path)
         return matching_files
+
 
 class InteractivesSubprocessError(Exception):
     pass


### PR DESCRIPTION
## Summary
- stop building a shell command string in `tests/sherlock_interactives.py`
- invoke the CLI helper via `sys.executable -m sherlock_project` with an argv list
- preserve stderr capture and the existing `CalledProcessError` -> `InteractivesSubprocessError` flow

## Why
Using `shell=True` here makes the helper depend on shell parsing and quoting behavior instead of direct CLI argument handling. An argv-based call is safer, easier to reason about, and more faithful to how the tests want to exercise the CLI.

## Self-review
- kept the change scoped to the interactive test helper only
- used `shlex.split(...)` so existing string-based test inputs still map onto argv cleanly
- used `sys.executable` to avoid relying on a separate `sherlock` or `py` shell command being present on PATH

Closes #2864
