### PR TITLE
fix: handle UnicodeDecodeError on usernames with special characters (fixes #2730)

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -136,6 +136,9 @@ def get_response(request_future, error_type, social_network):
     except requests.exceptions.RequestException as err:
         error_context = "Unknown Error"
         exception_text = str(err)
+    except UnicodeError as err:
+        error_context = "Encoding Error"
+        exception_text = str(err)
 
     return response, error_context, exception_text
 

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,0 +1,47 @@
+"""Tests for handling usernames with special/unicode characters."""
+
+from concurrent.futures import Future
+
+from sherlock_project.sherlock import get_response
+
+
+def _make_future_with_exception(exc):
+    """Create a Future that raises the given exception."""
+    future = Future()
+    future.set_exception(exc)
+    return future
+
+
+def test_get_response_handles_unicode_decode_error():
+    """Regression test for issue #2730.
+
+    Usernames with special characters (e.g. 'Émile') can trigger a
+    UnicodeDecodeError inside the requests library during redirect
+    handling. This must not crash the program.
+    """
+    future = _make_future_with_exception(
+        UnicodeDecodeError("utf-8", b"\xe9", 0, 1, "invalid continuation byte")
+    )
+    response, error_context, exception_text = get_response(
+        request_future=future,
+        error_type=["status_code"],
+        social_network="TestSite",
+    )
+    assert response is None
+    assert error_context == "Encoding Error"
+    assert "utf-8" in exception_text
+
+
+def test_get_response_handles_unicode_encode_error():
+    """UnicodeEncodeError should also be caught (subclass of UnicodeError)."""
+    future = _make_future_with_exception(
+        UnicodeEncodeError("ascii", "É", 0, 1, "ordinal not in range(128)")
+    )
+    response, error_context, exception_text = get_response(
+        request_future=future,
+        error_type=["status_code"],
+        social_network="TestSite",
+    )
+    assert response is None
+    assert error_context == "Encoding Error"
+    assert "ascii" in exception_text

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -4,7 +4,7 @@ from sherlock_interactives import Interactives
 from sherlock_interactives import InteractivesSubprocessError
 
 def test_remove_nsfw(sites_obj):
-    nsfw_target: str = 'Pornhub'
+    nsfw_target: str = 'Xvideos'
     assert nsfw_target in {site.name: site.information for site in sites_obj}
     sites_obj.remove_nsfw_sites()
     assert nsfw_target not in {site.name: site.information for site in sites_obj}
@@ -12,8 +12,8 @@ def test_remove_nsfw(sites_obj):
 
 # Parametrized sites should *not* include Motherless, which is acting as the control
 @pytest.mark.parametrize('nsfwsites', [
-    ['Pornhub'],
-    ['Pornhub', 'Xvideos'],
+    ['Xvideos'],
+    ['Xvideos', 'Erome'],
 ])
 def test_nsfw_explicit_selection(sites_obj, nsfwsites):
     for site in nsfwsites:


### PR DESCRIPTION
## Summary
This PR fixes issue #2730 where Sherlock crashes with a `UnicodeDecodeError` when searching for usernames with special characters (e.g., 'Émile').

## Root Cause
The `UnicodeDecodeError` was escaping all exception handlers in `get_response()` because it's not a subclass of `requests.exceptions.RequestException`. The error occurs when the `requests` library tries to handle redirects from servers that send improperly encoded URLs.

## Changes
- Added a `UnicodeError` exception handler in `get_response()` function
- Treats unicode encoding errors similar to other connection errors
- Added comprehensive tests for both `UnicodeDecodeError` and `UnicodeEncodeError`
- Updated NSFW test to use Xvideos instead of Pornhub (site availability)

## Test Plan
- All existing tests pass (27 passed, 956 deselected)
- New unicode-specific tests verify the fix works correctly
- Manual testing with `sherlock 'Émile'` confirms no crash occurs

## Verification
```bash
# Run the new unicode tests
python -m pytest tests/test_unicode.py -v

# Test with the original failing username
sherlock 'Émile'
```

This fix ensures that sites with unicode encoding issues are gracefully skipped instead of crashing the entire scan.

Bahtya