### PR TITLE
fix: resolve false positives for ArtStation, GeeksforGeeks, and LushStories

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -159,6 +159,7 @@
     "errorType": "status_code",
     "url": "https://www.artstation.com/{}",
     "urlMain": "https://www.artstation.com/",
+    "urlProbe": "https://www.artstation.com/users/{}.json",
     "username_claimed": "Blue"
   },
   "Asciinema": {
@@ -952,7 +953,8 @@
     "username_claimed": "blue"
   },
   "GeeksforGeeks": {
-    "errorType": "status_code",
+    "errorMsg": "false   | GeeksforGeeks Profile",
+    "errorType": "message",
     "url": "https://auth.geeksforgeeks.org/user/{}",
     "urlMain": "https://www.geeksforgeeks.org/",
     "username_claimed": "adam"
@@ -1526,7 +1528,8 @@
     "username_claimed": "lottiefiles"
   },
   "LushStories": {
-    "errorType": "status_code",
+    "errorType": "response_url",
+    "errorUrl": "https://www.lushstories.com/login",
     "isNSFW": true,
     "url": "https://www.lushstories.com/profile/{}",
     "urlMain": "https://www.lushstories.com/",


### PR DESCRIPTION
## Summary

Fixes false positive issues for three sites that incorrectly report usernames as claimed.

### Changes

~~**ArtStation** (Closes # 2714)~~
- ~~Added `urlProbe` pointing to the JSON API endpoint (`https://www.artstation.com/users/{}.json`)~~
- ~~The main ArtStation page returns HTTP 200 for both existing and non-existing profiles due to client-side rendering, making status_code detection unreliable~~
- ~~The API endpoint correctly returns 404 for non-existing users and 200 for existing ones~~

**GeeksforGeeks** (Closes #2782)
- Switched from `status_code` to `message` detection
- Both existing and non-existing profiles return HTTP 200
- Non-existing profiles have a distinctive page title: `"false   | GeeksforGeeks Profile"`
- This title pattern is used as the errorMsg for reliable detection

**LushStories** (Closes #2371)
- Switched from `status_code` to `response_url` detection
- Non-existing profiles redirect (HTTP 302) to `/login` while existing profiles return HTTP 200
- Added `errorUrl` pointing to `https://www.lushstories.com/login`

### Testing
- ~~Verified ArtStation API returns 404 for non-existing users and 200 for `Blue`~~
- Verified GeeksforGeeks non-existing profiles contain the error title pattern
- Verified LushStories non-existing profiles redirect to `/login` while `chris_brown` returns 200
- All changes produce valid JSON per the data.schema.json