### PR TITLE
ensure pip is actually upgraded during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,6 @@
   # 3. Build image with BOTH latest and version tags
     # i.e. `docker build -t sherlock/sherlock:0.16.0 -t sherlock/sherlock:latest .`
 
-FROM python:3.12-slim-bullseye AS build
-WORKDIR /sherlock
-
-RUN pip3 install --no-cache-dir --upgrade pip
-
 FROM python:3.12-slim-bullseye
 WORKDIR /sherlock
 
@@ -24,7 +19,8 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.version=$VERSION_TAG \
       website="https://sherlockproject.xyz"
 
-RUN pip3 install --no-cache-dir sherlock-project==$VERSION_TAG
+RUN pip3 install --no-cache-dir --upgrade pip && \
+    pip3 install --no-cache-dir sherlock-project==$VERSION_TAG
 
 WORKDIR /sherlock
 


### PR DESCRIPTION
Previously, pip was upgraded in an isolated AS build stage that was never copied into the final image, meaning the upgrade was completely discarded. This commit removes the unused multi-stage block and moves the pip upgrade into the final stage. This ensures the container actually uses the latest version of pip when installing the project dependencies, while also cleaning up dead code.