### PR TITLE
fix: Refactor site-list generator for deterministic sorting, safer wr…

### DIFF
--- a/devel/site-list.py
+++ b/devel/site-list.py
@@ -1,45 +1,164 @@
-#!/usr/bin/env python
-# This module generates the listing of supported sites which can be found in
-# sites.mdx. It also organizes all the sites in alphanumeric order
+#!/usr/bin/env python3
+# This module generates the listing of supported sites found in sites.mdx.
+# It also organizes site keys in data.json using custom alphanumeric ordering.
+import argparse
 import json
 import os
-
-DATA_REL_URI: str = "sherlock_project/resources/data.json"
+import tempfile
+from pathlib import Path
+from typing import Any
 
 DEFAULT_ENCODING = "utf-8"
+SCHEMA_KEY = "$schema"
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+DEFAULT_DATA_PATH = REPO_ROOT / "sherlock_project" / "resources" / "data.json"
+DEFAULT_OUTPUT_DIR = SCRIPT_DIR / "output"
 
-# Read the data.json file
-with open(DATA_REL_URI, "r", encoding=DEFAULT_ENCODING) as data_file:
-    data: dict = json.load(data_file)
 
-# Removes schema-specific keywords for proper processing
-social_networks = data.copy()
-social_networks.pop('$schema', None)
+def site_sort_key(name: str) -> tuple[int, str]:
+    """Sort names with digit-prefixed entries first, then alphabetically."""
+    return (0 if name[:1].isdigit() else 1, name.casefold())
 
-# Sort the social networks in alphanumeric order
-social_networks = sorted(social_networks.items())
 
-# Make output dir where the site list will be written
-os.mkdir("output")
+def build_sorted_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Return ordered data with schema first and sites custom-sorted."""
+    schema_value = data.get(SCHEMA_KEY)
+    site_items = [(k, v) for k, v in data.items() if k != SCHEMA_KEY]
+    sorted_sites = sorted(site_items, key=lambda item: site_sort_key(item[0]))
 
-# Write the list of supported sites to sites.mdx
-with open("output/sites.mdx", "w", encoding=DEFAULT_ENCODING) as site_file:
-    site_file.write("---\n")
-    site_file.write("title: 'List of supported sites'\n")
-    site_file.write("sidebarTitle: 'Supported sites'\n")
-    site_file.write("icon: 'globe'\n")
-    site_file.write("description: 'Sherlock currently supports **400+** sites'\n")
-    site_file.write("---\n\n")
+    sorted_data: dict[str, Any] = {}
+    if schema_value is not None:
+        sorted_data[SCHEMA_KEY] = schema_value
+    for key, value in sorted_sites:
+        sorted_data[key] = value
+    return sorted_data
 
-    for social_network, info in social_networks:
+
+def validate_sites(data: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """Validate site entries and return them as sorted candidate tuples."""
+    site_items: list[tuple[str, dict[str, Any]]] = []
+    for site_name, site_info in data.items():
+        if site_name == SCHEMA_KEY:
+            continue
+        if not isinstance(site_info, dict):
+            raise ValueError(f"Site '{site_name}' has invalid metadata (expected object).")
+        url_main = site_info.get("urlMain")
+        if not isinstance(url_main, str) or not url_main.strip():
+            raise ValueError(f"Site '{site_name}' is missing a valid 'urlMain' value.")
+        site_items.append((site_name, site_info))
+    return site_items
+
+
+def render_sites_mdx(sites: list[tuple[str, dict[str, Any]]]) -> str:
+    """Create the markdown list of supported sites."""
+    lines = [
+        "---",
+        "title: 'List of supported sites'",
+        "sidebarTitle: 'Supported sites'",
+        "icon: 'globe'",
+        f"description: 'Sherlock currently supports **{len(sites)}** sites'",
+        "---",
+        "",
+    ]
+
+    for social_network, info in sites:
         url_main = info["urlMain"]
-        is_nsfw = "**(NSFW)**" if info.get("isNSFW") else ""
-        site_file.write(f"1. [{social_network}]({url_main}) {is_nsfw}\n")
+        is_nsfw = " **(NSFW)**" if info.get("isNSFW") else ""
+        lines.append(f"1. [{social_network}]({url_main}){is_nsfw}")
 
-# Overwrite the data.json file with sorted data
-with open(DATA_REL_URI, "w", encoding=DEFAULT_ENCODING) as data_file:
-    sorted_data = json.dumps(data, indent=2, sort_keys=True)
-    data_file.write(sorted_data)
-    data_file.write("\n")  # Keep the newline after writing data
+    lines.append("")
+    return "\n".join(lines)
 
-print("Finished updating supported site listing!")
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Write content atomically to avoid partially-written files."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_file_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding=DEFAULT_ENCODING,
+            dir=path.parent,
+            delete=False,
+        ) as temp_file:
+            temp_file.write(content)
+            temp_file_path = Path(temp_file.name)
+        os.replace(temp_file_path, path)
+    finally:
+        if temp_file_path is not None and temp_file_path.exists():
+            temp_file_path.unlink()
+
+
+def is_custom_sorted(data: dict[str, Any]) -> bool:
+    """Return whether the incoming dict already follows expected order."""
+    keys = list(data.keys())
+    if not keys:
+        return True
+    if SCHEMA_KEY in data and keys[0] != SCHEMA_KEY:
+        return False
+
+    site_keys = [k for k in keys if k != SCHEMA_KEY]
+    return site_keys == sorted(site_keys, key=site_sort_key)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate supported site listing and sort data.json keys."
+    )
+    parser.add_argument(
+        "--data-file",
+        type=Path,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to data.json (default: {DEFAULT_DATA_PATH})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory where sites.mdx will be written (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check whether data.json is custom-sorted without modifying files.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write sorted data.json and generated sites.mdx (default behavior).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.check and args.write:
+        raise SystemExit("Use either --check or --write, not both.")
+
+    with args.data_file.open("r", encoding=DEFAULT_ENCODING) as data_file:
+        data: dict[str, Any] = json.load(data_file)
+
+    validate_sites(data)
+    sorted_data = build_sorted_data(data)
+    sorted_sites = [(k, v) for k, v in sorted_data.items() if k != SCHEMA_KEY]
+
+    if args.check:
+        if is_custom_sorted(data):
+            print("OK: data.json is already sorted with digit-first ordering.")
+            return 0
+        print("FAIL: data.json is not sorted with digit-first ordering.")
+        return 1
+
+    output_file = args.output_dir / "sites.mdx"
+    mdx_content = render_sites_mdx(sorted_sites)
+    json_content = json.dumps(sorted_data, indent=2, ensure_ascii=False) + "\n"
+
+    atomic_write_text(output_file, mdx_content)
+    atomic_write_text(args.data_file, json_content)
+    print(f"Finished updating supported site listing at {output_file}!")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -29,14 +29,6 @@
     "urlMain": "https://www.9gag.com/",
     "username_claimed": "blue"
   },
-  "APClips": {
-    "errorMsg": "Amateur Porn Content Creators",
-    "errorType": "message",
-    "isNSFW": true,
-    "url": "https://apclips.com/{}",
-    "urlMain": "https://apclips.com/",
-    "username_claimed": "onlybbyraq"
-  },
   "About.me": {
     "errorType": "status_code",
     "url": "https://about.me/{}",
@@ -48,6 +40,13 @@
     "regexCheck": "^[^.]*$",
     "url": "https://independent.academia.edu/{}",
     "urlMain": "https://www.academia.edu/",
+    "username_claimed": "blue"
+  },
+  "addons.wago.io": {
+    "url": "https://addons.wago.io/user/{}",
+    "urlMain": "https://addons.wago.io/",
+    "errorType": "status_code",
+    "errorCode": 404,
     "username_claimed": "blue"
   },
   "AdmireMe.Vip": {
@@ -70,6 +69,12 @@
     "urlMain": "https://www.airliners.net/",
     "username_claimed": "yushinlin"
   },
+  "akniga": {
+    "errorType": "status_code",
+    "url": "https://akniga.org/profile/{}",
+    "urlMain": "https://akniga.org/profile/blue/",
+    "username_claimed": "blue"
+  },
   "All Things Worn": {
     "errorMsg": "Sell Used Panties",
     "errorType": "message",
@@ -84,13 +89,6 @@
     "regexCheck": "^[a-z0-9][a-z0-9-]{2,32}$",
     "url": "https://allmylinks.com/{}",
     "urlMain": "https://allmylinks.com/",
-    "username_claimed": "blue"
-  },
-  "AniWorld": {
-    "errorMsg": "Dieses Profil ist nicht verf\u00fcgbar",
-    "errorType": "message",
-    "url": "https://aniworld.to/user/profil/{}",
-    "urlMain": "https://aniworld.to/",
     "username_claimed": "blue"
   },
   "Anilist": {
@@ -108,6 +106,29 @@
     "urlProbe": "https://graphql.anilist.co/",
     "username_claimed": "Josh"
   },
+  "AniWorld": {
+    "errorMsg": "Dieses Profil ist nicht verfügbar",
+    "errorType": "message",
+    "url": "https://aniworld.to/user/profil/{}",
+    "urlMain": "https://aniworld.to/",
+    "username_claimed": "blue"
+  },
+  "Aparat": {
+    "errorType": "status_code",
+    "request_method": "GET",
+    "url": "https://www.aparat.com/{}/",
+    "urlMain": "https://www.aparat.com/",
+    "urlProbe": "https://www.aparat.com/api/fa/v1/user/user/information/username/{}",
+    "username_claimed": "jadi"
+  },
+  "APClips": {
+    "errorMsg": "Amateur Porn Content Creators",
+    "errorType": "message",
+    "isNSFW": true,
+    "url": "https://apclips.com/{}",
+    "urlMain": "https://apclips.com/",
+    "username_claimed": "onlybbyraq"
+  },
   "Apple Developer": {
     "errorType": "status_code",
     "url": "https://developer.apple.com/forums/profile/{}",
@@ -120,14 +141,6 @@
     "url": "https://discussions.apple.com/profile/{}",
     "urlMain": "https://discussions.apple.com",
     "username_claimed": "jason"
-  },
-  "Aparat": {
-    "errorType": "status_code",
-    "request_method": "GET",
-    "url": "https://www.aparat.com/{}/",
-    "urlMain": "https://www.aparat.com/",
-    "urlProbe": "https://www.aparat.com/api/fa/v1/user/user/information/username/{}",
-    "username_claimed": "jadi"
   },
   "Archive of Our Own": {
     "errorType": "status_code",
@@ -179,17 +192,17 @@
     "urlMain": "https://atcoder.jp/",
     "username_claimed": "ksun48"
   },
-  "Vjudge": {
-    "errorType": "status_code",
-    "url": "https://VJudge.net/user/{}",
-    "urlMain": "https://VJudge.net/",
-    "username_claimed": "tokitsukaze"
-  },
   "Audiojungle": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z0-9_]+$",
     "url": "https://audiojungle.net/user/{}",
     "urlMain": "https://audiojungle.net/",
+    "username_claimed": "blue"
+  },
+  "authorSTREAM": {
+    "errorType": "status_code",
+    "url": "http://www.authorstream.com/{}/",
+    "urlMain": "http://www.authorstream.com/",
     "username_claimed": "blue"
   },
   "Autofrage": {
@@ -212,13 +225,22 @@
     "urlMain": "https://skillsprofile.skillbuilder.aws",
     "username_claimed": "mayank04pant"
   },
-  "BOOTH": {
+  "babyblogRU": {
     "errorType": "response_url",
-    "errorUrl": "https://booth.pm/",
-    "regexCheck": "^[\\w@-]+?$",
-    "url": "https://{}.booth.pm/",
-    "urlMain": "https://booth.pm/",
+    "errorUrl": "https://www.babyblog.ru/",
+    "url": "https://www.babyblog.ru/user/{}",
+    "urlMain": "https://www.babyblog.ru/",
     "username_claimed": "blue"
+  },
+  "BabyRu": {
+    "url": "https://www.baby.ru/u/{}",
+    "urlMain": "https://www.baby.ru/",
+    "errorType": "message",
+    "errorMsg": [
+      "Страница, которую вы искали, не найдена",
+      "Доступ с вашего IP-адреса временно ограничен"
+    ],
+    "username_claimed": "example"
   },
   "Bandcamp": {
     "errorType": "status_code",
@@ -298,6 +320,14 @@
     "urlMain": "https://bsky.app/",
     "username_claimed": "mcuban"
   },
+  "BoardGameGeek": {
+    "errorMsg": "\"isValid\":true",
+    "errorType": "message",
+    "url": "https://boardgamegeek.com/user/{}",
+    "urlMain": "https://boardgamegeek.com/",
+    "urlProbe": "https://api.geekdo.com/api/accounts/validate/username?username={}",
+    "username_claimed": "blue"
+  },
   "BongaCams": {
     "errorType": "status_code",
     "isNSFW": true,
@@ -311,12 +341,12 @@
     "urlMain": "https://www.bookcrossing.com/",
     "username_claimed": "blue"
   },
-  "BoardGameGeek": {
-    "errorMsg": "\"isValid\":true",
-    "errorType": "message",
-    "url": "https://boardgamegeek.com/user/{}",
-    "urlMain": "https://boardgamegeek.com/",
-    "urlProbe": "https://api.geekdo.com/api/accounts/validate/username?username={}",
+  "BOOTH": {
+    "errorType": "response_url",
+    "errorUrl": "https://booth.pm/",
+    "regexCheck": "^[\\w@-]+?$",
+    "url": "https://{}.booth.pm/",
+    "urlMain": "https://booth.pm/",
     "username_claimed": "blue"
   },
   "BraveCommunity": {
@@ -352,38 +382,6 @@
     "urlMain": "https://buzzfeed.com/",
     "username_claimed": "blue"
   },
-  "Cfx.re Forum": {
-    "errorType": "status_code",
-    "url": "https://forum.cfx.re/u/{}/summary",
-    "urlMain": "https://forum.cfx.re",
-    "username_claimed": "hightowerlssd"
-  },
-  "CGTrader": {
-    "errorType": "status_code",
-    "regexCheck": "^[^.]*?$",
-    "url": "https://www.cgtrader.com/{}",
-    "urlMain": "https://www.cgtrader.com",
-    "username_claimed": "blue"
-  },
-  "CNET": {
-    "errorType": "status_code",
-    "regexCheck": "^[a-z].*$",
-    "url": "https://www.cnet.com/profiles/{}/",
-    "urlMain": "https://www.cnet.com/",
-    "username_claimed": "melliott"
-  },
-  "CSSBattle": {
-    "errorType": "status_code",
-    "url": "https://cssbattle.dev/player/{}",
-    "urlMain": "https://cssbattle.dev",
-    "username_claimed": "beo"
-  },
-  "CTAN": {
-    "errorType": "status_code",
-    "url": "https://ctan.org/author/{}",
-    "urlMain": "https://ctan.org/",
-    "username_claimed": "briggs"
-  },
   "Caddy Community": {
     "errorType": "status_code",
     "url": "https://caddy.community/u/{}/summary",
@@ -405,7 +403,7 @@
     "username_claimed": "jenny"
   },
   "Career.habr": {
-    "errorMsg": "<h1>\u041e\u0448\u0438\u0431\u043a\u0430 404</h1>",
+    "errorMsg": "<h1>Ошибка 404</h1>",
     "errorType": "message",
     "url": "https://career.habr.com/{}",
     "urlMain": "https://career.habr.com/",
@@ -416,6 +414,19 @@
     "url": "https://cash.app/${}",
     "urlMain": "https://cash.app",
     "username_claimed": "hotdiggitydog"
+  },
+  "Cfx.re Forum": {
+    "errorType": "status_code",
+    "url": "https://forum.cfx.re/u/{}/summary",
+    "urlMain": "https://forum.cfx.re",
+    "username_claimed": "hightowerlssd"
+  },
+  "CGTrader": {
+    "errorType": "status_code",
+    "regexCheck": "^[^.]*?$",
+    "url": "https://www.cgtrader.com/{}",
+    "urlMain": "https://www.cgtrader.com",
+    "username_claimed": "blue"
   },
   "Championat": {
     "errorType": "status_code",
@@ -429,8 +440,14 @@
     "urlMain": "https://chaos.social/",
     "username_claimed": "ordnung"
   },
+  "chaos.social": {
+    "errorType": "status_code",
+    "url": "https://chaos.social/@{}",
+    "urlMain": "https://chaos.social/",
+    "username_claimed": "rixx"
+  },
   "Chatujme.cz": {
-    "errorMsg": "Neexistujic\u00ed profil",
+    "errorMsg": "Neexistujicí profil",
     "errorType": "message",
     "regexCheck": "^[a-zA-Z][a-zA-Z1-9_-]*$",
     "url": "https://profil.chatujme.cz/{}",
@@ -459,6 +476,13 @@
     "urlMain": "https://choice.community/",
     "username_claimed": "gordon"
   },
+  "Chollometro": {
+    "errorType": "status_code",
+    "url": "https://www.chollometro.com/profile/{}",
+    "urlMain": "https://www.chollometro.com/",
+    "username_claimed": "blue",
+    "request_method": "GET"
+  },
   "Clapper": {
     "errorType": "status_code",
     "url": "https://clapperapp.com/{}",
@@ -483,6 +507,13 @@
     "url": "https://www.clubhouse.com/@{}",
     "urlMain": "https://www.clubhouse.com",
     "username_claimed": "waniathar"
+  },
+  "CNET": {
+    "errorType": "status_code",
+    "regexCheck": "^[a-z].*$",
+    "url": "https://www.cnet.com/profiles/{}/",
+    "urlMain": "https://www.cnet.com/",
+    "username_claimed": "melliott"
   },
   "Code Snippet Wiki": {
     "errorMsg": "This user has not filled out their profile page yet",
@@ -587,6 +618,12 @@
     "urlMain": "https://coroflot.com/",
     "username_claimed": "blue"
   },
+  "couchsurfing": {
+    "errorType": "status_code",
+    "url": "https://www.couchsurfing.com/people/{}",
+    "urlMain": "https://www.couchsurfing.com/",
+    "username_claimed": "blue"
+  },
   "Cplusplus": {
     "errorType": "message",
     "errorMsg": "<title>404 Page Not Found</title>",
@@ -641,12 +678,31 @@
     "urlMain": "https://community.cryptomator.org/",
     "username_claimed": "michael"
   },
+  "CSSBattle": {
+    "errorType": "status_code",
+    "url": "https://cssbattle.dev/player/{}",
+    "urlMain": "https://cssbattle.dev",
+    "username_claimed": "beo"
+  },
+  "CTAN": {
+    "errorType": "status_code",
+    "url": "https://ctan.org/author/{}",
+    "urlMain": "https://ctan.org/",
+    "username_claimed": "briggs"
+  },
   "Cults3D": {
     "errorMsg": "Oh dear, this page is not working!",
     "errorType": "message",
     "url": "https://cults3d.com/en/users/{}/creations",
     "urlMain": "https://cults3d.com/en",
     "username_claimed": "brown"
+  },
+  "CurseForge": {
+    "url": "https://www.curseforge.com/members/{}/projects",
+    "urlMain": "https://www.curseforge.com.",
+    "errorType": "status_code",
+    "errorCode": 404,
+    "username_claimed": "blue"
   },
   "CyberDefenders": {
     "errorType": "status_code",
@@ -656,24 +712,30 @@
     "urlMain": "https://cyberdefenders.org/",
     "username_claimed": "mlohn"
   },
-  "DEV Community": {
+  "d3RU": {
     "errorType": "status_code",
-    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
-    "url": "https://dev.to/{}",
-    "urlMain": "https://dev.to/",
+    "url": "https://d3.ru/user/{}/posts",
+    "urlMain": "https://d3.ru/",
     "username_claimed": "blue"
   },
-  "DMOJ": {
-    "errorMsg": "No such user",
+  "dailykos": {
+    "errorMsg": "{\"result\":true,\"message\":null}",
     "errorType": "message",
-    "url": "https://dmoj.ca/user/{}",
-    "urlMain": "https://dmoj.ca/",
-    "username_claimed": "junferno"
+    "url": "https://www.dailykos.com/user/{}",
+    "urlMain": "https://www.dailykos.com",
+    "urlProbe": "https://www.dailykos.com/signup/check_nickname?nickname={}",
+    "username_claimed": "blue"
   },
   "DailyMotion": {
     "errorType": "status_code",
     "url": "https://www.dailymotion.com/{}",
     "urlMain": "https://www.dailymotion.com/",
+    "username_claimed": "blue"
+  },
+  "datingRU": {
+    "errorType": "status_code",
+    "url": "http://dating.ru/{}",
+    "urlMain": "http://dating.ru",
     "username_claimed": "blue"
   },
   "dcinside": {
@@ -690,12 +752,26 @@
     "urlMain": "https://www.dealabs.com/",
     "username_claimed": "blue"
   },
+  "DEV Community": {
+    "errorType": "status_code",
+    "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
+    "url": "https://dev.to/{}",
+    "urlMain": "https://dev.to/",
+    "username_claimed": "blue"
+  },
   "DeviantArt": {
     "errorType": "message",
     "errorMsg": "Llama Not Found",
     "regexCheck": "^[a-zA-Z][a-zA-Z0-9_-]*$",
     "url": "https://www.deviantart.com/{}",
     "urlMain": "https://www.deviantart.com/",
+    "username_claimed": "blue"
+  },
+  "devRant": {
+    "errorType": "response_url",
+    "errorUrl": "https://devrant.com/",
+    "url": "https://devrant.com/users/{}",
+    "urlMain": "https://devrant.com/",
     "username_claimed": "blue"
   },
   "DigitalSpy": {
@@ -717,7 +793,10 @@
     "url": "https://discord.com",
     "urlMain": "https://discord.com/",
     "urlProbe": "https://discord.com/api/v9/unique-username/username-attempt-unauthed",
-    "errorMsg": ["{\"taken\":false}", "The resource is being rate limited"],
+    "errorMsg": [
+      "{\"taken\":false}",
+      "The resource is being rate limited"
+    ],
     "request_method": "POST",
     "request_payload": {
       "username": "{}"
@@ -755,6 +834,13 @@
     "urlMain": "https://disqus.com/",
     "username_claimed": "blue"
   },
+  "DMOJ": {
+    "errorMsg": "No such user",
+    "errorType": "message",
+    "url": "https://dmoj.ca/user/{}",
+    "urlMain": "https://dmoj.ca/",
+    "username_claimed": "junferno"
+  },
   "Docker Hub": {
     "errorType": "status_code",
     "url": "https://hub.docker.com/u/{}/",
@@ -770,12 +856,31 @@
     "urlMain": "https://dribbble.com/",
     "username_claimed": "blue"
   },
+  "drive2": {
+    "errorType": "status_code",
+    "url": "https://www.drive2.ru/users/{}",
+    "urlMain": "https://www.drive2.ru/",
+    "username_claimed": "blue"
+  },
   "Duolingo": {
     "errorMsg": "{\"users\":[]}",
     "errorType": "message",
     "url": "https://www.duolingo.com/profile/{}",
     "urlMain": "https://duolingo.com/",
     "urlProbe": "https://www.duolingo.com/2017-06-30/users?username={}",
+    "username_claimed": "blue"
+  },
+  "eGPU": {
+    "errorType": "status_code",
+    "url": "https://egpu.io/forums/profile/{}/",
+    "urlMain": "https://egpu.io/",
+    "username_claimed": "blue"
+  },
+  "eintracht": {
+    "errorType": "status_code",
+    "regexCheck": "^[^.]*?$",
+    "url": "https://community.eintracht.de/fans/{}",
+    "urlMain": "https://eintracht.de",
     "username_claimed": "blue"
   },
   "Eintracht Frankfurt Forum": {
@@ -805,18 +910,18 @@
     "urlMain": "https://www.erome.com/",
     "username_claimed": "bob"
   },
+  "exophase": {
+    "errorType": "status_code",
+    "url": "https://www.exophase.com/user/{}/",
+    "urlMain": "https://www.exophase.com/",
+    "username_claimed": "blue"
+  },
   "Exposure": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z0-9-]{1,63}$",
     "url": "https://{}.exposure.co/",
     "urlMain": "https://exposure.co/",
     "username_claimed": "jonasjacobsson"
-  },
-  "exophase": {
-    "errorType": "status_code",
-    "url": "https://www.exophase.com/user/{}/",
-    "urlMain": "https://www.exophase.com/",
-    "username_claimed": "blue"
   },
   "EyeEm": {
     "errorType": "status_code",
@@ -855,6 +960,18 @@
     "urlMain": "https://www.finanzfrage.net/",
     "username_claimed": "finanzfrage"
   },
+  "fixya": {
+    "errorType": "status_code",
+    "url": "https://www.fixya.com/users/{}",
+    "urlMain": "https://www.fixya.com",
+    "username_claimed": "adam"
+  },
+  "fl": {
+    "errorType": "status_code",
+    "url": "https://www.fl.ru/users/{}",
+    "urlMain": "https://www.fl.ru/",
+    "username_claimed": "blue"
+  },
   "Flickr": {
     "errorType": "status_code",
     "url": "https://www.flickr.com/people/{}",
@@ -876,7 +993,7 @@
     "username_claimed": "blue"
   },
   "Football": {
-    "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u0441 \u0442\u0430\u043a\u0438\u043c \u0438\u043c\u0435\u043d\u0435\u043c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d",
+    "errorMsg": "Пользователь с таким именем не найден",
     "errorType": "message",
     "url": "https://www.rusfootball.info/user/{}/",
     "urlMain": "https://www.rusfootball.info/",
@@ -896,6 +1013,13 @@
     "urlMain": "https://www.forumophilia.com/",
     "username_claimed": "bob"
   },
+  "forum_guns": {
+    "errorMsg": "action=https://forum.guns.ru/forummisc/blog/search",
+    "errorType": "message",
+    "url": "https://forum.guns.ru/forummisc/blog/{}",
+    "urlMain": "https://forum.guns.ru/",
+    "username_claimed": "red"
+  },
   "Fosstodon": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z0-9_]{1,30}$",
@@ -909,6 +1033,13 @@
     "url": "https://framapiaf.org/@{}",
     "urlMain": "https://framapiaf.org",
     "username_claimed": "pylapp"
+  },
+  "freecodecamp": {
+    "errorType": "status_code",
+    "url": "https://www.freecodecamp.org/{}",
+    "urlMain": "https://www.freecodecamp.org/",
+    "urlProbe": "https://api.freecodecamp.org/api/users/get-public-profile?username={}",
+    "username_claimed": "naveennamani"
   },
   "Freelancer": {
     "errorMsg": "\"users\":{}",
@@ -924,13 +1055,12 @@
     "urlMain": "https://freesound.org/",
     "username_claimed": "blue"
   },
-  "GNOME VCS": {
-    "errorType": "response_url",
-    "errorUrl": "https://gitlab.gnome.org/{}",
-    "regexCheck": "^(?!-)[a-zA-Z0-9_.-]{2,255}(?<!\\.)$",
-    "url": "https://gitlab.gnome.org/{}",
-    "urlMain": "https://gitlab.gnome.org/",
-    "username_claimed": "adam"
+  "furaffinity": {
+    "errorMsg": "This user cannot be found.",
+    "errorType": "message",
+    "url": "https://www.furaffinity.net/user/{}",
+    "urlMain": "https://www.furaffinity.net",
+    "username_claimed": "jesus"
   },
   "GaiaOnline": {
     "errorMsg": "No user ID specified or user does not exist",
@@ -939,16 +1069,16 @@
     "urlMain": "https://www.gaiaonline.com/",
     "username_claimed": "adam"
   },
-  "Gamespot": {
-    "errorType": "status_code",
-    "url": "https://www.gamespot.com/profile/{}/",
-    "urlMain": "https://www.gamespot.com/",
-    "username_claimed": "blue"
-  },
   "GameFAQs": {
     "errorType": "status_code",
     "url": "https://gamefaqs.gamespot.com/community/{}",
     "urlMain": "https://gamefaqs.gamespot.com",
+    "username_claimed": "blue"
+  },
+  "Gamespot": {
+    "errorType": "status_code",
+    "url": "https://www.gamespot.com/profile/{}/",
+    "urlMain": "https://www.gamespot.com/",
     "username_claimed": "blue"
   },
   "GeeksforGeeks": {
@@ -970,6 +1100,12 @@
     "url": "https://genius.com/{}",
     "urlMain": "https://genius.com/",
     "username_claimed": "genius"
+  },
+  "geocaching": {
+    "errorType": "status_code",
+    "url": "https://www.geocaching.com/p/default.aspx?u={}",
+    "urlMain": "https://www.geocaching.com/",
+    "username_claimed": "blue"
   },
   "Gesundheitsfrage": {
     "errorType": "status_code",
@@ -1003,29 +1139,6 @@
     "urlMain": "https://gitbook.com/",
     "username_claimed": "gitbook"
   },
-  "GitHub": {
-    "errorType": "status_code",
-    "regexCheck": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$",
-    "url": "https://www.github.com/{}",
-    "urlMain": "https://www.github.com/",
-    "username_claimed": "blue"
-  },
-  "Warframe Market": {
-    "errorType": "status_code",
-    "request_method": "GET",
-    "url": "https://warframe.market/profile/{}",
-    "urlMain": "https://warframe.market/",
-    "urlProbe": "https://api.warframe.market/v2/user/{}",
-    "username_claimed": "kaiallalone"
-  },
-  "GitLab": {
-    "errorMsg": "[]",
-    "errorType": "message",
-    "url": "https://gitlab.com/{}",
-    "urlMain": "https://gitlab.com/",
-    "urlProbe": "https://gitlab.com/api/v4/users?username={}",
-    "username_claimed": "blue"
-  },
   "Gitea": {
     "errorType": "status_code",
     "url": "https://gitea.com/{}",
@@ -1037,6 +1150,29 @@
     "url": "https://gitee.com/{}",
     "urlMain": "https://gitee.com/",
     "username_claimed": "wizzer"
+  },
+  "GitHub": {
+    "errorType": "status_code",
+    "regexCheck": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$",
+    "url": "https://www.github.com/{}",
+    "urlMain": "https://www.github.com/",
+    "username_claimed": "blue"
+  },
+  "GitLab": {
+    "errorMsg": "[]",
+    "errorType": "message",
+    "url": "https://gitlab.com/{}",
+    "urlMain": "https://gitlab.com/",
+    "urlProbe": "https://gitlab.com/api/v4/users?username={}",
+    "username_claimed": "blue"
+  },
+  "GNOME VCS": {
+    "errorType": "response_url",
+    "errorUrl": "https://gitlab.gnome.org/{}",
+    "regexCheck": "^(?!-)[a-zA-Z0-9_.-]{2,255}(?<!\\.)$",
+    "url": "https://gitlab.gnome.org/{}",
+    "urlMain": "https://gitlab.gnome.org/",
+    "username_claimed": "adam"
   },
   "GoodReads": {
     "errorType": "status_code",
@@ -1086,11 +1222,11 @@
     "urlMain": "https://www.gutefrage.net/",
     "username_claimed": "gutefrage"
   },
-  "HackTheBox": {
+  "habr": {
     "errorType": "status_code",
-    "url": "https://forum.hackthebox.com/u/{}",
-    "urlMain": "https://forum.hackthebox.com/",
-    "username_claimed": "angar"
+    "url": "https://habr.com/ru/users/{}",
+    "urlMain": "https://habr.com/",
+    "username_claimed": "blue"
   },
   "Hackaday": {
     "errorType": "status_code",
@@ -1114,7 +1250,10 @@
   },
   "HackerNews": {
     "__comment__": "First errMsg invalid, second errMsg rate limited. Not ideal. Adjust for better rate limit filtering.",
-    "errorMsg": ["No such user.", "Sorry."],
+    "errorMsg": [
+      "No such user.",
+      "Sorry."
+    ],
     "errorType": "message",
     "url": "https://news.ycombinator.com/user?id={}",
     "urlMain": "https://news.ycombinator.com/",
@@ -1146,6 +1285,18 @@
     "url": "https://hackmd.io/@{}",
     "urlMain": "https://hackmd.io/",
     "username_claimed": "blue"
+  },
+  "hackster": {
+    "errorType": "status_code",
+    "url": "https://www.hackster.io/{}",
+    "urlMain": "https://www.hackster.io",
+    "username_claimed": "blue"
+  },
+  "HackTheBox": {
+    "errorType": "status_code",
+    "url": "https://forum.hackthebox.com/u/{}",
+    "urlMain": "https://forum.hackthebox.com/",
+    "username_claimed": "angar"
   },
   "Harvard Scholar": {
     "errorType": "status_code",
@@ -1186,6 +1337,13 @@
     "urlProbe": "https://www.holopin.io/api/auth/username",
     "username_claimed": "red"
   },
+  "HotUKdeals": {
+    "errorType": "status_code",
+    "url": "https://www.hotukdeals.com/profile/{}",
+    "urlMain": "https://www.hotukdeals.com/",
+    "username_claimed": "Blue",
+    "request_method": "GET"
+  },
   "Houzz": {
     "errorType": "status_code",
     "url": "https://houzz.com/user/{}",
@@ -1218,6 +1376,19 @@
     "urlMain": "https://huggingface.co/",
     "username_claimed": "Pasanlaksitha"
   },
+  "hunting": {
+    "errorMsg": "Указанный пользователь не найден. Пожалуйста, введите другое имя.",
+    "errorType": "message",
+    "url": "https://www.hunting.ru/forum/members/?username={}",
+    "urlMain": "https://www.hunting.ru/forum/",
+    "username_claimed": "red"
+  },
+  "Icons8 Community": {
+    "errorType": "status_code",
+    "url": "https://community.icons8.com/u/{}/summary",
+    "urlMain": "https://community.icons8.com/",
+    "username_claimed": "thefourCraft"
+  },
   "IFTTT": {
     "errorType": "status_code",
     "regexCheck": "^[A-Za-z0-9]{3,35}$",
@@ -1231,18 +1402,12 @@
     "urlMain": "https://ifunny.co/",
     "username_claimed": "agua"
   },
-  "IRC-Galleria": {
-    "errorType": "response_url",
-    "errorUrl": "https://irc-galleria.net/users/search?username={}",
-    "url": "https://irc-galleria.net/user/{}",
-    "urlMain": "https://irc-galleria.net/",
-    "username_claimed": "appas"
-  },
-  "Icons8 Community": {
-    "errorType": "status_code",
-    "url": "https://community.icons8.com/u/{}/summary",
-    "urlMain": "https://community.icons8.com/",
-    "username_claimed": "thefourCraft"
+  "igromania": {
+    "errorMsg": "Пользователь не зарегистрирован и не имеет профиля для просмотра.",
+    "errorType": "message",
+    "url": "http://forum.igromania.ru/member.php?username={}",
+    "urlMain": "http://forum.igromania.ru/",
+    "username_claimed": "blue"
   },
   "Image Fap": {
     "errorMsg": "Not found",
@@ -1292,6 +1457,13 @@
     "urlProbe": "https://www.instructables.com/json-api/showAuthorExists?screenName={}",
     "username_claimed": "blue"
   },
+  "interpals": {
+    "errorMsg": "The requested user does not exist or is inactive",
+    "errorType": "message",
+    "url": "https://www.interpals.net/{}",
+    "urlMain": "https://www.interpals.net/",
+    "username_claimed": "blue"
+  },
   "Intigriti": {
     "errorType": "status_code",
     "regexCheck": "[a-z0-9_]{1,25}",
@@ -1306,6 +1478,19 @@
     "url": "https://forum.ionicframework.com/u/{}",
     "urlMain": "https://forum.ionicframework.com/",
     "username_claimed": "theblue222"
+  },
+  "IRC-Galleria": {
+    "errorType": "response_url",
+    "errorUrl": "https://irc-galleria.net/users/search?username={}",
+    "url": "https://irc-galleria.net/user/{}",
+    "urlMain": "https://irc-galleria.net/",
+    "username_claimed": "appas"
+  },
+  "irecommend": {
+    "errorType": "status_code",
+    "url": "https://irecommend.ru/users/{}",
+    "urlMain": "https://irecommend.ru/",
+    "username_claimed": "blue"
   },
   "Issuu": {
     "errorType": "status_code",
@@ -1327,12 +1512,26 @@
     "urlMain": "https://www.itemfix.com/",
     "username_claimed": "blue"
   },
+  "jbzd.com.pl": {
+    "errorType": "status_code",
+    "url": "https://jbzd.com.pl/uzytkownik/{}",
+    "urlMain": "https://jbzd.com.pl/",
+    "username_claimed": "blue"
+  },
   "Jellyfin Weblate": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z0-9@._-]{1,150}$",
     "url": "https://translate.jellyfin.org/user/{}/",
     "urlMain": "https://translate.jellyfin.org/",
     "username_claimed": "EraYaN"
+  },
+  "jeuxvideo": {
+    "errorType": "status_code",
+    "request_method": "GET",
+    "url": "https://www.jeuxvideo.com/profil/{}",
+    "urlMain": "https://www.jeuxvideo.com",
+    "urlProbe": "https://www.jeuxvideo.com/profil/{}?mode=infos",
+    "username_claimed": "adam"
   },
   "Jimdo": {
     "errorType": "status_code",
@@ -1390,6 +1589,13 @@
     "urlProbe": "https://ws2.kik.com/user/{}",
     "username_claimed": "blue"
   },
+  "kofi": {
+    "errorType": "response_url",
+    "errorUrl": "https://ko-fi.com/art?=redirect",
+    "url": "https://ko-fi.com/{}",
+    "urlMain": "https://ko-fi.com",
+    "username_claimed": "yeahkenny"
+  },
   "Kongregate": {
     "errorType": "status_code",
     "headers": {
@@ -1409,11 +1615,11 @@
     "urlMain": "https://forum.kvinneguiden.no",
     "username_claimed": "blue"
   },
-  "LOR": {
+  "kwork": {
     "errorType": "status_code",
-    "url": "https://www.linux.org.ru/people/{}/profile",
-    "urlMain": "https://linux.org.ru/",
-    "username_claimed": "red"
+    "url": "https://kwork.ru/user/{}",
+    "urlMain": "https://www.kwork.ru/",
+    "username_claimed": "blue"
   },
   "Laracast": {
     "errorType": "status_code",
@@ -1422,11 +1628,23 @@
     "regexCheck": "^[a-zA-Z0-9_-]{3,}$",
     "username_claimed": "user1"
   },
+  "last.fm": {
+    "errorType": "status_code",
+    "url": "https://last.fm/user/{}",
+    "urlMain": "https://last.fm/",
+    "username_claimed": "blue"
+  },
   "Launchpad": {
     "errorType": "status_code",
     "url": "https://launchpad.net/~{}",
     "urlMain": "https://launchpad.net/",
     "username_claimed": "blue"
+  },
+  "leasehackr": {
+    "errorType": "status_code",
+    "url": "https://forum.leasehackr.com/u/{}/summary/",
+    "urlMain": "https://forum.leasehackr.com/",
+    "username_claimed": "adam"
   },
   "LeetCode": {
     "errorType": "status_code",
@@ -1449,7 +1667,7 @@
     "username_claimed": "habryka"
   },
   "Letterboxd": {
-    "errorMsg": "Sorry, we can\u2019t find the page you\u2019ve requested.",
+    "errorMsg": "Sorry, we can’t find the page you’ve requested.",
     "errorType": "message",
     "url": "https://letterboxd.com/{}",
     "urlMain": "https://letterboxd.com/",
@@ -1471,7 +1689,7 @@
     "urlMain": "https://lichess.org",
     "username_claimed": "john"
   },
- "LinkedIn": {
+  "LinkedIn": {
     "errorType": "status_code",
     "headers": {
       "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -1512,12 +1730,24 @@
     "urlMain": "https://www.livejournal.com/",
     "username_claimed": "blue"
   },
+  "livelib": {
+    "errorType": "status_code",
+    "url": "https://www.livelib.ru/reader/{}",
+    "urlMain": "https://www.livelib.ru/",
+    "username_claimed": "blue"
+  },
   "Lobsters": {
     "errorType": "status_code",
     "regexCheck": "[A-Za-z0-9][A-Za-z0-9_-]{0,24}",
     "url": "https://lobste.rs/u/{}",
     "urlMain": "https://lobste.rs/",
     "username_claimed": "jcs"
+  },
+  "LOR": {
+    "errorType": "status_code",
+    "url": "https://www.linux.org.ru/people/{}/profile",
+    "urlMain": "https://linux.org.ru/",
+    "username_claimed": "red"
   },
   "LottieFiles": {
     "errorType": "status_code",
@@ -1532,18 +1762,30 @@
     "urlMain": "https://www.lushstories.com/",
     "username_claimed": "chris_brown"
   },
-  "MMORPG Forum": {
-    "errorType": "status_code",
-    "url": "https://forums.mmorpg.com/profile/{}",
-    "urlMain": "https://forums.mmorpg.com/",
-    "username_claimed": "goku"
-  },
   "Mamot": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z0-9_]{1,30}$",
     "url": "https://mamot.fr/@{}",
     "urlMain": "https://mamot.fr/",
     "username_claimed": "anciensEnssat"
+  },
+  "mastodon.cloud": {
+    "errorType": "status_code",
+    "url": "https://mastodon.cloud/@{}",
+    "urlMain": "https://mastodon.cloud/",
+    "username_claimed": "TheAdmin"
+  },
+  "mastodon.social": {
+    "errorType": "status_code",
+    "url": "https://mastodon.social/@{}",
+    "urlMain": "https://chaos.social/",
+    "username_claimed": "Gargron"
+  },
+  "mastodon.xyz": {
+    "errorType": "status_code",
+    "url": "https://mastodon.xyz/@{}",
+    "urlMain": "https://mastodon.xyz/",
+    "username_claimed": "TheKinrar"
   },
   "Medium": {
     "errorMsg": "<body",
@@ -1559,6 +1801,20 @@
     "urlMain": "https://www.memrise.com/",
     "username_claimed": "blue"
   },
+  "mercadolivre": {
+    "errorType": "status_code",
+    "url": "https://www.mercadolivre.com.br/perfil/{}",
+    "urlMain": "https://www.mercadolivre.com.br",
+    "username_claimed": "blue"
+  },
+  "minds": {
+    "errorMsg": "\"valid\":true",
+    "errorType": "message",
+    "url": "https://www.minds.com/{}/",
+    "urlMain": "https://www.minds.com",
+    "urlProbe": "https://www.minds.com/api/v3/register/validate?username={}",
+    "username_claimed": "john"
+  },
   "Minecraft": {
     "errorMsg": "Couldn't find any profile with name",
     "errorType": "message",
@@ -1573,6 +1829,18 @@
     "urlMain": "https://www.mixcloud.com/",
     "urlProbe": "https://api.mixcloud.com/{}/",
     "username_claimed": "jenny"
+  },
+  "MMORPG Forum": {
+    "errorType": "status_code",
+    "url": "https://forums.mmorpg.com/profile/{}",
+    "urlMain": "https://forums.mmorpg.com/",
+    "username_claimed": "goku"
+  },
+  "moikrug": {
+    "errorType": "status_code",
+    "url": "https://moikrug.ru/{}",
+    "urlMain": "https://moikrug.ru/",
+    "username_claimed": "blue"
   },
   "Monkeytype": {
     "errorType": "status_code",
@@ -1595,6 +1863,18 @@
     "urlMain": "https://www.motorradfrage.net/",
     "username_claimed": "gutefrage"
   },
+  "mstdn.io": {
+    "errorType": "status_code",
+    "url": "https://mstdn.io/@{}",
+    "urlMain": "https://mstdn.io/",
+    "username_claimed": "blue"
+  },
+  "mstdn.social": {
+    "errorType": "status_code",
+    "url": "https://mstdn.social/@{}",
+    "urlMain": "https://mstdn.social/",
+    "username_claimed": "MagicLike"
+  },
   "MuseScore": {
     "errorType": "status_code",
     "url": "https://musescore.com/{}",
@@ -1608,11 +1888,12 @@
     "urlMain": "https://myanimelist.net/",
     "username_claimed": "blue"
   },
-  "MyMiniFactory": {
+  "Mydealz": {
     "errorType": "status_code",
-    "url": "https://www.myminifactory.com/users/{}",
-    "urlMain": "https://www.myminifactory.com/",
-    "username_claimed": "blue"
+    "url": "https://www.mydealz.de/profile/{}",
+    "urlMain": "https://www.mydealz.de/",
+    "username_claimed": "blue",
+    "request_method": "GET"
   },
   "Mydramalist": {
     "errorMsg": "The requested page was not found",
@@ -1621,18 +1902,29 @@
     "urlMain": "https://mydramalist.com",
     "username_claimed": "elhadidy12398"
   },
+  "MyMiniFactory": {
+    "errorType": "status_code",
+    "url": "https://www.myminifactory.com/users/{}",
+    "urlMain": "https://www.myminifactory.com/",
+    "username_claimed": "blue"
+  },
   "Myspace": {
     "errorType": "status_code",
     "url": "https://myspace.com/{}",
     "urlMain": "https://myspace.com/",
     "username_claimed": "blue"
   },
-  "NICommunityForum": {
-    "errorMsg": "The page you were looking for could not be found.",
-    "errorType": "message",
-    "url": "https://community.native-instruments.com/profile/{}",
-    "urlMain": "https://www.native-instruments.com/forum/",
-    "username_claimed": "jambert"
+  "n8n Community": {
+    "errorType": "status_code",
+    "url": "https://community.n8n.io/u/{}/summary",
+    "urlMain": "https://community.n8n.io/",
+    "username_claimed": "n8n"
+  },
+  "nairaland.com": {
+    "errorType": "status_code",
+    "url": "https://www.nairaland.com/{}",
+    "urlMain": "https://www.nairaland.com/",
+    "username_claimed": "red"
   },
   "namuwiki": {
     "__comment__": "This is a Korean site and it's expected to return false negatives in certain other regions.",
@@ -1681,6 +1973,13 @@
     "urlMain": "https://nextcloud.com/",
     "username_claimed": "blue"
   },
+  "NICommunityForum": {
+    "errorMsg": "The page you were looking for could not be found.",
+    "errorType": "message",
+    "url": "https://community.native-instruments.com/profile/{}",
+    "urlMain": "https://www.native-instruments.com/forum/",
+    "username_claimed": "jambert"
+  },
   "Nightbot": {
     "errorType": "status_code",
     "url": "https://nightbot.tv/t/{}/commands",
@@ -1708,6 +2007,13 @@
     "urlMain": "https://www.nitrotype.com/",
     "username_claimed": "jianclash"
   },
+  "nnRU": {
+    "errorType": "status_code",
+    "regexCheck": "^[\\w@-]+?$",
+    "url": "https://{}.www.nn.ru/",
+    "urlMain": "https://www.nn.ru/",
+    "username_claimed": "blue"
+  },
   "NotABug.org": {
     "errorType": "status_code",
     "url": "https://notabug.org/{}",
@@ -1715,11 +2021,23 @@
     "urlProbe": "https://notabug.org/{}/followers",
     "username_claimed": "red"
   },
+  "note": {
+    "errorType": "status_code",
+    "url": "https://note.com/{}",
+    "urlMain": "https://note.com/",
+    "username_claimed": "blue"
+  },
   "Nothing Community": {
     "errorType": "status_code",
     "url": "https://nothing.community/u/{}",
     "urlMain": "https://nothing.community/",
     "username_claimed": "Carl"
+  },
+  "npm": {
+    "errorType": "status_code",
+    "url": "https://www.npmjs.com/~{}",
+    "urlMain": "https://www.npmjs.com/",
+    "username_claimed": "kennethsweezy"
   },
   "Nyaa.si": {
     "errorType": "status_code",
@@ -1734,6 +2052,21 @@
     "urlMain": "https://observablehq.com/",
     "username_claimed": "mbostock"
   },
+  "Odysee": {
+    "errorMsg": "<link rel=\"canonical\" content=\"odysee.com\"/>",
+    "errorType": "message",
+    "url": "https://odysee.com/@{}",
+    "urlMain": "https://odysee.com/",
+    "username_claimed": "Odysee"
+  },
+  "omg.lol": {
+    "errorMsg": "\"available\": true",
+    "errorType": "message",
+    "url": "https://{}.omg.lol",
+    "urlMain": "https://home.omg.lol",
+    "urlProbe": "https://api.omg.lol/address/{}/availability",
+    "username_claimed": "adam"
+  },
   "Open Collective": {
     "errorType": "status_code",
     "url": "https://opencollective.com/{}",
@@ -1746,6 +2079,20 @@
     "urlMain": "https://opengameart.org",
     "username_claimed": "ski"
   },
+  "opennet": {
+    "errorMsg": "Имя участника не найдено",
+    "errorType": "message",
+    "regexCheck": "^[^-]*$",
+    "url": "https://www.opennet.ru/~{}",
+    "urlMain": "https://www.opennet.ru/",
+    "username_claimed": "anonismus"
+  },
+  "Opensource": {
+    "errorType": "status_code",
+    "url": "https://opensource.com/users/{}",
+    "urlMain": "https://opensource.com/",
+    "username_claimed": "red"
+  },
   "OpenStreetMap": {
     "errorType": "status_code",
     "regexCheck": "^[^.]*?$",
@@ -1753,18 +2100,11 @@
     "urlMain": "https://www.openstreetmap.org/",
     "username_claimed": "blue"
   },
-  "Odysee": {
-    "errorMsg": "<link rel=\"canonical\" content=\"odysee.com\"/>",
-    "errorType": "message",
-    "url": "https://odysee.com/@{}",
-    "urlMain": "https://odysee.com/",
-    "username_claimed": "Odysee"
-  },
-  "Opensource": {
+  "osu!": {
     "errorType": "status_code",
-    "url": "https://opensource.com/users/{}",
-    "urlMain": "https://opensource.com/",
-    "username_claimed": "red"
+    "url": "https://osu.ppy.sh/users/{}",
+    "urlMain": "https://osu.ppy.sh/",
+    "username_claimed": "blue"
   },
   "OurDJTalk": {
     "errorMsg": "The specified member cannot be found",
@@ -1779,20 +2119,6 @@
     "url": "https://outgress.com/agents/{}",
     "urlMain": "https://outgress.com/",
     "username_claimed": "pylapp"
-  },
-  "PCGamer": {
-    "errorMsg": "The specified member cannot be found. Please enter a member's entire name.",
-    "errorType": "message",
-    "url": "https://forums.pcgamer.com/members/?username={}",
-    "urlMain": "https://pcgamer.com",
-    "username_claimed": "admin"
-  },
-  "PSNProfiles.com": {
-    "errorType": "response_url",
-    "errorUrl": "https://psnprofiles.com/?psnId={}",
-    "url": "https://psnprofiles.com/{}",
-    "urlMain": "https://psnprofiles.com/",
-    "username_claimed": "blue"
   },
   "Packagist": {
     "errorType": "response_url",
@@ -1821,6 +2147,13 @@
     "urlMain": "https://www.patreon.com/",
     "username_claimed": "blue"
   },
+  "PCGamer": {
+    "errorMsg": "The specified member cannot be found. Please enter a member's entire name.",
+    "errorType": "message",
+    "url": "https://forums.pcgamer.com/members/?username={}",
+    "urlMain": "https://pcgamer.com",
+    "username_claimed": "admin"
+  },
   "PentesterLab": {
     "errorType": "status_code",
     "regexCheck": "^[\\w]{4,30}$",
@@ -1828,25 +2161,18 @@
     "urlMain": "https://pentesterlab.com/",
     "username_claimed": "0day"
   },
-  "HotUKdeals": {
+  "Pepperdeals": {
     "errorType": "status_code",
-    "url": "https://www.hotukdeals.com/profile/{}",
-    "urlMain": "https://www.hotukdeals.com/",
-    "username_claimed": "Blue",
+    "url": "https://www.pepperdeals.se/profile/{}",
+    "urlMain": "https://www.pepperdeals.se/",
+    "username_claimed": "Mark",
     "request_method": "GET"
   },
-  "Mydealz": {
+  "PepperealsUS": {
     "errorType": "status_code",
-    "url": "https://www.mydealz.de/profile/{}",
-    "urlMain": "https://www.mydealz.de/",
-    "username_claimed": "blue",
-    "request_method": "GET"
-  },
-  "Chollometro": {
-    "errorType": "status_code",
-    "url": "https://www.chollometro.com/profile/{}",
-    "urlMain": "https://www.chollometro.com/",
-    "username_claimed": "blue",
+    "url": "https://www.pepperdeals.com/profile/{}",
+    "urlMain": "https://www.pepperdeals.com/",
+    "username_claimed": "Stepan",
     "request_method": "GET"
   },
   "PepperNL": {
@@ -1863,38 +2189,23 @@
     "username_claimed": "FireChicken",
     "request_method": "GET"
   },
-  "Preisjaeger": {
-    "errorType": "status_code",
-    "url": "https://www.preisjaeger.at/profile/{}",
-    "urlMain": "https://www.preisjaeger.at/",
-    "username_claimed": "Stefan",
-    "request_method": "GET"
-  },
-  "Pepperdeals": {
-    "errorType": "status_code",
-    "url": "https://www.pepperdeals.se/profile/{}",
-    "urlMain": "https://www.pepperdeals.se/",
-    "username_claimed": "Mark",
-    "request_method": "GET"
-  },
-  "PepperealsUS": {
-    "errorType": "status_code",
-    "url": "https://www.pepperdeals.com/profile/{}",
-    "urlMain": "https://www.pepperdeals.com/",
-    "username_claimed": "Stepan",
-    "request_method": "GET"
-  },
-  "Promodescuentos": {
-    "errorType": "status_code",
-    "url": "https://www.promodescuentos.com/profile/{}",
-    "urlMain": "https://www.promodescuentos.com/",
-    "username_claimed": "blue",
-    "request_method": "GET"
-  },
   "Periscope": {
     "errorType": "status_code",
     "url": "https://www.periscope.tv/{}/",
     "urlMain": "https://www.periscope.tv/",
+    "username_claimed": "blue"
+  },
+  "phpRU": {
+    "errorMsg": "Указанный пользователь не найден. Пожалуйста, введите другое имя.",
+    "errorType": "message",
+    "url": "https://php.ru/forum/members/?username={}",
+    "urlMain": "https://php.ru/forum/",
+    "username_claimed": "apple"
+  },
+  "pikabu": {
+    "errorType": "status_code",
+    "url": "https://pikabu.ru/@{}",
+    "urlMain": "https://pikabu.ru/",
     "username_claimed": "blue"
   },
   "Pinkbike": {
@@ -1904,11 +2215,27 @@
     "urlMain": "https://www.pinkbike.com/",
     "username_claimed": "blue"
   },
+  "Pinterest": {
+    "errorType": "status_code",
+    "errorUrl": "https://www.pinterest.com/",
+    "url": "https://www.pinterest.com/{}/",
+    "urlProbe": "https://www.pinterest.com/oembed.json?url=https://www.pinterest.com/{}/",
+    "urlMain": "https://www.pinterest.com/",
+    "username_claimed": "blue"
+  },
   "pixelfed.social": {
     "errorType": "status_code",
     "url": "https://pixelfed.social/{}/",
     "urlMain": "https://pixelfed.social",
     "username_claimed": "pylapp"
+  },
+  "Platzi": {
+    "errorType": "status_code",
+    "errorCode": 404,
+    "url": "https://platzi.com/p/{}/",
+    "urlMain": "https://platzi.com/",
+    "username_claimed": "freddier",
+    "request_method": "GET"
   },
   "PlayStore": {
     "errorType": "status_code",
@@ -1970,11 +2297,32 @@
     "urlMain": "https://pornhub.com/",
     "username_claimed": "blue"
   },
+  "pr0gramm": {
+    "errorType": "status_code",
+    "url": "https://pr0gramm.com/user/{}",
+    "urlMain": "https://pr0gramm.com/",
+    "urlProbe": "https://pr0gramm.com/api/profile/info?name={}",
+    "username_claimed": "cha0s"
+  },
+  "Preisjaeger": {
+    "errorType": "status_code",
+    "url": "https://www.preisjaeger.at/profile/{}",
+    "urlMain": "https://www.preisjaeger.at/",
+    "username_claimed": "Stefan",
+    "request_method": "GET"
+  },
   "ProductHunt": {
     "errorType": "status_code",
     "url": "https://www.producthunt.com/@{}",
     "urlMain": "https://www.producthunt.com/",
     "username_claimed": "jenny"
+  },
+  "prog.hu": {
+    "errorType": "response_url",
+    "errorUrl": "https://prog.hu/azonosito/info/{}",
+    "url": "https://prog.hu/azonosito/info/{}",
+    "urlMain": "https://prog.hu/",
+    "username_claimed": "Sting"
   },
   "programming.dev": {
     "errorMsg": "Error!",
@@ -1983,12 +2331,12 @@
     "urlMain": "https://programming.dev",
     "username_claimed": "pylapp"
   },
-  "Pychess": {
-    "errorType": "message",
-    "errorMsg": "404",
-    "url": "https://www.pychess.org/@/{}",
-    "urlMain": "https://www.pychess.org",
-    "username_claimed": "gbtami"
+  "Promodescuentos": {
+    "errorType": "status_code",
+    "url": "https://www.promodescuentos.com/profile/{}",
+    "urlMain": "https://www.promodescuentos.com/",
+    "username_claimed": "blue",
+    "request_method": "GET"
   },
   "PromoDJ": {
     "errorType": "status_code",
@@ -2001,6 +2349,20 @@
     "url": "https://pronouns.page/@{}",
     "urlMain": "https://pronouns.page/",
     "username_claimed": "andrea"
+  },
+  "PSNProfiles.com": {
+    "errorType": "response_url",
+    "errorUrl": "https://psnprofiles.com/?psnId={}",
+    "url": "https://psnprofiles.com/{}",
+    "urlMain": "https://psnprofiles.com/",
+    "username_claimed": "blue"
+  },
+  "Pychess": {
+    "errorType": "message",
+    "errorMsg": "404",
+    "url": "https://www.pychess.org/@/{}",
+    "urlMain": "https://www.pychess.org",
+    "username_claimed": "gbtami"
   },
   "PyPi": {
     "errorType": "status_code",
@@ -2041,12 +2403,12 @@
     "urlMain": "https://forum.rclone.org/",
     "username_claimed": "ncw"
   },
-  "RedTube": {
-    "errorType": "status_code",
-    "isNSFW": true,
-    "url": "https://www.redtube.com/users/{}",
-    "urlMain": "https://www.redtube.com/",
-    "username_claimed": "hacker"
+  "Realmeye": {
+    "errorMsg": "Sorry, but we either:",
+    "errorType": "message",
+    "url": "https://www.realmeye.com/player/{}",
+    "urlMain": "https://www.realmeye.com/",
+    "username_claimed": "rotmg"
   },
   "Redbubble": {
     "errorType": "status_code",
@@ -2064,12 +2426,12 @@
     "urlMain": "https://www.reddit.com/",
     "username_claimed": "blue"
   },
-  "Realmeye": {
-    "errorMsg": "Sorry, but we either:",
-    "errorType": "message",
-    "url": "https://www.realmeye.com/player/{}",
-    "urlMain": "https://www.realmeye.com/",
-    "username_claimed": "rotmg"
+  "RedTube": {
+    "errorType": "status_code",
+    "isNSFW": true,
+    "url": "https://www.redtube.com/users/{}",
+    "urlMain": "https://www.redtube.com/",
+    "username_claimed": "hacker"
   },
   "Reisefrage": {
     "errorType": "status_code",
@@ -2147,11 +2509,11 @@
     "urlProbe": "https://apps.runescape.com/runemetrics/profile/profile?user={}",
     "username_claimed": "L33"
   },
-  "SWAPD": {
+  "satsisRU": {
     "errorType": "status_code",
-    "url": "https://swapd.co/u/{}",
-    "urlMain": "https://swapd.co/",
-    "username_claimed": "swapd"
+    "url": "https://satsis.info/user/{}",
+    "urlMain": "https://satsis.info/",
+    "username_claimed": "red"
   },
   "Sbazar.cz": {
     "errorType": "status_code",
@@ -2178,6 +2540,12 @@
     "urlMain": "https://www.seoforum.com/",
     "username_claimed": "ko"
   },
+  "sessionize": {
+    "errorType": "status_code",
+    "url": "https://sessionize.com/{}",
+    "urlMain": "https://sessionize.com/",
+    "username_claimed": "jason-mayes"
+  },
   "Shelf": {
     "errorType": "status_code",
     "url": "https://www.shelf.im/{}",
@@ -2191,7 +2559,7 @@
     "username_claimed": "blue"
   },
   "Signal": {
-    "errorMsg": "Oops! That page doesn\u2019t exist or is private.",
+    "errorMsg": "Oops! That page doesn’t exist or is private.",
     "errorType": "message",
     "url": "https://community.signalusers.org/u/{}",
     "urlMain": "https://community.signalusers.org",
@@ -2224,18 +2592,18 @@
     "urlMain": "https://slashdot.org",
     "username_claimed": "blue"
   },
-  "SlideShare": {
-    "errorType": "message",
-    "errorMsg": "<title>Page no longer exists</title>",
-    "url": "https://slideshare.net/{}",
-    "urlMain": "https://slideshare.net/",
-    "username_claimed": "blue"
-  },
   "Slides": {
     "errorCode": 204,
     "errorType": "status_code",
     "url": "https://slides.com/{}",
     "urlMain": "https://slides.com/",
+    "username_claimed": "blue"
+  },
+  "SlideShare": {
+    "errorType": "message",
+    "errorMsg": "<title>Page no longer exists</title>",
+    "url": "https://slideshare.net/{}",
+    "urlMain": "https://slideshare.net/",
     "username_claimed": "blue"
   },
   "SmugMug": {
@@ -2259,6 +2627,12 @@
     "url": "https://www.snapchat.com/add/{}",
     "urlMain": "https://www.snapchat.com",
     "username_claimed": "teamsnapchat"
+  },
+  "social.tchncs.de": {
+    "errorType": "status_code",
+    "url": "https://social.tchncs.de/@{}",
+    "urlMain": "https://social.tchncs.de/",
+    "username_claimed": "Milan"
   },
   "SOOP": {
     "errorType": "status_code",
@@ -2303,6 +2677,12 @@
     "url": "https://forum.spells8.com/u/{}",
     "urlMain": "https://spells8.com",
     "username_claimed": "susurrus"
+  },
+  "spletnik": {
+    "errorType": "status_code",
+    "url": "https://spletnik.ru/user/{}",
+    "urlMain": "https://spletnik.ru/",
+    "username_claimed": "blue"
   },
   "Splice": {
     "errorType": "status_code",
@@ -2382,55 +2762,17 @@
     "urlMain": "https://forum.sublimetext.com/",
     "username_claimed": "blue"
   },
-  "TETR.IO": {
-    "errorMsg": "No such user!",
-    "errorType": "message",
-    "url": "https://ch.tetr.io/u/{}",
-    "urlMain": "https://tetr.io",
-    "urlProbe": "https://ch.tetr.io/api/users/{}",
-    "username_claimed": "osk"
-  },
-  "TheMovieDB": {
+  "svidbook": {
     "errorType": "status_code",
-    "url": "https://www.themoviedb.org/u/{}",
-    "urlMain": "https://www.themoviedb.org/",
-    "username_claimed": "blue"
+    "url": "https://www.svidbook.ru/user/{}",
+    "urlMain": "https://www.svidbook.ru/",
+    "username_claimed": "green"
   },
-  "TikTok": {
-    "url": "https://www.tiktok.com/@{}",
-    "urlMain": "https://www.tiktok.com",
-    "errorType": "message",
-    "errorMsg": [
-      "\"statusCode\":10221",
-      "Govt. of India decided to block 59 apps"
-    ],
-    "username_claimed": "charlidamelio"
-  },
-  "Tiendanube": {
-    "url": "https://{}.mitiendanube.com/",
-    "urlMain": "https://www.tiendanube.com/",
+  "SWAPD": {
     "errorType": "status_code",
-    "username_claimed": "blue"
-  },
-  "Topcoder": {
-    "errorType": "status_code",
-    "url": "https://profiles.topcoder.com/{}/",
-    "urlMain": "https://topcoder.com/",
-    "username_claimed": "USER",
-    "urlProbe": "https://api.topcoder.com/v5/members/{}",
-    "regexCheck": "^[a-zA-Z0-9_.]+$"
-  },
-  "Topmate": {
-    "errorType": "status_code",
-    "url": "https://topmate.io/{}",
-    "urlMain": "https://topmate.io/",
-    "username_claimed": "blue"
-  },
-  "TRAKTRAIN": {
-    "errorType": "status_code",
-    "url": "https://traktrain.com/{}",
-    "urlMain": "https://traktrain.com/",
-    "username_claimed": "traktrain"
+    "url": "https://swapd.co/u/{}",
+    "urlMain": "https://swapd.co/",
+    "username_claimed": "swapd"
   },
   "Telegram": {
     "errorMsg": [
@@ -2463,11 +2805,51 @@
     "urlMain": "https://forums.terraria.org/index.php",
     "username_claimed": "blue"
   },
+  "TETR.IO": {
+    "errorMsg": "No such user!",
+    "errorType": "message",
+    "url": "https://ch.tetr.io/u/{}",
+    "urlMain": "https://tetr.io",
+    "urlProbe": "https://ch.tetr.io/api/users/{}",
+    "username_claimed": "osk"
+  },
   "ThemeForest": {
     "errorType": "status_code",
     "url": "https://themeforest.net/user/{}",
     "urlMain": "https://themeforest.net/",
     "username_claimed": "user"
+  },
+  "TheMovieDB": {
+    "errorType": "status_code",
+    "url": "https://www.themoviedb.org/u/{}",
+    "urlMain": "https://www.themoviedb.org/",
+    "username_claimed": "blue"
+  },
+  "threads": {
+    "errorMsg": "<title>Threads • Log in</title>",
+    "errorType": "message",
+    "headers": {
+      "Sec-Fetch-Mode": "navigate"
+    },
+    "url": "https://www.threads.net/@{}",
+    "urlMain": "https://www.threads.net/",
+    "username_claimed": "zuck"
+  },
+  "Tiendanube": {
+    "url": "https://{}.mitiendanube.com/",
+    "urlMain": "https://www.tiendanube.com/",
+    "errorType": "status_code",
+    "username_claimed": "blue"
+  },
+  "TikTok": {
+    "url": "https://www.tiktok.com/@{}",
+    "urlMain": "https://www.tiktok.com",
+    "errorType": "message",
+    "errorMsg": [
+      "\"statusCode\":10221",
+      "Govt. of India decided to block 59 apps"
+    ],
+    "username_claimed": "charlidamelio"
   },
   "tistory": {
     "errorType": "status_code",
@@ -2482,6 +2864,26 @@
     "urlMain": "https://www.tnaflix.com/",
     "username_claimed": "hacker"
   },
+  "Topcoder": {
+    "errorType": "status_code",
+    "url": "https://profiles.topcoder.com/{}/",
+    "urlMain": "https://topcoder.com/",
+    "username_claimed": "USER",
+    "urlProbe": "https://api.topcoder.com/v5/members/{}",
+    "regexCheck": "^[a-zA-Z0-9_.]+$"
+  },
+  "Topmate": {
+    "errorType": "status_code",
+    "url": "https://topmate.io/{}",
+    "urlMain": "https://topmate.io/",
+    "username_claimed": "blue"
+  },
+  "toster": {
+    "errorType": "status_code",
+    "url": "https://www.toster.ru/user/{}/answers",
+    "urlMain": "https://www.toster.ru/",
+    "username_claimed": "adam"
+  },
   "TradingView": {
     "errorType": "status_code",
     "request_method": "GET",
@@ -2495,6 +2897,12 @@
     "url": "https://www.trakt.tv/users/{}",
     "urlMain": "https://www.trakt.tv/",
     "username_claimed": "blue"
+  },
+  "TRAKTRAIN": {
+    "errorType": "status_code",
+    "url": "https://traktrain.com/{}",
+    "urlMain": "https://traktrain.com/",
+    "username_claimed": "traktrain"
   },
   "TrashboxRU": {
     "errorType": "status_code",
@@ -2517,6 +2925,13 @@
     "urlProbe": "https://trello.com/1/Members/{}",
     "username_claimed": "blue"
   },
+  "Trovo": {
+    "errorMsg": "Uh Ohhh...",
+    "errorType": "message",
+    "url": "https://trovo.live/s/{}/",
+    "urlMain": "https://trovo.live",
+    "username_claimed": "Aimilios"
+  },
   "TryHackMe": {
     "errorMsg": "{\"success\":false}",
     "errorType": "message",
@@ -2525,6 +2940,12 @@
     "urlMain": "https://tryhackme.com/",
     "urlProbe": "https://tryhackme.com/api/user/exist/{}",
     "username_claimed": "ashu"
+  },
+  "tumblr": {
+    "errorType": "status_code",
+    "url": "https://{}.tumblr.com/",
+    "urlMain": "https://www.tumblr.com/",
+    "username_claimed": "goku"
   },
   "Tuna": {
     "errorType": "status_code",
@@ -2546,14 +2967,6 @@
     "urlMain": "https://www.twitch.tv",
     "username_claimed": "xqc"
   },
-
-  "Trovo": {
-    "errorMsg": "Uh Ohhh...",
-    "errorType": "message",
-    "url": "https://trovo.live/s/{}/",
-    "urlMain": "https://trovo.live",
-    "username_claimed": "Aimilios"
-  },
   "Twitter": {
     "errorMsg": [
       "<div class=\"error-panel\"><span>User ",
@@ -2571,6 +2984,12 @@
     "errorType": "message",
     "url": "https://data.typeracer.com/pit/profile?user={}",
     "urlMain": "https://typeracer.com",
+    "username_claimed": "blue"
+  },
+  "uid": {
+    "errorType": "status_code",
+    "url": "http://uid.me/{}",
+    "urlMain": "https://uid.me/",
     "username_claimed": "blue"
   },
   "Ultimate-Guitar": {
@@ -2599,19 +3018,6 @@
     "urlMain": "https://valorantforums.com",
     "username_claimed": "Wolves"
   },
-  "VK": {
-    "errorType": "response_url",
-    "errorUrl": "https://www.quora.com/profile/{}",
-    "url": "https://vk.com/{}",
-    "urlMain": "https://vk.com/",
-    "username_claimed": "brown"
-  },
-  "VSCO": {
-    "errorType": "status_code",
-    "url": "https://vsco.co/{}",
-    "urlMain": "https://vsco.co/",
-    "username_claimed": "blue"
-  },
   "Velog": {
     "errorType": "status_code",
     "url": "https://velog.io/@{}/posts",
@@ -2619,14 +3025,16 @@
     "username_claimed": "qlgks1"
   },
   "Velomania": {
-    "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430.",
+    "errorMsg": "Пользователь не зарегистрирован и не имеет профиля для просмотра.",
     "errorType": "message",
     "url": "https://forum.velomania.ru/member.php?username={}",
     "urlMain": "https://forum.velomania.ru/",
     "username_claimed": "red"
   },
   "Venmo": {
-    "errorMsg": ["Venmo | Page Not Found"],
+    "errorMsg": [
+      "Venmo | Page Not Found"
+    ],
     "errorType": "message",
     "headers": {
       "Host": "account.venmo.com"
@@ -2658,24 +3066,44 @@
     "urlProbe": "https://www.virustotal.com/ui/users/{}/avatar",
     "username_claimed": "blue"
   },
+  "Vjudge": {
+    "errorType": "status_code",
+    "url": "https://VJudge.net/user/{}",
+    "urlMain": "https://VJudge.net/",
+    "username_claimed": "tokitsukaze"
+  },
+  "VK": {
+    "errorType": "response_url",
+    "errorUrl": "https://www.quora.com/profile/{}",
+    "url": "https://vk.com/{}",
+    "urlMain": "https://vk.com/",
+    "username_claimed": "brown"
+  },
   "VLR": {
     "errorType": "status_code",
     "url": "https://www.vlr.gg/user/{}",
     "urlMain": "https://www.vlr.gg",
     "username_claimed": "optms"
   },
-  "WICG Forum": {
+  "VSCO": {
     "errorType": "status_code",
-    "regexCheck": "^(?![.-])[a-zA-Z0-9_.-]{3,20}$",
-    "url": "https://discourse.wicg.io/u/{}/summary",
-    "urlMain": "https://discourse.wicg.io/",
-    "username_claimed": "stefano"
+    "url": "https://vsco.co/{}",
+    "urlMain": "https://vsco.co/",
+    "username_claimed": "blue"
   },
   "Wakatime": {
     "errorType": "status_code",
     "url": "https://wakatime.com/@{}",
     "urlMain": "https://wakatime.com/",
     "username_claimed": "blue"
+  },
+  "Warframe Market": {
+    "errorType": "status_code",
+    "request_method": "GET",
+    "url": "https://warframe.market/profile/{}",
+    "urlMain": "https://warframe.market/",
+    "urlProbe": "https://api.warframe.market/v2/user/{}",
+    "username_claimed": "kaiallalone"
   },
   "Warrior Forum": {
     "errorType": "status_code",
@@ -2690,13 +3118,6 @@
     "urlProbe": "https://www.wattpad.com/api/v3/users/{}/",
     "username_claimed": "Dogstho7951"
   },
-  "WebNode": {
-    "errorType": "status_code",
-    "regexCheck": "^[\\w@-]+?$",
-    "url": "https://{}.webnode.cz/",
-    "urlMain": "https://www.webnode.cz/",
-    "username_claimed": "radkabalcarova"
-  },
   "Weblate": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z0-9@._-]{1,150}$",
@@ -2704,12 +3125,26 @@
     "urlMain": "https://hosted.weblate.org/",
     "username_claimed": "adam"
   },
+  "WebNode": {
+    "errorType": "status_code",
+    "regexCheck": "^[\\w@-]+?$",
+    "url": "https://{}.webnode.cz/",
+    "urlMain": "https://www.webnode.cz/",
+    "username_claimed": "radkabalcarova"
+  },
   "Weebly": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z0-9-]{1,63}$",
     "url": "https://{}.weebly.com/",
     "urlMain": "https://weebly.com/",
     "username_claimed": "blue"
+  },
+  "WICG Forum": {
+    "errorType": "status_code",
+    "regexCheck": "^(?![.-])[a-zA-Z0-9_.-]{3,20}$",
+    "url": "https://discourse.wicg.io/u/{}/summary",
+    "urlMain": "https://discourse.wicg.io/",
+    "username_claimed": "stefano"
   },
   "Wikidot": {
     "errorMsg": "User does not exist.",
@@ -2744,6 +3179,14 @@
     "urlMain": "https://community.wolfram.com/",
     "username_claimed": "unico"
   },
+  "Wordnik": {
+    "errorMsg": "Page Not Found",
+    "errorType": "message",
+    "regexCheck": "^[a-zA-Z0-9_.+-]{1,40}$",
+    "url": "https://www.wordnik.com/users/{}",
+    "urlMain": "https://www.wordnik.com/",
+    "username_claimed": "blue"
+  },
   "WordPress": {
     "errorType": "response_url",
     "errorUrl": "wordpress.com/typo/?subdomain=",
@@ -2759,13 +3202,18 @@
     "urlMain": "https://wordpress.org/",
     "username_claimed": "blue"
   },
-  "Wordnik": {
-    "errorMsg": "Page Not Found",
-    "errorType": "message",
-    "regexCheck": "^[a-zA-Z0-9_.+-]{1,40}$",
-    "url": "https://www.wordnik.com/users/{}",
-    "urlMain": "https://www.wordnik.com/",
+  "Wowhead": {
+    "url": "https://wowhead.com/user={}",
+    "urlMain": "https://wowhead.com/",
+    "errorType": "status_code",
+    "errorCode": 404,
     "username_claimed": "blue"
+  },
+  "write.as": {
+    "errorType": "status_code",
+    "url": "https://write.as/{}",
+    "urlMain": "https://write.as",
+    "username_claimed": "pylapp"
   },
   "Wykop": {
     "errorType": "status_code",
@@ -2779,6 +3227,14 @@
     "urlMain": "https://xboxgamertag.com/",
     "username_claimed": "red"
   },
+  "xHamster": {
+    "errorType": "status_code",
+    "isNSFW": true,
+    "url": "https://xhamster.com/users/{}",
+    "urlMain": "https://xhamster.com",
+    "urlProbe": "https://xhamster.com/users/{}?old_browser=true",
+    "username_claimed": "blue"
+  },
   "Xvideos": {
     "errorType": "status_code",
     "isNSFW": true,
@@ -2789,8 +3245,8 @@
   "YandexMusic": {
     "__comment__": "The first and third errorMsg relate to geo-restrictions and bot detection/captchas.",
     "errorMsg": [
-      "\u041e\u0448\u0438\u0431\u043a\u0430 404",
-      "<meta name=\"description\" content=\"\u041e\u0442\u043a\u0440\u044b\u0432\u0430\u0439\u0442\u0435 \u043d\u043e\u0432\u0443\u044e \u043c\u0443\u0437\u044b\u043a\u0443 \u043a\u0430\u0436\u0434\u044b\u0439 \u0434\u0435\u043d\u044c.",
+      "Ошибка 404",
+      "<meta name=\"description\" content=\"Открывайте новую музыку каждый день.",
       "<input type=\"submit\" class=\"CheckboxCaptcha-Button\""
     ],
     "errorType": "message",
@@ -2825,459 +3281,10 @@
     "urlMain": "https://www.youtube.com/",
     "username_claimed": "youtube"
   },
-  "akniga": {
-    "errorType": "status_code",
-    "url": "https://akniga.org/profile/{}",
-    "urlMain": "https://akniga.org/profile/blue/",
-    "username_claimed": "blue"
-  },
-  "authorSTREAM": {
-    "errorType": "status_code",
-    "url": "http://www.authorstream.com/{}/",
-    "urlMain": "http://www.authorstream.com/",
-    "username_claimed": "blue"
-  },
-  "babyblogRU": {
-    "errorType": "response_url",
-    "errorUrl": "https://www.babyblog.ru/",
-    "url": "https://www.babyblog.ru/user/{}",
-    "urlMain": "https://www.babyblog.ru/",
-    "username_claimed": "blue"
-  },
-  "chaos.social": {
-    "errorType": "status_code",
-    "url": "https://chaos.social/@{}",
-    "urlMain": "https://chaos.social/",
-    "username_claimed": "rixx"
-  },
-  "couchsurfing": {
-    "errorType": "status_code",
-    "url": "https://www.couchsurfing.com/people/{}",
-    "urlMain": "https://www.couchsurfing.com/",
-    "username_claimed": "blue"
-  },
-  "d3RU": {
-    "errorType": "status_code",
-    "url": "https://d3.ru/user/{}/posts",
-    "urlMain": "https://d3.ru/",
-    "username_claimed": "blue"
-  },
-  "dailykos": {
-    "errorMsg": "{\"result\":true,\"message\":null}",
-    "errorType": "message",
-    "url": "https://www.dailykos.com/user/{}",
-    "urlMain": "https://www.dailykos.com",
-    "urlProbe": "https://www.dailykos.com/signup/check_nickname?nickname={}",
-    "username_claimed": "blue"
-  },
-  "datingRU": {
-    "errorType": "status_code",
-    "url": "http://dating.ru/{}",
-    "urlMain": "http://dating.ru",
-    "username_claimed": "blue"
-  },
-  "devRant": {
-    "errorType": "response_url",
-    "errorUrl": "https://devrant.com/",
-    "url": "https://devrant.com/users/{}",
-    "urlMain": "https://devrant.com/",
-    "username_claimed": "blue"
-  },
-  "drive2": {
-    "errorType": "status_code",
-    "url": "https://www.drive2.ru/users/{}",
-    "urlMain": "https://www.drive2.ru/",
-    "username_claimed": "blue"
-  },
-  "eGPU": {
-    "errorType": "status_code",
-    "url": "https://egpu.io/forums/profile/{}/",
-    "urlMain": "https://egpu.io/",
-    "username_claimed": "blue"
-  },
-  "eintracht": {
-    "errorType": "status_code",
-    "regexCheck": "^[^.]*?$",
-    "url": "https://community.eintracht.de/fans/{}",
-    "urlMain": "https://eintracht.de",
-    "username_claimed": "blue"
-  },
-  "fixya": {
-    "errorType": "status_code",
-    "url": "https://www.fixya.com/users/{}",
-    "urlMain": "https://www.fixya.com",
-    "username_claimed": "adam"
-  },
-  "fl": {
-    "errorType": "status_code",
-    "url": "https://www.fl.ru/users/{}",
-    "urlMain": "https://www.fl.ru/",
-    "username_claimed": "blue"
-  },
-  "forum_guns": {
-    "errorMsg": "action=https://forum.guns.ru/forummisc/blog/search",
-    "errorType": "message",
-    "url": "https://forum.guns.ru/forummisc/blog/{}",
-    "urlMain": "https://forum.guns.ru/",
-    "username_claimed": "red"
-  },
-  "freecodecamp": {
-    "errorType": "status_code",
-    "url": "https://www.freecodecamp.org/{}",
-    "urlMain": "https://www.freecodecamp.org/",
-    "urlProbe": "https://api.freecodecamp.org/api/users/get-public-profile?username={}",
-    "username_claimed": "naveennamani"
-  },
-  "furaffinity": {
-    "errorMsg": "This user cannot be found.",
-    "errorType": "message",
-    "url": "https://www.furaffinity.net/user/{}",
-    "urlMain": "https://www.furaffinity.net",
-    "username_claimed": "jesus"
-  },
-  "geocaching": {
-    "errorType": "status_code",
-    "url": "https://www.geocaching.com/p/default.aspx?u={}",
-    "urlMain": "https://www.geocaching.com/",
-    "username_claimed": "blue"
-  },
-  "habr": {
-    "errorType": "status_code",
-    "url": "https://habr.com/ru/users/{}",
-    "urlMain": "https://habr.com/",
-    "username_claimed": "blue"
-  },
-  "hackster": {
-    "errorType": "status_code",
-    "url": "https://www.hackster.io/{}",
-    "urlMain": "https://www.hackster.io",
-    "username_claimed": "blue"
-  },
-  "hunting": {
-    "errorMsg": "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0434\u0440\u0443\u0433\u043e\u0435 \u0438\u043c\u044f.",
-    "errorType": "message",
-    "url": "https://www.hunting.ru/forum/members/?username={}",
-    "urlMain": "https://www.hunting.ru/forum/",
-    "username_claimed": "red"
-  },
-  "igromania": {
-    "errorMsg": "\u041f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u0437\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043e\u0432\u0430\u043d \u0438 \u043d\u0435 \u0438\u043c\u0435\u0435\u0442 \u043f\u0440\u043e\u0444\u0438\u043b\u044f \u0434\u043b\u044f \u043f\u0440\u043e\u0441\u043c\u043e\u0442\u0440\u0430.",
-    "errorType": "message",
-    "url": "http://forum.igromania.ru/member.php?username={}",
-    "urlMain": "http://forum.igromania.ru/",
-    "username_claimed": "blue"
-  },
-  "interpals": {
-    "errorMsg": "The requested user does not exist or is inactive",
-    "errorType": "message",
-    "url": "https://www.interpals.net/{}",
-    "urlMain": "https://www.interpals.net/",
-    "username_claimed": "blue"
-  },
-  "irecommend": {
-    "errorType": "status_code",
-    "url": "https://irecommend.ru/users/{}",
-    "urlMain": "https://irecommend.ru/",
-    "username_claimed": "blue"
-  },
-  "jbzd.com.pl": {
-    "errorType": "status_code",
-    "url": "https://jbzd.com.pl/uzytkownik/{}",
-    "urlMain": "https://jbzd.com.pl/",
-    "username_claimed": "blue"
-  },
-  "jeuxvideo": {
-    "errorType": "status_code",
-    "request_method": "GET",
-    "url": "https://www.jeuxvideo.com/profil/{}",
-    "urlMain": "https://www.jeuxvideo.com",
-    "urlProbe": "https://www.jeuxvideo.com/profil/{}?mode=infos",
-    "username_claimed": "adam"
-  },
-  "kofi": {
-    "errorType": "response_url",
-    "errorUrl": "https://ko-fi.com/art?=redirect",
-    "url": "https://ko-fi.com/{}",
-    "urlMain": "https://ko-fi.com",
-    "username_claimed": "yeahkenny"
-  },
-  "kwork": {
-    "errorType": "status_code",
-    "url": "https://kwork.ru/user/{}",
-    "urlMain": "https://www.kwork.ru/",
-    "username_claimed": "blue"
-  },
-  "last.fm": {
-    "errorType": "status_code",
-    "url": "https://last.fm/user/{}",
-    "urlMain": "https://last.fm/",
-    "username_claimed": "blue"
-  },
-  "leasehackr": {
-    "errorType": "status_code",
-    "url": "https://forum.leasehackr.com/u/{}/summary/",
-    "urlMain": "https://forum.leasehackr.com/",
-    "username_claimed": "adam"
-  },
-  "livelib": {
-    "errorType": "status_code",
-    "url": "https://www.livelib.ru/reader/{}",
-    "urlMain": "https://www.livelib.ru/",
-    "username_claimed": "blue"
-  },
-  "mastodon.cloud": {
-    "errorType": "status_code",
-    "url": "https://mastodon.cloud/@{}",
-    "urlMain": "https://mastodon.cloud/",
-    "username_claimed": "TheAdmin"
-  },
-  "mastodon.social": {
-    "errorType": "status_code",
-    "url": "https://mastodon.social/@{}",
-    "urlMain": "https://chaos.social/",
-    "username_claimed": "Gargron"
-  },
-  "mastodon.xyz": {
-    "errorType": "status_code",
-    "url": "https://mastodon.xyz/@{}",
-    "urlMain": "https://mastodon.xyz/",
-    "username_claimed": "TheKinrar"
-  },
-  "mstdn.social": {
-    "errorType": "status_code",
-    "url": "https://mstdn.social/@{}",
-    "urlMain": "https://mstdn.social/",
-    "username_claimed": "MagicLike"
-  },
-  "mercadolivre": {
-    "errorType": "status_code",
-    "url": "https://www.mercadolivre.com.br/perfil/{}",
-    "urlMain": "https://www.mercadolivre.com.br",
-    "username_claimed": "blue"
-  },
-  "minds": {
-    "errorMsg": "\"valid\":true",
-    "errorType": "message",
-    "url": "https://www.minds.com/{}/",
-    "urlMain": "https://www.minds.com",
-    "urlProbe": "https://www.minds.com/api/v3/register/validate?username={}",
-    "username_claimed": "john"
-  },
-  "moikrug": {
-    "errorType": "status_code",
-    "url": "https://moikrug.ru/{}",
-    "urlMain": "https://moikrug.ru/",
-    "username_claimed": "blue"
-  },
-  "mstdn.io": {
-    "errorType": "status_code",
-    "url": "https://mstdn.io/@{}",
-    "urlMain": "https://mstdn.io/",
-    "username_claimed": "blue"
-  },
-  "nairaland.com": {
-    "errorType": "status_code",
-    "url": "https://www.nairaland.com/{}",
-    "urlMain": "https://www.nairaland.com/",
-    "username_claimed": "red"
-  },
-  "n8n Community": {
-    "errorType": "status_code",
-    "url": "https://community.n8n.io/u/{}/summary",
-    "urlMain": "https://community.n8n.io/",
-    "username_claimed": "n8n"
-  },
-  "nnRU": {
-    "errorType": "status_code",
-    "regexCheck": "^[\\w@-]+?$",
-    "url": "https://{}.www.nn.ru/",
-    "urlMain": "https://www.nn.ru/",
-    "username_claimed": "blue"
-  },
-  "note": {
-    "errorType": "status_code",
-    "url": "https://note.com/{}",
-    "urlMain": "https://note.com/",
-    "username_claimed": "blue"
-  },
-  "npm": {
-    "errorType": "status_code",
-    "url": "https://www.npmjs.com/~{}",
-    "urlMain": "https://www.npmjs.com/",
-    "username_claimed": "kennethsweezy"
-  },
-  "omg.lol": {
-    "errorMsg": "\"available\": true",
-    "errorType": "message",
-    "url": "https://{}.omg.lol",
-    "urlMain": "https://home.omg.lol",
-    "urlProbe": "https://api.omg.lol/address/{}/availability",
-    "username_claimed": "adam"
-  },
-  "opennet": {
-    "errorMsg": "\u0418\u043c\u044f \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430 \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u043e",
-    "errorType": "message",
-    "regexCheck": "^[^-]*$",
-    "url": "https://www.opennet.ru/~{}",
-    "urlMain": "https://www.opennet.ru/",
-    "username_claimed": "anonismus"
-  },
-  "osu!": {
-    "errorType": "status_code",
-    "url": "https://osu.ppy.sh/users/{}",
-    "urlMain": "https://osu.ppy.sh/",
-    "username_claimed": "blue"
-  },
-  "phpRU": {
-    "errorMsg": "\u0423\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044c \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0434\u0440\u0443\u0433\u043e\u0435 \u0438\u043c\u044f.",
-    "errorType": "message",
-    "url": "https://php.ru/forum/members/?username={}",
-    "urlMain": "https://php.ru/forum/",
-    "username_claimed": "apple"
-  },
-  "pikabu": {
-    "errorType": "status_code",
-    "url": "https://pikabu.ru/@{}",
-    "urlMain": "https://pikabu.ru/",
-    "username_claimed": "blue"
-  },
-  "Pinterest": {
-    "errorType": "status_code",
-    "errorUrl": "https://www.pinterest.com/",
-    "url": "https://www.pinterest.com/{}/",
-    "urlProbe": "https://www.pinterest.com/oembed.json?url=https://www.pinterest.com/{}/",
-    "urlMain": "https://www.pinterest.com/",
-    "username_claimed": "blue"
-  },
-  "pr0gramm": {
-    "errorType": "status_code",
-    "url": "https://pr0gramm.com/user/{}",
-    "urlMain": "https://pr0gramm.com/",
-    "urlProbe": "https://pr0gramm.com/api/profile/info?name={}",
-    "username_claimed": "cha0s"
-  },
-  "prog.hu": {
-    "errorType": "response_url",
-    "errorUrl": "https://prog.hu/azonosito/info/{}",
-    "url": "https://prog.hu/azonosito/info/{}",
-    "urlMain": "https://prog.hu/",
-    "username_claimed": "Sting"
-  },
-  "satsisRU": {
-    "errorType": "status_code",
-    "url": "https://satsis.info/user/{}",
-    "urlMain": "https://satsis.info/",
-    "username_claimed": "red"
-  },
-  "sessionize": {
-    "errorType": "status_code",
-    "url": "https://sessionize.com/{}",
-    "urlMain": "https://sessionize.com/",
-    "username_claimed": "jason-mayes"
-  },
-  "social.tchncs.de": {
-    "errorType": "status_code",
-    "url": "https://social.tchncs.de/@{}",
-    "urlMain": "https://social.tchncs.de/",
-    "username_claimed": "Milan"
-  },
-  "spletnik": {
-    "errorType": "status_code",
-    "url": "https://spletnik.ru/user/{}",
-    "urlMain": "https://spletnik.ru/",
-    "username_claimed": "blue"
-  },
-  "svidbook": {
-    "errorType": "status_code",
-    "url": "https://www.svidbook.ru/user/{}",
-    "urlMain": "https://www.svidbook.ru/",
-    "username_claimed": "green"
-  },
-  "threads": {
-    "errorMsg": "<title>Threads • Log in</title>",
-    "errorType": "message",
-    "headers": {
-      "Sec-Fetch-Mode": "navigate"
-    },
-    "url": "https://www.threads.net/@{}",
-    "urlMain": "https://www.threads.net/",
-    "username_claimed": "zuck"
-  },
-  "toster": {
-    "errorType": "status_code",
-    "url": "https://www.toster.ru/user/{}/answers",
-    "urlMain": "https://www.toster.ru/",
-    "username_claimed": "adam"
-  },
-  "tumblr": {
-    "errorType": "status_code",
-    "url": "https://{}.tumblr.com/",
-    "urlMain": "https://www.tumblr.com/",
-    "username_claimed": "goku"
-  },
-  "uid": {
-    "errorType": "status_code",
-    "url": "http://uid.me/{}",
-    "urlMain": "https://uid.me/",
-    "username_claimed": "blue"
-  },
-  "write.as": {
-    "errorType": "status_code",
-    "url": "https://write.as/{}",
-    "urlMain": "https://write.as",
-    "username_claimed": "pylapp"
-  },
-  "xHamster": {
-    "errorType": "status_code",
-    "isNSFW": true,
-    "url": "https://xhamster.com/users/{}",
-    "urlMain": "https://xhamster.com",
-    "urlProbe": "https://xhamster.com/users/{}?old_browser=true",
-    "username_claimed": "blue"
-  },
   "znanylekarz.pl": {
     "errorType": "status_code",
     "url": "https://www.znanylekarz.pl/{}",
     "urlMain": "https://znanylekarz.pl",
     "username_claimed": "janusz-nowak"
-  },
-  "Platzi": {
-    "errorType": "status_code",
-    "errorCode": 404,
-    "url": "https://platzi.com/p/{}/",
-    "urlMain": "https://platzi.com/",
-    "username_claimed": "freddier",
-    "request_method": "GET"
-  },
-  "BabyRu": {
-    "url": "https://www.baby.ru/u/{}",
-    "urlMain": "https://www.baby.ru/",
-    "errorType": "message",
-    "errorMsg": [
-      "\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430, \u043a\u043e\u0442\u043e\u0440\u0443\u044e \u0432\u044b \u0438\u0441\u043a\u0430\u043b\u0438, \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u0430",
-      "\u0414\u043e\u0441\u0442\u0443\u043f \u0441 \u0432\u0430\u0448\u0435\u0433\u043e IP-\u0430\u0434\u0440\u0435\u0441\u0430 \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u043e \u043e\u0433\u0440\u0430\u043d\u0438\u0447\u0435\u043d"
-    ],
-    "username_claimed": "example"
-  },
-  "Wowhead": {
-    "url": "https://wowhead.com/user={}",
-    "urlMain": "https://wowhead.com/",
-    "errorType": "status_code",
-    "errorCode": 404,
-    "username_claimed": "blue"
-  },
-  "addons.wago.io": {
-    "url": "https://addons.wago.io/user/{}",
-    "urlMain": "https://addons.wago.io/",
-    "errorType": "status_code",
-    "errorCode": 404,
-    "username_claimed": "blue"
-  },
-  "CurseForge": {
-    "url": "https://www.curseforge.com/members/{}/projects",
-    "urlMain": "https://www.curseforge.com.",
-    "errorType": "status_code",
-    "errorCode": 404,
-    "username_claimed": "blue"
   }
 }


### PR DESCRIPTION
## Overview

This issue improves the `devel/site-list.py` workflow so site metadata generation is deterministic, safer to run repeatedly, and easier to validate in CI.
The script now enforces project-specific ordering rules (digit-prefixed names first, then alphabetical), validates input data quality, and introduces a CLI interface for both checking and writing outputs.

## Why these changes were needed
The previous implementation worked, but had a few gaps that made maintenance and automation harder:
- **Sorting behavior was generic, not project-specific**  
  Default lexical sorting did not clearly enforce the desired ordering strategy (digit-first, then normal alphabetical).
- **Execution depended on current working directory**  
  Relative paths could fail when the script was run from a different folder.
- **Output directory creation was not idempotent**  
  Re-running could fail if `output/` already existed.
- **No explicit check mode for CI**  
  There was no dedicated way to validate sort/order correctness without rewriting files.
- **Potential risk of partial writes**  
  Direct write operations can leave files half-written if interrupted.
- **Static site count in docs output**  
  The generated `sites.mdx` description could become stale over time.
- **No defensive validation for malformed entries**  
  Missing or invalid `urlMain` fields could fail later with less actionable errors.
---
## What changed
### 1) Deterministic custom sorting
- Added an explicit sort key:
  - keys starting with digits come first
  - remaining keys sorted alphabetically (case-insensitive)
- Preserves `"$schema"` at the top of `data.json`
### 2) Reliable path handling
- Uses `pathlib` and script-relative defaults so the script works regardless of where it is invoked from.
### 3) Safer structure and execution
- Refactored into `main()` with `if __name__ == "__main__":` guard.
- Improves testability and prevents accidental side effects on import.
### 4) Validation of input records
- Validates each site entry is an object.
- Validates each site has a non-empty `urlMain`.
- Fails early with clear, actionable error messages.
### 5) Atomic file writes
- Writes via temp file + replace to prevent corrupted partial outputs.
### 6) CLI support for automation
- Added:
  - `--check` → verify ordering without writing
  - `--write` → write sorted `data.json` and generated `sites.mdx`
  - `--data-file` → custom data source path
  - `--output-dir` → custom output directory
### 7) Dynamic generated metadata
- `sites.mdx` description now uses the actual number of supported sites automatically.
---
## How to use the current script
From the repository root (or anywhere, since paths are script-relative by default):
### Check-only mode (ideal for CI)
```bash
python3 sherlock/devel/site-list.py --check
```

This aims to solve issue [#2904](https://github.com/sherlock-project/sherlock/issues/2904)