### PR TITLE
fix: correct None check in xlsx response_time_s block (#2891)

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -910,7 +910,7 @@ def main():
                 ):
                     continue
 
-                if response_time_s is None:
+                if results[site]["status"].query_time is None:
                     response_time_s.append("")
                 else:
                     response_time_s.append(results[site]["status"].query_time)


### PR DESCRIPTION
The condition checked if response_time_s (a list) is None, which is always False. Fixed to check the actual query_time value instead, consistent with the CSV block above it.
issue 2891

Problem
In the xlsx output block, the condition `if response_time_s is None` 
checks whether the list itself is None — which is always False since 
it is initialized as an empty list `[]`. As a result, when a site's 
query_time is None (timeout/error), None gets appended to the list 
instead of an empty string, causing Excel cells to contain None.$

Solution proposed
Changed the condition to check the actual value:
`if results[site]["status"].query_time is None`

This is consistent with the CSV block just above it (lines ~882-884).
Verification
Manually reviewed the code logic. The fix mirrors the already-correct 
CSV implementation in the same function.