### PR TITLE
fix: correct None check for query_time in xlsx response_time_s output

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -910,7 +910,7 @@ def main():
                 ):
                     continue
 
-                if response_time_s is None:
+                if results[site]["status"].query_time is None:
                     response_time_s.append("")
                 else:
                     response_time_s.append(results[site]["status"].query_time)


### PR DESCRIPTION
Fixes #2891

The `--xlsx` output block initializes `response_time_s` as a list and then checks `if response_time_s is None` before appending — but a list is never `None`, so the fallback empty string path is dead code. Sites that don't return a response time (timeouts, errors) end up with raw `None` values in the Excel column instead of a blank cell.

The fix mirrors what the `--csv` block already does correctly: check `results[site]["status"].query_time is None` rather than the accumulator list.

One-line change, no behaviour change for sites that do return a response time.