### PR TITLE
Fix akniga false negatives

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2827,8 +2827,10 @@
   },
   "akniga": {
     "errorType": "status_code",
+    "errorCode": 404,
+    "request_method": "GET",
     "url": "https://akniga.org/profile/{}",
-    "urlMain": "https://akniga.org/profile/blue/",
+    "urlMain": "https://akniga.org/",
     "username_claimed": "blue"
   },
   "authorSTREAM": {


### PR DESCRIPTION
## Summary
- Adds an explicit 404 missing-user status for akniga.
- Forces akniga checks to use GET requests.
- Corrects the akniga homepage URL.
- Fixes #2807.

## Test plan
- Ran `python -m sherlock_project --site akniga --local --print-all --timeout 20 blue` and verified the account is found.
- Ran `python -m sherlock_project --site akniga --local --print-all --timeout 20 sherlockunlikelyuser2807abcxyz` and verified the account is not found.
- Confirmed the updated `data.json` entry loads as valid JSON.
- Not run: pytest, because this environment is missing pytest.