### PR TITLE
fix(xlsx): use query_time (not the list itself) for None check (#2891)

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -900,7 +900,7 @@ def main():
                 ):
                     continue
 
-                if response_time_s is None:
+                if results[site]["status"].query_time is None:
                     response_time_s.append("")
                 else:
                     response_time_s.append(results[site]["status"].query_time)


### PR DESCRIPTION
Closes #2891.

The CSV branch in `sherlock.py` handles a missing `query_time` correctly:

```python
response_time_s = results[site]['status'].query_time
if response_time_s is None:
    response_time_s = ''
```

The xlsx branch a few lines down initialises `response_time_s` as an empty list and then checks `if response_time_s is None` — which is always `False` (the list isn't `None`), so the empty-string fallback never fires. The literal `None` ends up in the xlsx cell when pandas writes the DataFrame.

The fix mirrors the CSV branch exactly: check the per-site `query_time` directly, not the local accumulator. One-line diff.

The bug + fix were both already laid out in the issue body by @robert-trach1985-bunny — picking it up to ship it.
