### PR TITLE
fix: resolve 10 bugs found in code review

### DIFF
--- a/sherlock_project/notify.py
+++ b/sherlock_project/notify.py
@@ -7,9 +7,6 @@ from sherlock_project.result import QueryStatus
 from colorama import Fore, Style
 import webbrowser
 
-# Global variable to count the number of results.
-globvar = 0
-
 
 class QueryNotify:
     """Query Notify Object.
@@ -136,6 +133,7 @@ class QueryNotifyPrint(QueryNotify):
         self.verbose = verbose
         self.print_all = print_all
         self.browse = browse
+        self.result_count = 0
 
         return
 
@@ -153,6 +151,7 @@ class QueryNotifyPrint(QueryNotify):
         Nothing.
         """
 
+        self.result_count = 0
         title = "Checking username"
 
         print(Style.BRIGHT + Fore.GREEN + "[" +
@@ -175,9 +174,8 @@ class QueryNotifyPrint(QueryNotify):
         Return Value:
         The number of results by the time we call the function.
         """
-        global globvar
-        globvar += 1
-        return globvar
+        self.result_count += 1
+        return self.result_count
 
     def update(self, result):
         """Notify Update.
@@ -265,7 +263,7 @@ class QueryNotifyPrint(QueryNotify):
         Return Value:
         Nothing.
         """
-        NumberOfResults = self.countResults() - 1
+        NumberOfResults = self.result_count
 
         print(Style.BRIGHT + Fore.GREEN + "[" +
               Fore.YELLOW + "*" +

--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -110,7 +110,7 @@ class SherlockFuturesSession(FuturesSession):
         )
 
 
-def get_response(request_future, error_type, social_network):
+def get_response(request_future, social_network):
     # Default for Response object if some failure occurs.
     response = None
 
@@ -174,7 +174,7 @@ def sherlock(
     dump_response: bool = False,
     proxy: Optional[str] = None,
     timeout: int = 60,
-) -> dict[str, dict[str, str | QueryResult]]:
+) -> dict:
     """Run Sherlock Analysis.
 
     Checks for existence of username on various social media sites.
@@ -355,7 +355,7 @@ def sherlock(
         # Retrieve future and ensure it has finished
         future = net_info["request_future"]
         r, error_text, exception_text = get_response(
-            request_future=future, error_type=error_type, social_network=social_network
+            request_future=future, social_network=social_network
         )
 
         # Get response time for response of our request.
@@ -370,7 +370,7 @@ def sherlock(
         except Exception:
             http_status = "?"
         try:
-            response_text = r.text.encode(r.encoding or "UTF-8")
+            response_text = r.text
         except Exception:
             response_text = ""
 
@@ -389,7 +389,11 @@ def sherlock(
             r'{return l.onPageView}}),Object.defineProperty(r,"perimeterxIdentifiers",{enumerable:' # 2024-04-09 PerimeterX / Human Security
         ]
 
-        if error_text is not None:
+        if r is None:
+            query_status = QueryStatus.UNKNOWN
+            error_context = error_text or "No response received"
+
+        elif error_text is not None:
             error_context = error_text
 
         elif any(hitMsg in r.text for hitMsg in WAFHitMsgs):
@@ -712,9 +716,10 @@ def main():
         latest_release_json = json_loads(latest_release_raw)
         latest_remote_tag = latest_release_json["tag_name"]
 
-        if latest_remote_tag[1:] != __version__:
+        remote_version = latest_remote_tag.lstrip("v")
+        if remote_version != __version__:
             print(
-                f"Update available! {__version__} --> {latest_remote_tag[1:]}"
+                f"Update available! {__version__} --> {remote_version}"
                 f"\n{latest_release_json['html_url']}"
             )
 
@@ -910,10 +915,8 @@ def main():
                 ):
                     continue
 
-                if response_time_s is None:
-                    response_time_s.append("")
-                else:
-                    response_time_s.append(results[site]["status"].query_time)
+                qt = results[site]["status"].query_time
+                response_time_s.append(qt if qt is not None else "")
                 usernames.append(username)
                 names.append(site)
                 url_main.append(results[site]["url_main"])
@@ -925,17 +928,21 @@ def main():
                 {
                     "username": usernames,
                     "name": names,
-                    "url_main": [f'=HYPERLINK(\"{u}\")' for u in url_main],
-                    "url_user": [f'=HYPERLINK(\"{u}\")' for u in url_user],
+                    "url_main": [f'=HYPERLINK(\"{u.replace(chr(34), chr(34)*2)}\")' for u in url_main],
+                    "url_user": [f'=HYPERLINK(\"{u.replace(chr(34), chr(34)*2)}\")' for u in url_user],
                     "exists": exists,
                     "http_status": http_status,
                     "response_time_s": response_time_s,
                 }
             )
-            DataFrame.to_excel(f"{username}.xlsx", sheet_name="sheet1", index=False)
+            xlsx_file = f"{username}.xlsx"
+            if args.folderoutput:
+                os.makedirs(args.folderoutput, exist_ok=True)
+                xlsx_file = os.path.join(args.folderoutput, xlsx_file)
+            DataFrame.to_excel(xlsx_file, sheet_name="sheet1", index=False)
 
         print()
-    query_notify.finish()
+        query_notify.finish()
 
 
 if __name__ == "__main__":

--- a/sherlock_project/sites.py
+++ b/sherlock_project/sites.py
@@ -6,6 +6,7 @@ This is the raw data that will be used to search for usernames.
 import json
 import requests
 import secrets
+from typing import Optional
 
 
 MANIFEST_URL = "https://raw.githubusercontent.com/sherlock-project/sherlock/master/sherlock_project/resources/data.json"
@@ -13,7 +14,7 @@ EXCLUSIONS_URL = "https://raw.githubusercontent.com/sherlock-project/sherlock/re
 
 class SiteInformation:
     def __init__(self, name, url_home, url_username_format, username_claimed,
-                information, is_nsfw, username_unclaimed=secrets.token_urlsafe(10)):
+                information, is_nsfw, username_unclaimed=None):
         """Create Site Information Object.
 
         Contains information about a specific website.
@@ -56,7 +57,7 @@ class SiteInformation:
         self.url_username_format = url_username_format
 
         self.username_claimed = username_claimed
-        self.username_unclaimed = secrets.token_urlsafe(32)
+        self.username_unclaimed = username_unclaimed or secrets.token_urlsafe(32)
         self.information = information
         self.is_nsfw  = is_nsfw
 
@@ -78,9 +79,9 @@ class SiteInformation:
 class SitesInformation:
     def __init__(
             self,
-            data_file_path: str|None = None,
+            data_file_path: Optional[str] = None,
             honor_exclusions: bool = True,
-            do_not_exclude: list[str] = [],
+            do_not_exclude: Optional[list[str]] = None,
         ):
         """Create Sites Information Object.
 
@@ -120,6 +121,9 @@ class SitesInformation:
             # this instead of the local one is so that the user has the most up-to-date data. This prevents
             # users from creating issue about false positives which has already been fixed or having outdated data
             data_file_path = MANIFEST_URL
+
+        if do_not_exclude is None:
+            do_not_exclude = []
 
         # Ensure that specified data file has correct extension.
         if not data_file_path.lower().endswith(".json"):
@@ -210,7 +214,7 @@ class SitesInformation:
 
         return
 
-    def remove_nsfw_sites(self, do_not_remove: list = []):
+    def remove_nsfw_sites(self, do_not_remove: Optional[list] = None):
         """
         Remove NSFW sites from the sites, if isNSFW flag is true for site
 
@@ -221,6 +225,8 @@ class SitesInformation:
         None
         """
         sites = {}
+        if do_not_remove is None:
+            do_not_remove = []
         do_not_remove = [site.casefold() for site in do_not_remove]
         for site in self.sites:
             if self.sites[site].is_nsfw and site.casefold() not in do_not_remove:


### PR DESCRIPTION
## Summary

Code review identified and fixes 10 bugs across `sherlock.py`, `notify.py`, and `sites.py`:

### HIGH — Crashes
- **NoneType crash when response is None** — `r.text` and `r.status_code` were accessed in WAF detection and account detection logic without null checks. Network errors (timeout, proxy failure, etc.) return `response = None`, causing `AttributeError` on every detection path.

### MEDIUM — Incorrect Behavior
- **`response_text` bytes/str type mismatch** — `r.text.encode(r.encoding or "UTF-8")` returns `bytes`, but the fallback assigns `""` (str). Downstream consumers (CSV, display) expect str, causing `TypeError` when concatenating or writing.
- **Global result counter gives wrong totals across multiple usernames** — `globvar` was a module-level global never reset. Running `sherlock user1 user2` would show cumulative count (e.g., "8 results" when user2 only had 3). Converted to instance variable, reset per-username in `start()`.
- **Dead None check on `response_time_s` in xlsx export** — The list `response_time_s` was checked `if response_time_s is None` (always False since it's initialized as `[]`). Individual `query_time` values were never checked for None.
- **xlsx output ignores `--folderoutput` flag** — CSV and TXT correctly write to `--folderoutput`, but xlsx always wrote to cwd.
- **`finish()` called once after ALL usernames** — `start()` was called per-username but `finish()` was outside the loop, so the summary only appeared once with a cumulative count.

### MEDIUM — Security
- **Excel formula injection in xlsx HYPERLINK** — URLs from site data were directly interpolated into `=HYPERLINK("...")` formulas without sanitizing double quotes, allowing formula breakout.

### LOW — Code Quality
- **Unused `username_unclaimed` parameter in `SiteInformation.__init__`** — Accepted with default `secrets.token_urlsafe(10)` but immediately overwritten with `secrets.token_urlsafe(32)`. Parameter value was never used.
- **Unused `error_type` parameter in `get_response()`** — Passed from call site but never referenced in the function body.
- **Mutable default arguments `[]`** — `do_not_exclude` and `do_not_remove` used `[]` as defaults, which are shared across calls in Python.
- **Version tag parsing assumes `v` prefix** — `latest_remote_tag[1:]` strips exactly one character, breaking if the tag has no `v` prefix. Changed to `lstrip('v')`.
- **Python 3.9 incompatible type hints** — `str|None` and `dict[str, ...]` syntax doesn't work on 3.9. Changed to `Optional` and removed the return type hint.

## Test plan
- [x] Syntax validated for all modified files
- [x] Existing non-live tests pass (live probe tests are flaky by nature — WAF detection on AllMyLinks)
- [x] `test_validate_targets.py` passes (956 targets validated)
- [ ] Manual test: run `sherlock user1 user2 --txt --csv --xlsx --folderoutput /tmp/out` and verify per-username counts are correct
- [ ] Manual test: verify xlsx file appears in `--folderoutput` directory
- [ ] Manual test: verify no crash when network is unreachable (timeout scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)