### PR TITLE
fix(site): detect missing Shelf profiles by message

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2179,7 +2179,8 @@
     "username_claimed": "ko"
   },
   "Shelf": {
-    "errorType": "status_code",
+    "errorMsg": "User Not Found",
+    "errorType": "message",
     "url": "https://www.shelf.im/{}",
     "urlMain": "https://www.shelf.im/",
     "username_claimed": "blue"


### PR DESCRIPTION
## Summary
- update Shelf detection to use the page's `User Not Found` marker instead of HTTP status
- fix the current false-negative behavior for existing Shelf profiles
- keep the change isolated to the single site manifest entry

## Notes
- I validated the site behavior from this environment: both claimed and unclaimed Shelf usernames return HTTP 200, and missing profiles include `User Not Found` in the response body.

Closes #2806
