### PR TITLE
sites: include HTTP status + body snippet in data-fetch error

### DIFF
--- a/sherlock_project/sites.py
+++ b/sherlock_project/sites.py
@@ -131,9 +131,16 @@ class SitesInformation:
                 )
 
             if response.status_code != 200:
-                raise FileNotFoundError(f"Bad response while accessing "
-                                        f"data file URL '{data_file_path}'."
-                                        )
+                # Include the status code and a short body snippet so users
+                # can tell the difference between e.g. a 404 (URL moved),
+                # 5xx (host outage), or a captive-portal HTML page.
+                body_snippet = response.text[:200].strip()
+                raise FileNotFoundError(
+                    f"Bad response while accessing data file URL "
+                    f"'{data_file_path}': HTTP {response.status_code} "
+                    f"{response.reason}. "
+                    f"Response body starts with: {body_snippet!r}"
+                )
             try:
                 site_data = response.json()
             except Exception as error:


### PR DESCRIPTION
Closes #2924.

When fetching `MANIFEST_URL` fails, the existing error gives the user nothing to go on:

```
Bad response while accessing data file URL '<url>'.
```

That makes it hard to tell whether they hit:
- a 404 (URL moved — exactly what happened in #2924, where the user was on an older version pointing at the old `raw.githubusercontent.com` path)
- a 5xx (host outage)
- a captive-portal HTML page returned by an upstream proxy
- some other failure mode

This includes the HTTP status code, the reason phrase, and the first 200 characters of the response body in the exception message. No behavior change — just makes the error self-diagnosable.