### PR TITLE
Fix: WAF Detection Improvements

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -389,10 +389,20 @@ def sherlock(
             r'{return l.onPageView}}),Object.defineProperty(r,"perimeterxIdentifiers",{enumerable:' # 2024-04-09 PerimeterX / Human Security
         ]
 
+        WAFHitHeaders = {
+            "cf-mitigated": "challenge", # 2026-04-05 Cloudflare challenge header on HEAD/GET
+        }
+
         if error_text is not None:
             error_context = error_text
 
         elif any(hitMsg in r.text for hitMsg in WAFHitMsgs):
+            query_status = QueryStatus.WAF
+
+        elif any(
+            r.headers.get(header_name, "").lower() == expected_value
+            for header_name, expected_value in WAFHitHeaders.items()
+        ):
             query_status = QueryStatus.WAF
 
         else:


### PR DESCRIPTION
## Summary

Based one the issue: [#2868]

Fixes false negatives for Instagram where existing accounts are incorrectly reported as **"Not Found"**.

This issue occurs when ```https://imginn.com/{}``` returns a Cloudflare challenge response instead of a normal profile response. The current logic treats this response as a valid "Not Found" result instead of identifying it as a WAF (Web Application Firewall) block.

---

## Changes Made

- Added header-based detection for Cloudflare responses
- Extended WAF detection logic to identify challenge responses
