### PR TITLE
Fix LushStories false positives

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1526,7 +1526,8 @@
     "username_claimed": "lottiefiles"
   },
   "LushStories": {
-    "errorType": "status_code",
+    "errorType": "response_url",
+    "errorUrl": "https://www.lushstories.com/login",
     "isNSFW": true,
     "url": "https://www.lushstories.com/profile/{}",
     "urlMain": "https://www.lushstories.com/",


### PR DESCRIPTION
## Summary
- Updates the LushStories target to detect missing profiles via the `/login` redirect.
- Switches the target from status-code detection to response-url detection.
- Fixes #2371.

## Test plan
- Verified `https://www.lushstories.com/profile/chris_brown` returns 200.
- Verified `https://www.lushstories.com/profile/aytvill` returns 302.
- Verified `https://www.lushstories.com/profile/sherlockunlikelyuser2371abcxyz` returns 302.
- Confirmed the updated `data.json` entry loads as valid JSON.
- Not run: pytest, because this environment is missing pytest.