### PR TITLE
Fix Cracked Forum false positives

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -602,10 +602,9 @@
     "username_claimed": "blue"
   },
   "Cracked Forum": {
-    "errorMsg": "The member you specified is either invalid or doesn't exist",
-    "errorType": "message",
-    "url": "https://cracked.sh/{}",
-    "urlMain": "https://cracked.sh/",
+    "errorType": "status_code",
+    "url": "https://cracked.ax/{}",
+    "urlMain": "https://cracked.ax/",
     "username_claimed": "Blue"
   },
   "Credly": {


### PR DESCRIPTION
## Summary
- Updates Cracked Forum to use the current `cracked.ax` profile host.
- Switches detection to status-code checks so missing users return available instead of false positives.
- Fixes #2818.

## Test plan
- Verified `https://cracked.ax/Blue` returns 200.
- Verified `https://cracked.ax/sherlockunlikelyuser2818abcxyz` returns 404.
- Confirmed the updated `data.json` entry loads as valid JSON.
- Not run: pytest, because this environment is missing pytest.