### PR TITLE
fix: sanitize subprocess call in sherlock_interactives.py

### DIFF
--- a/tests/sherlock_interactives.py
+++ b/tests/sherlock_interactives.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import re
+import shlex
 import subprocess
 
 class Interactives:
@@ -8,13 +9,13 @@ class Interactives:
         """Pass arguments to Sherlock as a normal user on the command line"""
         # Adapt for platform differences (Windows likes to be special)
         if platform.system() == "Windows":
-            command:str = f"py -m sherlock_project {args}"
+            command:list = ["py", "-m", "sherlock_project"] + shlex.split(args)
         else:
-            command:str = f"sherlock {args}"
+            command:list = ["sherlock"] + shlex.split(args)
 
         proc_out:str = ""
         try:
-            proc_out = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+            proc_out = subprocess.check_output(command, shell=False, stderr=subprocess.STDOUT)
             return proc_out.decode()
         except subprocess.CalledProcessError as e:
             raise InteractivesSubprocessError(e.output.decode())


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `tests/sherlock_interactives.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tests/sherlock_interactives.py:17` |
| **CWE** | CWE-78 |

**Description**: The test suite uses subprocess.check_output with shell=True, allowing arbitrary command injection. The 'command' parameter is constructed from user-controllable input without sanitization. An attacker who can control the command string can inject shell metacharacters (;, &&, ||, |, $(), etc.) to execute arbitrary commands on the system with the privileges of the Python process.

## Changes
- `tests/sherlock_interactives.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
