### PR TITLE
fix(cli): normalize invalid timeout parse errors

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -517,7 +517,12 @@ def timeout_check(value):
     NOTE:  Will raise an exception if the timeout in invalid.
     """
 
-    float_value = float(value)
+    try:
+        float_value = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ArgumentTypeError(
+            f"Invalid timeout value: {value}. Timeout must be a positive number."
+        ) from exc
 
     if float_value <= 0:
         raise ArgumentTypeError(

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -41,3 +41,12 @@ def test_wildcard_username_expansion():
 def test_no_usernames_provided(cliargs):
     with pytest.raises(InteractivesSubprocessError, match=r"error: the following arguments are required: USERNAMES"):
         Interactives.run_cli(cliargs)
+
+@pytest.mark.parametrize('cliargs', [
+    '--timeout abc testuser',
+    '--timeout not-a-number testuser',
+])
+def test_invalid_timeout_reports_argparse_error(cliargs):
+    with pytest.raises(InteractivesSubprocessError, match=r"argument --timeout: Invalid timeout value"):
+        Interactives.run_cli(cliargs)
+


### PR DESCRIPTION
## Summary
- convert non-numeric `--timeout` inputs into `ArgumentTypeError` instead of leaking a raw `ValueError`
- keep the existing positive-number validation message unchanged
- add a CLI regression test covering invalid timeout values

## Notes
- I couldn't run the Python test suite in this sandbox because there is no usable `python3` / `pytest` runtime available here.
- The change is intentionally small and only touches timeout argument validation plus the focused regression test.

Closes #2866
