### PR TITLE
Improve username URL encoding and fix Reddit verification page false positives

### DIFF
--- a/sherlock_project/notify.py
+++ b/sherlock_project/notify.py
@@ -235,11 +235,14 @@ class QueryNotifyPrint(QueryNotify):
 
         elif result.status == QueryStatus.WAF:
             if self.print_all:
+                waf_message = "Blocked by bot detection"
+                if self.result.context is not None:
+                    waf_message += f" ({self.result.context})"
                 print(Style.BRIGHT + Fore.WHITE + "[" +
                       Fore.RED + "-" +
                       Fore.WHITE + "]" +
                       Fore.GREEN + f" {self.result.site_name}:" +
-                      Fore.RED + " Blocked by bot detection" +
+                      Fore.RED + f" {waf_message}" +
                       Fore.YELLOW + " (proxy may help)")
 
         else:

--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -25,6 +25,7 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from json import loads as json_loads
 from time import monotonic
 from typing import Optional
+from urllib.parse import quote
 
 import requests
 from requests_futures.sessions import FuturesSession
@@ -150,6 +151,23 @@ def interpolate_string(input_object, username):
     return input_object
 
 
+def encode_username_for_url(username):
+    """Encode usernames before interpolating them into URLs."""
+    return quote(username, safe="@._-")
+
+
+def is_reddit_verification_page(response_text):
+    """Detect Reddit verification / challenge pages."""
+    return (
+        "Please wait for verification" in response_text
+        and (
+            'name="js_challenge"' in response_text
+            or 'name="solution"' in response_text
+            or 'name="jsc_orig_r"' in response_text
+        )
+    )
+
+
 def check_for_parameter(username):
     """checks if {?} exists in the username
     if exist it means that sherlock is looking for more multiple username"""
@@ -243,7 +261,8 @@ def sherlock(
             headers.update(net_info["headers"])
 
         # URL of user on site (if it exists)
-        url = interpolate_string(net_info["url"], username.replace(' ', '%20'))
+        encoded_username = encode_username_for_url(username)
+        url = interpolate_string(net_info["url"], encoded_username)
 
         # Don't make request if username is invalid for the site
         regex_check = net_info.get("regexCheck")
@@ -285,7 +304,7 @@ def sherlock(
             else:
                 # There is a special URL for probing existence separate
                 # from where the user profile normally can be found.
-                url_probe = interpolate_string(url_probe, username)
+                url_probe = interpolate_string(url_probe, encoded_username)
 
             if request is None:
                 if net_info["errorType"] == "status_code":
@@ -395,6 +414,10 @@ def sherlock(
         elif any(hitMsg in r.text for hitMsg in WAFHitMsgs):
             query_status = QueryStatus.WAF
 
+        elif social_network == "Reddit" and is_reddit_verification_page(r.text):
+            query_status = QueryStatus.WAF
+            error_context = "Reddit verification page"
+
         else:
             if any(errtype not in ["message", "status_code", "response_url"] for errtype in error_type):
                 error_context = f"Unknown error type '{error_type}' for {social_network}"
@@ -465,10 +488,15 @@ def sherlock(
                 print(f"RESPONSE CODE : {r.status_code}")
             except Exception:
                 pass
-            try:
-                print(f"ERROR TEXT    : {net_info['errorMsg']}")
-            except KeyError:
-                pass
+            if error_context is not None:
+                print(f"CONTEXT       : {error_context}")
+            if query_status is QueryStatus.WAF:
+                print("DETECTED AS   : WAF / challenge page")
+            else:
+                try:
+                    print(f"EXPECTED TEXT : {net_info['errorMsg']}")
+                except KeyError:
+                    pass
             print(">>>>> BEGIN RESPONSE TEXT")
             try:
                 print(r.text)

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -1,7 +1,9 @@
 import pytest
 from sherlock_project import sherlock
+from sherlock_project.result import QueryStatus
 from sherlock_interactives import Interactives
 from sherlock_interactives import InteractivesSubprocessError
+
 
 def test_remove_nsfw(sites_obj):
     nsfw_target: str = 'Pornhub'
@@ -31,6 +33,93 @@ def test_wildcard_username_expansion():
     assert sherlock.check_for_parameter('test{?test') is False
     assert sherlock.check_for_parameter('test?}test') is False
     assert sherlock.multiple_usernames('test{?}test') == ["test_test" , "test-test" , "test.test"]
+
+
+def test_encode_username_for_url_preserves_safe_characters():
+    assert sherlock.encode_username_for_url('user-name_1.@') == 'user-name_1.@'
+
+
+def test_encode_username_for_url_escapes_special_characters():
+    assert sherlock.encode_username_for_url('a/b c+') == 'a%2Fb%20c%2B'
+
+
+def test_interpolate_string_uses_encoded_username_for_urls():
+    encoded_username = sherlock.encode_username_for_url('a/b c+')
+    assert sherlock.interpolate_string('https://example.com/{}', encoded_username) == 'https://example.com/a%2Fb%20c%2B'
+
+
+def test_is_reddit_verification_page_detects_challenge_html():
+    html = '''
+    <title>Reddit - Please wait for verification</title>
+    <form hidden method="GET" action="/user/j%20a%20c%20k%20s%20o%20n%20/">
+      <input type="hidden" name="solution" />
+      <input type="hidden" name="js_challenge" value="1"/>
+      <input type="hidden" name="token" value="abc123"/>
+      <input type="hidden" name="jsc_orig_r" value=""/>
+    </form>
+    '''
+    assert sherlock.is_reddit_verification_page(html) is True
+
+
+def test_is_reddit_verification_page_rejects_normal_html():
+    html = '<html><head><title>Reddit - user page</title></head><body>normal content</body></html>'
+    assert sherlock.is_reddit_verification_page(html) is False
+
+
+def test_reddit_verification_page_is_classified_as_waf(monkeypatch):
+    class FakeResponse:
+        status_code = 200
+        elapsed = 0.1
+        encoding = 'utf-8'
+        text = '''
+        <title>Reddit - Please wait for verification</title>
+        <form hidden method="GET" action="/user/j%20a%20c%20k%20s%20o%20n%20/">
+          <input type="hidden" name="solution" />
+          <input type="hidden" name="js_challenge" value="1"/>
+          <input type="hidden" name="token" value="abc123"/>
+          <input type="hidden" name="jsc_orig_r" value=""/>
+        </form>
+        '''
+
+    class FakeFuture:
+        def result(self):
+            return FakeResponse()
+
+    class FakeSherlockFuturesSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, *args, **kwargs):
+            return FakeFuture()
+
+        def head(self, *args, **kwargs):
+            return FakeFuture()
+
+        def post(self, *args, **kwargs):
+            return FakeFuture()
+
+        def put(self, *args, **kwargs):
+            return FakeFuture()
+
+    monkeypatch.setattr(sherlock, 'SherlockFuturesSession', FakeSherlockFuturesSession)
+
+    reddit_site = {
+        'errorMsg': 'Sorry, nobody on Reddit goes by that name.',
+        'errorType': 'message',
+        'headers': {'accept-language': 'en-US,en;q=0.9'},
+        'url': 'https://www.reddit.com/user/{}',
+        'urlMain': 'https://www.reddit.com/',
+        'username_claimed': 'blue',
+    }
+
+    results = sherlock.sherlock(
+        username='j a c k s o n ',
+        site_data={'Reddit': reddit_site},
+        query_notify=sherlock.QueryNotify(),
+    )
+
+    assert results['Reddit']['status'].status is QueryStatus.WAF
+    assert results['Reddit']['status'].context == 'Reddit verification page'
 
 
 @pytest.mark.parametrize('cliargs', [


### PR DESCRIPTION
Summary
This PR improves username URL handling and fixes a real false-positive issue on Reddit.

1. Safer URL interpolation
I added [encode_username_for_url()] and used it for URL-based username interpolation to avoid breaking URL structure when usernames contain special characters (like '/').

2. Reddit verification/challenge page detection
Reddit sometimes returns a verification/challenge page instead of a normal user-not-found response.

Previously, this could be misclassified as [CLAIMED], causing a false positive.

To address this, I added [is_reddit_verification_page()] and integrated it into the main detection flow so these pages are classified as [QueryStatus.WAF] with a clearer context string: Reddit verification page.

3. Improved diagnostics
I also updated the [--dump-response] output and WAF terminal output so the detection reason is easier to understand.

Tests
Added coverage for:

URL encoding behavior
Reddit verification-page detection
Main-flow WAF classification for Reddit