### PR TITLE
fix: normalize invalid timeout parser errors

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -517,7 +517,12 @@ def timeout_check(value):
     NOTE:  Will raise an exception if the timeout in invalid.
     """
 
-    float_value = float(value)
+    try:
+        float_value = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ArgumentTypeError(
+            f"Invalid timeout value: {value}. Timeout must be a positive number."
+        ) from exc
 
     if float_value <= 0:
         raise ArgumentTypeError(

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -41,3 +41,13 @@ def test_wildcard_username_expansion():
 def test_no_usernames_provided(cliargs):
     with pytest.raises(InteractivesSubprocessError, match=r"error: the following arguments are required: USERNAMES"):
         Interactives.run_cli(cliargs)
+
+
+@pytest.mark.parametrize('cliargs', [
+    '--timeout abc testuser',
+    '--timeout 0 testuser',
+    '--timeout -1 testuser',
+])
+def test_invalid_timeout_reports_argparse_error(cliargs):
+    with pytest.raises(InteractivesSubprocessError, match=r"Invalid timeout value: .*Timeout must be a positive number."):
+        Interactives.run_cli(cliargs)


### PR DESCRIPTION
Closes #2866

## Summary
- wrap non-numeric timeout parsing failures in `ArgumentTypeError`
- keep zero/negative timeout validation unchanged
- add a regression test covering invalid timeout inputs

## Testing
- not run in this sandbox (no Python 3 runtime is available here)
