### PR TITLE
fix: correct false negative for BoardGameGeek (#2803)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -312,7 +312,7 @@
     "username_claimed": "blue"
   },
   "BoardGameGeek": {
-    "errorMsg": "\"isValid\":true",
+    "errorMsg": "\"isValid\":false",
     "errorType": "message",
     "url": "https://boardgamegeek.com/user/{}",
     "urlMain": "https://boardgamegeek.com/",


### PR DESCRIPTION
Issue #2803

Sherlock fails to detect existing BoardGameGeek profiles
The errorMsg was inverted: the API returns {"isValid":true} when a username 
is AVAILABLE, and {"isValid":false} when it is TAKEN (i.e. user exists)

Solution proposed
Changed errorMsg from "isValid":true to "isValid":false to correctly 
detect existing profiles

Verification done
Manually verified via API:
- https://api.geekdo.com/api/accounts/validate/username?username=zzznoneuser → {"isValid":true} (not found)
- https://api.geekdo.com/api/accounts/validate/username?username=blue → {"isValid":false,...} (found)