### PR TITLE
fix: correct false positive for GeeksForGeeks (#2782)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -952,7 +952,8 @@
     "username_claimed": "blue"
   },
   "GeeksforGeeks": {
-    "errorType": "status_code",
+    "errorType": "response_url",
+    "errorUrl": "https://auth.geeksforgeeks.org/user/false",
     "url": "https://auth.geeksforgeeks.org/user/{}",
     "urlMain": "https://www.geeksforgeeks.org/",
     "username_claimed": "adam"


### PR DESCRIPTION
Site redirects to /user/false for non-existent usernames. Changed errorType from status_code to response_url.