### PR TITLE
feat: use project section

### DIFF
--- a/.github/workflows/exclusions.yml
+++ b/.github/workflows/exclusions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/update-site-list.yml
+++ b/.github/workflows/update-site-list.yml
@@ -17,14 +17,14 @@ jobs:
     steps:
       # Check out the code at the specified pull request head commit
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       # Install Python 3
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/validate_modified_targets.yml
+++ b/.github/workflows/validate_modified_targets.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # Checkout the base branch but fetch all history to avoid a second fetch call
           ref: ${{ github.base_ref }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "poetry-core>=1.2.0" ]
+requires = [ "poetry-core>=2.0.0" ]
 build-backend = "poetry.core.masonry.api"
 # poetry-core 1.8 not available in .fc39. Can upgrade to 1.8.0 at .fc39 EOL
 
@@ -7,20 +7,22 @@ build-backend = "poetry.core.masonry.api"
 source = "init"
 
 [tool.poetry]
+packages = [ { include = "sherlock_project"} ]
+
+[project]
 name = "sherlock-project"
 version = "0.16.0"
 description = "Hunt down social media accounts by username across social networks"
-license = "MIT"
+license = {text="MIT"}
 authors = [
-    "Siddharth Dushantha <siddharth.dushantha@gmail.com>"
+    { name="Siddharth Dushantha", email="siddharth.dushantha@gmail.com" }
 ]
 maintainers = [
-    "Paul Pfeister <code@pfeister.dev>",
-    "Matheus Felipe <matheusfelipeog@protonmail.com>",
-    "Sondre Karlsen Dyrnes <sondre@villdyr.no>"
+    { name="Paul Pfeister", email="code@pfeister.dev" },
+    { name="Matheus Felipe", email="matheusfelipeog@protonmail.com" },
+    { name="Sondre Karlsen Dyrnes", email="sondre@villdyr.no" }
 ]
 readme = "docs/pyproject/README.md"
-packages = [ { include = "sherlock_project"} ]
 keywords = [ "osint", "reconnaissance", "information gathering" ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -33,36 +35,37 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security"
 ]
+requires-python = ">=3.9"
+dependencies = [
+    "certifi >=2019.6.16",
+    "colorama >=0.4.1",
+    "PySocks >=1.7.0",
+    "requests >=2.22.0",
+    "requests-futures >=1.0.0",
+    "stem >=1.8.0",
+    "pandas >=2.2.1",
+    "openpyxl >=3.0.10",
+    "tomli >=2.2.1"
+]
+
+[project.urls]
 homepage = "https://sherlockproject.xyz/"
 repository = "https://github.com/sherlock-project/sherlock"
-
-
-[tool.poetry.urls]
 "Bug Tracker" = "https://github.com/sherlock-project/sherlock/issues"
 
-[tool.poetry.dependencies]
-python = "^3.9"
-certifi = ">=2019.6.16"
-colorama = "^0.4.1"
-PySocks = "^1.7.0"
-requests = "^2.22.0"
-requests-futures = "^1.0.0"
-stem = "^1.8.0"
-pandas = "^2.2.1"
-openpyxl = "^3.0.10"
-tomli = "^2.2.1"
+[dependency-groups]
+dev = [
+    "jsonschema >=4.0.0",
+    "rstr >=3.2.2",
+    "pytest >=8.4.2",
+    "pytest-xdist >=3.8.0"
+]
+ci = [
+    "defusedxml >=0.7.1"
+]
 
-[tool.poetry.group.dev.dependencies]
-jsonschema = "^4.0.0"
-rstr = "^3.2.2"
-pytest = "^8.4.2"
-pytest-xdist = "^3.8.0"
-
-
-[tool.poetry.group.ci.dependencies]
-defusedxml = "^0.7.1"
-
-[tool.poetry.scripts]
+[project.scripts]
 sherlock = 'sherlock_project.sherlock:main'


### PR DESCRIPTION
# Description

Use project section as recommended by https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#writing-your-pyproject-toml

The project section support both poetry and uv, I test the speed of them on Mac with Python3.13 by the following command:
```
poetry env use 3.13
time poetry install --all-extras --all-groups
time poetry install --all-extras --all-groups

uv venv --python 3.13
time uv sync --all-extras --all-groups
time uv sync --all-extras --all-groups
```
Output:
```
poetry install --all-extras --all-groups  5.96s user 2.92s system 129% cpu 6.874 total
poetry install --all-extras --all-groups  0.95s user 0.23s system 97% cpu 1.209 total

uv sync --all-extras --all-groups  3.41s user 1.91s system 98% cpu 5.417 total
uv sync --all-extras --all-groups  0.02s user 0.01s system 85% cpu 0.039 total
```
This show that uv delivers a 30x speedup compared to poetry once packages installed.