### PR TITLE
improve: add granular error handling and expand WAF detection

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -127,12 +127,21 @@ def get_response(request_future, error_type, social_network):
     except requests.exceptions.ProxyError as errp:
         error_context = "Proxy Error"
         exception_text = str(errp)
+    except requests.exceptions.SSLError as errssl:
+        error_context = "SSL Error"
+        exception_text = str(errssl)
     except requests.exceptions.ConnectionError as errc:
         error_context = "Error Connecting"
         exception_text = str(errc)
     except requests.exceptions.Timeout as errt:
         error_context = "Timeout Error"
         exception_text = str(errt)
+    except requests.exceptions.ChunkedEncodingError as errce:
+        error_context = "Chunked Encoding Error"
+        exception_text = str(errce)
+    except requests.exceptions.ContentDecodingError as errcd:
+        error_context = "Content Decoding Error"
+        exception_text = str(errcd)
     except requests.exceptions.RequestException as err:
         error_context = "Unknown Error"
         exception_text = str(err)
@@ -388,11 +397,21 @@ def sherlock(
             r'AwsWafIntegration.forceRefreshToken', # 2024-11-11 Cloudfront (AWS)
             r'{return l.onPageView}}),Object.defineProperty(r,"perimeterxIdentifiers",{enumerable:' # 2024-04-09 PerimeterX / Human Security
         ]
+        WAFHitMsgsCaseInsensitive = [
+            r'cf-browser-verification', # 2025-03 Cloudflare browser verification
+            r'just a moment...',  # 2025-03 Cloudflare challenge page title
+            r'enable javascript and cookies to continue', # 2025-03 Cloudflare challenge
+            r'attentionrequired', # 2025-03 Cloudflare Turnstile
+            r'why do i have to complete a captcha', # 2025-03 Generic WAF captcha page
+        ]
 
         if error_text is not None:
             error_context = error_text
 
         elif any(hitMsg in r.text for hitMsg in WAFHitMsgs):
+            query_status = QueryStatus.WAF
+
+        elif any(hitMsg.lower() in r.text.lower() for hitMsg in WAFHitMsgsCaseInsensitive):
             query_status = QueryStatus.WAF
 
         else:


### PR DESCRIPTION
## Summary

Improves error handling granularity in `get_response()` and expands WAF (Web Application Firewall) detection to reduce false positives from WAF-blocked responses.

### Changes to `get_response()`

**Added `SSLError` handling**
- `requests.exceptions.SSLError` is a subclass of `ConnectionError` but represents a distinctly different problem (TLS certificate validation failure vs network connectivity)
- Previously, SSL errors fell through to the generic "Error Connecting" message
- Now reports "SSL Error" with the exception text, giving users actionable feedback about certificate issues
- Placed before `ConnectionError` catch since it is a more specific subclass

**Added `ChunkedEncodingError` handling**
- `requests.exceptions.ChunkedEncodingError` occurs when a server sends an incomplete chunked transfer encoding response
- Previously fell through to the generic "Unknown Error" catch-all
- Now reports "Chunked Encoding Error" which helps distinguish transient server issues from client-side problems

**Added `ContentDecodingError` handling**
- `requests.exceptions.ContentDecodingError` occurs when response body decompression fails (e.g., corrupted gzip/deflate content)
- Previously fell through to the generic "Unknown Error" catch-all
- Now reports "Content Decoding Error" which helps identify encoding-related issues

### Changes to WAF Detection

**Added case-insensitive WAF fingerprint matching**
- Some WAF challenge pages use varying capitalization that the existing case-sensitive patterns miss
- New `WAFHitMsgsCaseInsensitive` list for patterns that need case-insensitive matching

**New WAF fingerprints:**
- `cf-browser-verification`: Cloudflare browser verification class
- `just a moment...`: Cloudflare interstitial challenge page title (e.g., "Just a moment...")
- `enable javascript and cookies to continue`: Cloudflare challenge instruction text
- `attentionrequired`: Cloudflare Turnstile challenge attribute
- `why do i have to complete a captcha`: Generic WAF captcha explanation text

These fingerprints help catch WAF challenge pages that were previously missed, reducing false positives where Sherlock would incorrectly report a username as "Claimed" when the response was actually a WAF block page.

### Testing
- Verified Python syntax is valid
- Exception hierarchy is correct (SSLError before ConnectionError, specific errors before RequestException)
- All existing exception handlers remain unchanged