### PR TITLE
feat: add Carrd, SpaceHey, and Substack as supported sites

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -404,6 +404,13 @@
     "urlMain": "https://carbonmade.com/",
     "username_claimed": "jenny"
   },
+  "Carrd": {
+    "errorType": "status_code",
+    "regexCheck": "^[a-zA-Z0-9_-]{3,50}$",
+    "url": "https://{}.carrd.co/",
+    "urlMain": "https://carrd.co/",
+    "username_claimed": "blue"
+  },
   "Career.habr": {
     "errorMsg": "<h1>\u041e\u0448\u0438\u0431\u043a\u0430 404</h1>",
     "errorType": "message",
@@ -2279,6 +2286,13 @@
     "urlMain": "https://sourceforge.net/",
     "username_claimed": "blue"
   },
+  "SpaceHey": {
+    "errorType": "message",
+    "errorMsg": "Not Found (Error 404) | SpaceHey",
+    "url": "https://spacehey.com/{}",
+    "urlMain": "https://spacehey.com/",
+    "username_claimed": "blue"
+  },
   "SoylentNews": {
     "errorMsg": "The user you requested does not exist, no matter how much you wish this might be the case.",
     "errorType": "message",
@@ -2375,6 +2389,13 @@
     "url": "https://www.strava.com/athletes/{}",
     "urlMain": "https://www.strava.com/",
     "username_claimed": "blue"
+  },
+  "Substack": {
+    "errorType": "status_code",
+    "regexCheck": "^[a-zA-Z0-9][a-zA-Z0-9_-]{1,60}$",
+    "url": "https://{}.substack.com/",
+    "urlMain": "https://substack.com/",
+    "username_claimed": "green"
   },
   "SublimeForum": {
     "errorType": "status_code",


### PR DESCRIPTION
## Summary

Adds three new social media/publishing platforms to the Sherlock target manifest.

### New Sites

**Carrd** (https://carrd.co)
- Simple, one-page website builder
- Profile URLs: `https://{username}.carrd.co/`
- Detection: `status_code` (404 for non-existing, 200 for existing)
- Verified: `blue.carrd.co` returns 200, non-existing returns 404
- regexCheck: `^[a-zA-Z0-9_-]{3,50}$` (Carrd allows alphanumeric, hyphens, underscores, 3-50 chars)

**SpaceHey** (https://spacehey.com)
- Retro social network inspired by classic MySpace
- Profile URLs: `https://spacehey.com/{username}`
- Detection: `message` using title `"Not Found (Error 404) | SpaceHey"`
- Verified: `spacehey.com/blue` returns 200, non-existing profiles show the error title

**Substack** (https://substack.com)
- Newsletter and publishing platform
- Profile URLs: `https://{username}.substack.com/`
- Detection: `status_code` (404 for non-existing, 200 for existing)
- Verified: `green.substack.com` returns 200, non-existing returns 404
- regexCheck: `^[a-zA-Z0-9][a-zA-Z0-9_-]{1,60}$` (Substack allows alphanumeric, hyphens, underscores, 2-61 chars, must start with alphanumeric)

### Testing
- All three sites verified via HTTP requests
- Valid JSON per data.schema.json
- Total site count increased from 478 to 481