### PR TITLE
Add guns.lol

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1077,8 +1077,7 @@
     "errorType": "message",
     "url": "https://guns.lol",
     "urlMain": "https://guns.lol/{}",
-    "username_claimed": "example",
-    "username_unclaimed": "noonewouldeverusethis7"
+    "username_claimed": "example"
   },
   "Gumroad": {
     "errorMsg": "Page not found (404) - Gumroad",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1072,6 +1072,14 @@
     "urlMain": "http://en.gravatar.com/",
     "username_claimed": "blue"
   },
+  "guns.lol": {
+    "errorMsg": "Username not found",
+    "errorType": "message",
+    "url": "https://guns.lol",
+    "urlMain": "https://guns.lol/{}",
+    "username_claimed": "example",
+    "username_unclaimed": "noonewouldeverusethis7"
+  },
   "Gumroad": {
     "errorMsg": "Page not found (404) - Gumroad",
     "errorType": "message",


### PR DESCRIPTION
Added https://guns.lol

The site does not correctly return status codes. I used the domain itself as the name, as it's the widely used name. 