### PR TITLE
Keep request futures local to sherlock

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -227,6 +227,7 @@ def sherlock(
 
     # Results from analysis of all sites
     results_total = {}
+    request_futures = {}
 
     # First create futures for all requests. This allows for the requests to run in parallel
     for social_network, net_info in site_data.items():
@@ -333,7 +334,7 @@ def sherlock(
                 )
 
             # Store future in data for access later
-            net_info["request_future"] = future
+            request_futures[social_network] = future
 
         # Add this site's results into final dictionary with all the other results.
         results_total[social_network] = results_site
@@ -356,7 +357,7 @@ def sherlock(
             error_type: list[str] = [error_type]
 
         # Retrieve future and ensure it has finished
-        future = net_info["request_future"]
+        future = request_futures[social_network]
         r, error_text, exception_text = get_response(
             request_future=future, error_type=error_type, social_network=social_network
         )

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -1,5 +1,6 @@
 import pytest
 from sherlock_project import sherlock
+from sherlock_project.notify import QueryNotify
 from sherlock_interactives import Interactives
 from sherlock_interactives import InteractivesSubprocessError
 
@@ -31,6 +32,50 @@ def test_wildcard_username_expansion():
     assert sherlock.check_for_parameter('test{?test') is False
     assert sherlock.check_for_parameter('test?}test') is False
     assert sherlock.multiple_usernames('test{?}test') == ["test_test" , "test-test" , "test.test"]
+
+
+def test_sherlock_does_not_mutate_input_site_data(monkeypatch):
+    class FakeResponse:
+        status_code = 404
+        text = ""
+        encoding = "UTF-8"
+        elapsed = None
+
+    class FakeFuture:
+        def result(self):
+            return FakeResponse()
+
+    class FakeFuturesSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def head(self, **kwargs):
+            return FakeFuture()
+
+        get = head
+        post = head
+        put = head
+
+    monkeypatch.setattr(sherlock.requests, "session", lambda: object())
+    monkeypatch.setattr(sherlock, "SherlockFuturesSession", FakeFuturesSession)
+    site_data = {
+        "Example": {
+            "urlMain": "https://example.com",
+            "url": "https://example.com/{}",
+            "errorType": "status_code",
+            "errorCode": 404,
+        }
+    }
+    original_site_data = {name: dict(info) for name, info in site_data.items()}
+
+    sherlock.sherlock(
+        username="alice",
+        site_data=site_data,
+        query_notify=QueryNotify(),
+        timeout=1,
+    )
+
+    assert site_data == original_site_data
 
 
 @pytest.mark.parametrize('cliargs', [


### PR DESCRIPTION
 ## Summary

  This keeps request futures local to `sherlock()` instead of storing them inside the caller-provided `site_data` dictionaries.

  ## Rationale

  Although Sherlock is primarily used as a CLI, `sherlock()` is an importable function and is already called directly in the test suite. A wrapper, integration, or downstream test can reasonably pass in
  a `site_data` object and expect it to remain site metadata rather than become temporary request-state storage.

  Currently, the function iterates through `site_data` like this:

  ```python
  for social_network, net_info in site_data.items():
  ```

  Inside that loop, net_info is the per-site dictionary from site_data. The current implementation stores runtime request state there:

`  net_info["request_future"] = future`

  and reads it back later.

  This is harmless in the normal one-shot CLI path, because the mutated site_data is usually discarded. But it can surprise callers that reuse, inspect, compare, serialize, or share the same site_data
  object.

  This PR preserves the existing two-pass flow, but stores futures in a local dictionary keyed by social-network name instead.

  ## Behavior

  This should preserve user-visible behavior. It changes only where temporary request futures are stored during the call.

  The invalid-username path is still handled: when no future is created, the site already has a status, and the second pass continues before reading from the local futures dictionary.

  ## Test

  Added a focused no-network regression test that fakes the futures session and asserts that sherlock() does not mutate the supplied site_data.

  ## Local validation

`  python3 -m py_compile sherlock_project/sherlock.py tests/test_ux.py`

  I prepared this outside a fully installed Sherlock development environment, so I was not able to run the focused pytest command locally. The intended focused test command is:

`  python -m pytest -q tests/test_ux.py::test_sherlock_does_not_mutate_input_site_data`

