### PR TITLE
Improve Ctrl+C responsiveness during future polling

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -22,6 +22,7 @@ import pandas as pd
 import os
 import re
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from json import loads as json_loads
 from time import monotonic
 from typing import Optional
@@ -117,10 +118,18 @@ def get_response(request_future, error_type, social_network):
     error_context = "General Unknown Error"
     exception_text = None
     try:
-        response = request_future.result()
+        while True:
+            try:
+                response = request_future.result(timeout=0.1)
+                break
+            except FutureTimeoutError:
+                continue
+
         if response.status_code:
             # Status code exists in response object
             error_context = None
+    except KeyboardInterrupt:
+        raise
     except requests.exceptions.HTTPError as errh:
         error_context = "HTTP Error"
         exception_text = str(errh)
@@ -141,6 +150,17 @@ def get_response(request_future, error_type, social_network):
         exception_text = str(err)
 
     return response, error_context, exception_text
+
+
+
+def shutdown_request_session(session, underlying_session, site_data):
+    for net_info in site_data.values():
+        request_future = net_info.get("request_future")
+        if request_future is not None:
+            request_future.cancel()
+
+    session.executor.shutdown(wait=False, cancel_futures=True)
+    underlying_session.close()
 
 
 def interpolate_string(input_object, username):
@@ -228,280 +248,285 @@ def sherlock(
     # Results from analysis of all sites
     results_total = {}
 
-    # First create futures for all requests. This allows for the requests to run in parallel
-    for social_network, net_info in site_data.items():
-        # Results from analysis of this specific site
-        results_site = {"url_main": net_info.get("urlMain")}
+    try:
+        # First create futures for all requests. This allows for the requests to run in parallel
+        for social_network, net_info in site_data.items():
+            # Results from analysis of this specific site
+            results_site = {"url_main": net_info.get("urlMain")}
 
-        # Record URL of main site
+            # Record URL of main site
 
-        # A user agent is needed because some sites don't return the correct
-        # information since they think that we are bots (Which we actually are...)
-        headers = {
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0",
-        }
+            # A user agent is needed because some sites don't return the correct
+            # information since they think that we are bots (Which we actually are...)
+            headers = {
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0",
+            }
 
-        if "headers" in net_info:
-            # Override/append any extra headers required by a given site.
-            headers.update(net_info["headers"])
+            if "headers" in net_info:
+                # Override/append any extra headers required by a given site.
+                headers.update(net_info["headers"])
 
-        # URL of user on site (if it exists)
-        url = interpolate_string(net_info["url"], username.replace(' ', '%20'))
-
-        # Don't make request if username is invalid for the site
-        regex_check = net_info.get("regexCheck")
-        if regex_check and re.search(regex_check, username) is None:
-            # No need to do the check at the site: this username is not allowed.
-            results_site["status"] = QueryResult(
-                username, social_network, url, QueryStatus.ILLEGAL
-            )
-            results_site["url_user"] = ""
-            results_site["http_status"] = ""
-            results_site["response_text"] = ""
-            query_notify.update(results_site["status"])
-        else:
             # URL of user on site (if it exists)
-            results_site["url_user"] = url
-            url_probe = net_info.get("urlProbe")
-            request_method = net_info.get("request_method")
-            request_payload = net_info.get("request_payload")
-            request = None
+            url = interpolate_string(net_info["url"], username.replace(' ', '%20'))
 
-            if request_method is not None:
-                if request_method == "GET":
-                    request = session.get
-                elif request_method == "HEAD":
-                    request = session.head
-                elif request_method == "POST":
-                    request = session.post
-                elif request_method == "PUT":
-                    request = session.put
-                else:
-                    raise RuntimeError(f"Unsupported request_method for {url}")
-
-            if request_payload is not None:
-                request_payload = interpolate_string(request_payload, username)
-
-            if url_probe is None:
-                # Probe URL is normal one seen by people out on the web.
-                url_probe = url
-            else:
-                # There is a special URL for probing existence separate
-                # from where the user profile normally can be found.
-                url_probe = interpolate_string(url_probe, username)
-
-            if request is None:
-                if net_info["errorType"] == "status_code":
-                    # In most cases when we are detecting by status code,
-                    # it is not necessary to get the entire body:  we can
-                    # detect fine with just the HEAD response.
-                    request = session.head
-                else:
-                    # Either this detect method needs the content associated
-                    # with the GET response, or this specific website will
-                    # not respond properly unless we request the whole page.
-                    request = session.get
-
-            if net_info["errorType"] == "response_url":
-                # Site forwards request to a different URL if username not
-                # found.  Disallow the redirect so we can capture the
-                # http status from the original URL request.
-                allow_redirects = False
-            else:
-                # Allow whatever redirect that the site wants to do.
-                # The final result of the request will be what is available.
-                allow_redirects = True
-
-            # This future starts running the request in a new thread, doesn't block the main thread
-            if proxy is not None:
-                proxies = {"http": proxy, "https": proxy}
-                future = request(
-                    url=url_probe,
-                    headers=headers,
-                    proxies=proxies,
-                    allow_redirects=allow_redirects,
-                    timeout=timeout,
-                    json=request_payload,
+            # Don't make request if username is invalid for the site
+            regex_check = net_info.get("regexCheck")
+            if regex_check and re.search(regex_check, username) is None:
+                # No need to do the check at the site: this username is not allowed.
+                results_site["status"] = QueryResult(
+                    username, social_network, url, QueryStatus.ILLEGAL
                 )
+                results_site["url_user"] = ""
+                results_site["http_status"] = ""
+                results_site["response_text"] = ""
+                query_notify.update(results_site["status"])
             else:
-                future = request(
-                    url=url_probe,
-                    headers=headers,
-                    allow_redirects=allow_redirects,
-                    timeout=timeout,
-                    json=request_payload,
-                )
+                # URL of user on site (if it exists)
+                results_site["url_user"] = url
+                url_probe = net_info.get("urlProbe")
+                request_method = net_info.get("request_method")
+                request_payload = net_info.get("request_payload")
+                request = None
 
-            # Store future in data for access later
-            net_info["request_future"] = future
-
-        # Add this site's results into final dictionary with all the other results.
-        results_total[social_network] = results_site
-
-    # Open the file containing account links
-    for social_network, net_info in site_data.items():
-        # Retrieve results again
-        results_site = results_total.get(social_network)
-
-        # Retrieve other site information again
-        url = results_site.get("url_user")
-        status = results_site.get("status")
-        if status is not None:
-            # We have already determined the user doesn't exist here
-            continue
-
-        # Get the expected error type
-        error_type = net_info["errorType"]
-        if isinstance(error_type, str):
-            error_type: list[str] = [error_type]
-
-        # Retrieve future and ensure it has finished
-        future = net_info["request_future"]
-        r, error_text, exception_text = get_response(
-            request_future=future, error_type=error_type, social_network=social_network
-        )
-
-        # Get response time for response of our request.
-        try:
-            response_time = r.elapsed
-        except AttributeError:
-            response_time = None
-
-        # Attempt to get request information
-        try:
-            http_status = r.status_code
-        except Exception:
-            http_status = "?"
-        try:
-            response_text = r.text.encode(r.encoding or "UTF-8")
-        except Exception:
-            response_text = ""
-
-        query_status = QueryStatus.UNKNOWN
-        error_context = None
-
-        # As WAFs advance and evolve, they will occasionally block Sherlock and
-        # lead to false positives and negatives. Fingerprints should be added
-        # here to filter results that fail to bypass WAFs. Fingerprints should
-        # be highly targetted. Comment at the end of each fingerprint to
-        # indicate target and date fingerprinted.
-        WAFHitMsgs = [
-            r'.loading-spinner{visibility:hidden}body.no-js .challenge-running{display:none}body.dark{background-color:#222;color:#d9d9d9}body.dark a{color:#fff}body.dark a:hover{color:#ee730a;text-decoration:underline}body.dark .lds-ring div{border-color:#999 transparent transparent}body.dark .font-red{color:#b20f03}body.dark', # 2024-05-13 Cloudflare
-            r'<span id="challenge-error-text">', # 2024-11-11 Cloudflare error page
-            r'AwsWafIntegration.forceRefreshToken', # 2024-11-11 Cloudfront (AWS)
-            r'{return l.onPageView}}),Object.defineProperty(r,"perimeterxIdentifiers",{enumerable:' # 2024-04-09 PerimeterX / Human Security
-        ]
-
-        if error_text is not None:
-            error_context = error_text
-
-        elif any(hitMsg in r.text for hitMsg in WAFHitMsgs):
-            query_status = QueryStatus.WAF
-
-        else:
-            if any(errtype not in ["message", "status_code", "response_url"] for errtype in error_type):
-                error_context = f"Unknown error type '{error_type}' for {social_network}"
-                query_status = QueryStatus.UNKNOWN
-            else:
-                if "message" in error_type:
-                    # error_flag True denotes no error found in the HTML
-                    # error_flag False denotes error found in the HTML
-                    error_flag = True
-                    errors = net_info.get("errorMsg")
-                    # errors will hold the error message
-                    # it can be string or list
-                    # by isinstance method we can detect that
-                    # and handle the case for strings as normal procedure
-                    # and if its list we can iterate the errors
-                    if isinstance(errors, str):
-                        # Checks if the error message is in the HTML
-                        # if error is present we will set flag to False
-                        if errors in r.text:
-                            error_flag = False
+                if request_method is not None:
+                    if request_method == "GET":
+                        request = session.get
+                    elif request_method == "HEAD":
+                        request = session.head
+                    elif request_method == "POST":
+                        request = session.post
+                    elif request_method == "PUT":
+                        request = session.put
                     else:
-                        # If it's list, it will iterate all the error message
-                        for error in errors:
-                            if error in r.text:
+                        raise RuntimeError(f"Unsupported request_method for {url}")
+
+                if request_payload is not None:
+                    request_payload = interpolate_string(request_payload, username)
+
+                if url_probe is None:
+                    # Probe URL is normal one seen by people out on the web.
+                    url_probe = url
+                else:
+                    # There is a special URL for probing existence separate
+                    # from where the user profile normally can be found.
+                    url_probe = interpolate_string(url_probe, username)
+
+                if request is None:
+                    if net_info["errorType"] == "status_code":
+                        # In most cases when we are detecting by status code,
+                        # it is not necessary to get the entire body:  we can
+                        # detect fine with just the HEAD response.
+                        request = session.head
+                    else:
+                        # Either this detect method needs the content associated
+                        # with the GET response, or this specific website will
+                        # not respond properly unless we request the whole page.
+                        request = session.get
+
+                if net_info["errorType"] == "response_url":
+                    # Site forwards request to a different URL if username not
+                    # found.  Disallow the redirect so we can capture the
+                    # http status from the original URL request.
+                    allow_redirects = False
+                else:
+                    # Allow whatever redirect that the site wants to do.
+                    # The final result of the request will be what is available.
+                    allow_redirects = True
+
+                # This future starts running the request in a new thread, doesn't block the main thread
+                if proxy is not None:
+                    proxies = {"http": proxy, "https": proxy}
+                    future = request(
+                        url=url_probe,
+                        headers=headers,
+                        proxies=proxies,
+                        allow_redirects=allow_redirects,
+                        timeout=timeout,
+                        json=request_payload,
+                    )
+                else:
+                    future = request(
+                        url=url_probe,
+                        headers=headers,
+                        allow_redirects=allow_redirects,
+                        timeout=timeout,
+                        json=request_payload,
+                    )
+
+                # Store future in data for access later
+                net_info["request_future"] = future
+
+            # Add this site's results into final dictionary with all the other results.
+            results_total[social_network] = results_site
+
+        # Open the file containing account links
+        for social_network, net_info in site_data.items():
+            # Retrieve results again
+            results_site = results_total.get(social_network)
+
+            # Retrieve other site information again
+            url = results_site.get("url_user")
+            status = results_site.get("status")
+            if status is not None:
+                # We have already determined the user doesn't exist here
+                continue
+
+            # Get the expected error type
+            error_type = net_info["errorType"]
+            if isinstance(error_type, str):
+                error_type: list[str] = [error_type]
+
+            # Retrieve future and ensure it has finished
+            future = net_info["request_future"]
+            r, error_text, exception_text = get_response(
+                request_future=future, error_type=error_type, social_network=social_network
+            )
+
+            # Get response time for response of our request.
+            try:
+                response_time = r.elapsed
+            except AttributeError:
+                response_time = None
+
+            # Attempt to get request information
+            try:
+                http_status = r.status_code
+            except Exception:
+                http_status = "?"
+            try:
+                response_text = r.text.encode(r.encoding or "UTF-8")
+            except Exception:
+                response_text = ""
+
+            query_status = QueryStatus.UNKNOWN
+            error_context = None
+
+            # As WAFs advance and evolve, they will occasionally block Sherlock and
+            # lead to false positives and negatives. Fingerprints should be added
+            # here to filter results that fail to bypass WAFs. Fingerprints should
+            # be highly targetted. Comment at the end of each fingerprint to
+            # indicate target and date fingerprinted.
+            WAFHitMsgs = [
+                r'.loading-spinner{visibility:hidden}body.no-js .challenge-running{display:none}body.dark{background-color:#222;color:#d9d9d9}body.dark a{color:#fff}body.dark a:hover{color:#ee730a;text-decoration:underline}body.dark .lds-ring div{border-color:#999 transparent transparent}body.dark .font-red{color:#b20f03}body.dark', # 2024-05-13 Cloudflare
+                r'<span id="challenge-error-text">', # 2024-11-11 Cloudflare error page
+                r'AwsWafIntegration.forceRefreshToken', # 2024-11-11 Cloudfront (AWS)
+                r'{return l.onPageView}}),Object.defineProperty(r,"perimeterxIdentifiers",{enumerable:' # 2024-04-09 PerimeterX / Human Security
+            ]
+
+            if error_text is not None:
+                error_context = error_text
+
+            elif any(hitMsg in r.text for hitMsg in WAFHitMsgs):
+                query_status = QueryStatus.WAF
+
+            else:
+                if any(errtype not in ["message", "status_code", "response_url"] for errtype in error_type):
+                    error_context = f"Unknown error type '{error_type}' for {social_network}"
+                    query_status = QueryStatus.UNKNOWN
+                else:
+                    if "message" in error_type:
+                        # error_flag True denotes no error found in the HTML
+                        # error_flag False denotes error found in the HTML
+                        error_flag = True
+                        errors = net_info.get("errorMsg")
+                        # errors will hold the error message
+                        # it can be string or list
+                        # by isinstance method we can detect that
+                        # and handle the case for strings as normal procedure
+                        # and if its list we can iterate the errors
+                        if isinstance(errors, str):
+                            # Checks if the error message is in the HTML
+                            # if error is present we will set flag to False
+                            if errors in r.text:
                                 error_flag = False
-                                break
-                    if error_flag:
+                        else:
+                            # If it's list, it will iterate all the error message
+                            for error in errors:
+                                if error in r.text:
+                                    error_flag = False
+                                    break
+                        if error_flag:
+                            query_status = QueryStatus.CLAIMED
+                        else:
+                            query_status = QueryStatus.AVAILABLE
+
+                    if "status_code" in error_type and query_status is not QueryStatus.AVAILABLE:
+                        error_codes = net_info.get("errorCode")
                         query_status = QueryStatus.CLAIMED
-                    else:
-                        query_status = QueryStatus.AVAILABLE
 
-                if "status_code" in error_type and query_status is not QueryStatus.AVAILABLE:
-                    error_codes = net_info.get("errorCode")
-                    query_status = QueryStatus.CLAIMED
+                        # Type consistency, allowing for both singlets and lists in manifest
+                        if isinstance(error_codes, int):
+                            error_codes = [error_codes]
 
-                    # Type consistency, allowing for both singlets and lists in manifest
-                    if isinstance(error_codes, int):
-                        error_codes = [error_codes]
+                        if error_codes is not None and r.status_code in error_codes:
+                            query_status = QueryStatus.AVAILABLE
+                        elif r.status_code >= 300 or r.status_code < 200:
+                            query_status = QueryStatus.AVAILABLE
 
-                    if error_codes is not None and r.status_code in error_codes:
-                        query_status = QueryStatus.AVAILABLE
-                    elif r.status_code >= 300 or r.status_code < 200:
-                        query_status = QueryStatus.AVAILABLE
+                    if "response_url" in error_type and query_status is not QueryStatus.AVAILABLE:
+                        # For this detection method, we have turned off the redirect.
+                        # So, there is no need to check the response URL: it will always
+                        # match the request.  Instead, we will ensure that the response
+                        # code indicates that the request was successful (i.e. no 404, or
+                        # forward to some odd redirect).
+                        if 200 <= r.status_code < 300:
+                            query_status = QueryStatus.CLAIMED
+                        else:
+                            query_status = QueryStatus.AVAILABLE
 
-                if "response_url" in error_type and query_status is not QueryStatus.AVAILABLE:
-                    # For this detection method, we have turned off the redirect.
-                    # So, there is no need to check the response URL: it will always
-                    # match the request.  Instead, we will ensure that the response
-                    # code indicates that the request was successful (i.e. no 404, or
-                    # forward to some odd redirect).
-                    if 200 <= r.status_code < 300:
-                        query_status = QueryStatus.CLAIMED
-                    else:
-                        query_status = QueryStatus.AVAILABLE
+            if dump_response:
+                print("+++++++++++++++++++++")
+                print(f"TARGET NAME   : {social_network}")
+                print(f"USERNAME      : {username}")
+                print(f"TARGET URL    : {url}")
+                print(f"TEST METHOD   : {error_type}")
+                try:
+                    print(f"STATUS CODES  : {net_info['errorCode']}")
+                except KeyError:
+                    pass
+                print("Results...")
+                try:
+                    print(f"RESPONSE CODE : {r.status_code}")
+                except Exception:
+                    pass
+                try:
+                    print(f"ERROR TEXT    : {net_info['errorMsg']}")
+                except KeyError:
+                    pass
+                print(">>>>> BEGIN RESPONSE TEXT")
+                try:
+                    print(r.text)
+                except Exception:
+                    pass
+                print("<<<<< END RESPONSE TEXT")
+                print("VERDICT       : " + str(query_status))
+                print("+++++++++++++++++++++")
 
-        if dump_response:
-            print("+++++++++++++++++++++")
-            print(f"TARGET NAME   : {social_network}")
-            print(f"USERNAME      : {username}")
-            print(f"TARGET URL    : {url}")
-            print(f"TEST METHOD   : {error_type}")
-            try:
-                print(f"STATUS CODES  : {net_info['errorCode']}")
-            except KeyError:
-                pass
-            print("Results...")
-            try:
-                print(f"RESPONSE CODE : {r.status_code}")
-            except Exception:
-                pass
-            try:
-                print(f"ERROR TEXT    : {net_info['errorMsg']}")
-            except KeyError:
-                pass
-            print(">>>>> BEGIN RESPONSE TEXT")
-            try:
-                print(r.text)
-            except Exception:
-                pass
-            print("<<<<< END RESPONSE TEXT")
-            print("VERDICT       : " + str(query_status))
-            print("+++++++++++++++++++++")
+            # Notify caller about results of query.
+            result: QueryResult = QueryResult(
+                username=username,
+                site_name=social_network,
+                site_url_user=url,
+                status=query_status,
+                query_time=response_time,
+                context=error_context,
+            )
+            query_notify.update(result)
 
-        # Notify caller about results of query.
-        result: QueryResult = QueryResult(
-            username=username,
-            site_name=social_network,
-            site_url_user=url,
-            status=query_status,
-            query_time=response_time,
-            context=error_context,
-        )
-        query_notify.update(result)
+            # Save status of request
+            results_site["status"] = result
 
-        # Save status of request
-        results_site["status"] = result
+            # Save results from request
+            results_site["http_status"] = http_status
+            results_site["response_text"] = response_text
 
-        # Save results from request
-        results_site["http_status"] = http_status
-        results_site["response_text"] = response_text
+            # Add this site's results into final dictionary with all of the other results.
+            results_total[social_network] = results_site
+    except KeyboardInterrupt:
+        shutdown_request_session(session, underlying_session, site_data)
+        raise
 
-        # Add this site's results into final dictionary with all of the other results.
-        results_total[social_network] = results_site
-
+    session.close()
     return results_total
 
 
@@ -531,11 +556,11 @@ def timeout_check(value):
 
 
 def handler(signal_received, frame):
-    """Exit gracefully without throwing errors
+    """Raise KeyboardInterrupt so main flow can exit cleanly.
 
     Source: https://www.devdungeon.com/content/python-catch-sigint-ctrl-c
     """
-    sys.exit(0)
+    raise KeyboardInterrupt
 
 
 def main():
@@ -806,64 +831,96 @@ def main():
     )
 
     # Run report on all specified users.
-    all_usernames = []
-    for username in args.username:
-        if check_for_parameter(username):
-            for name in multiple_usernames(username):
-                all_usernames.append(name)
-        else:
-            all_usernames.append(username)
-    for username in all_usernames:
-        results = sherlock(
-            username,
-            site_data,
-            query_notify,
-            dump_response=args.dump_response,
-            proxy=args.proxy,
-            timeout=args.timeout,
-        )
+    try:
+        all_usernames = []
+        for username in args.username:
+            if check_for_parameter(username):
+                for name in multiple_usernames(username):
+                    all_usernames.append(name)
+            else:
+                all_usernames.append(username)
+        for username in all_usernames:
+            results = sherlock(
+                username,
+                site_data,
+                query_notify,
+                dump_response=args.dump_response,
+                proxy=args.proxy,
+                timeout=args.timeout,
+            )
 
-        if args.output:
-            result_file = args.output
-        elif args.folderoutput:
-            # The usernames results should be stored in a targeted folder.
-            # If the folder doesn't exist, create it first
-            os.makedirs(args.folderoutput, exist_ok=True)
-            result_file = os.path.join(args.folderoutput, f"{username}.txt")
-        else:
-            result_file = f"{username}.txt"
-
-        if args.output_txt:
-            with open(result_file, "w", encoding="utf-8") as file:
-                exists_counter = 0
-                for website_name in results:
-                    dictionary = results[website_name]
-                    if dictionary.get("status").status == QueryStatus.CLAIMED:
-                        exists_counter += 1
-                        file.write(dictionary["url_user"] + "\n")
-                file.write(f"Total Websites Username Detected On : {exists_counter}\n")
-
-        if args.csv:
-            result_file = f"{username}.csv"
-            if args.folderoutput:
+            if args.output:
+                result_file = args.output
+            elif args.folderoutput:
                 # The usernames results should be stored in a targeted folder.
                 # If the folder doesn't exist, create it first
                 os.makedirs(args.folderoutput, exist_ok=True)
-                result_file = os.path.join(args.folderoutput, result_file)
+                result_file = os.path.join(args.folderoutput, f"{username}.txt")
+            else:
+                result_file = f"{username}.txt"
 
-            with open(result_file, "w", newline="", encoding="utf-8") as csv_report:
-                writer = csv.writer(csv_report)
-                writer.writerow(
-                    [
-                        "username",
-                        "name",
-                        "url_main",
-                        "url_user",
-                        "exists",
-                        "http_status",
-                        "response_time_s",
-                    ]
-                )
+            if args.output_txt:
+                with open(result_file, "w", encoding="utf-8") as file:
+                    exists_counter = 0
+                    for website_name in results:
+                        dictionary = results[website_name]
+                        if dictionary.get("status").status == QueryStatus.CLAIMED:
+                            exists_counter += 1
+                            file.write(dictionary["url_user"] + "\n")
+                    file.write(f"Total Websites Username Detected On : {exists_counter}\n")
+
+            if args.csv:
+                result_file = f"{username}.csv"
+                if args.folderoutput:
+                    # The usernames results should be stored in a targeted folder.
+                    # If the folder doesn't exist, create it first
+                    os.makedirs(args.folderoutput, exist_ok=True)
+                    result_file = os.path.join(args.folderoutput, result_file)
+
+                with open(result_file, "w", newline="", encoding="utf-8") as csv_report:
+                    writer = csv.writer(csv_report)
+                    writer.writerow(
+                        [
+                            "username",
+                            "name",
+                            "url_main",
+                            "url_user",
+                            "exists",
+                            "http_status",
+                            "response_time_s",
+                        ]
+                    )
+                    for site in results:
+                        if (
+                            args.print_found
+                            and not args.print_all
+                            and results[site]["status"].status != QueryStatus.CLAIMED
+                        ):
+                            continue
+
+                        response_time_s = results[site]["status"].query_time
+                        if response_time_s is None:
+                            response_time_s = ""
+                        writer.writerow(
+                            [
+                                username,
+                                site,
+                                results[site]["url_main"],
+                                results[site]["url_user"],
+                                str(results[site]["status"].status),
+                                results[site]["http_status"],
+                                response_time_s,
+                            ]
+                        )
+            if args.xlsx:
+                usernames = []
+                names = []
+                url_main = []
+                url_user = []
+                exists = []
+                http_status = []
+                response_time_s = []
+
                 for site in results:
                     if (
                         args.print_found
@@ -872,63 +929,36 @@ def main():
                     ):
                         continue
 
-                    response_time_s = results[site]["status"].query_time
                     if response_time_s is None:
-                        response_time_s = ""
-                    writer.writerow(
-                        [
-                            username,
-                            site,
-                            results[site]["url_main"],
-                            results[site]["url_user"],
-                            str(results[site]["status"].status),
-                            results[site]["http_status"],
-                            response_time_s,
-                        ]
-                    )
-        if args.xlsx:
-            usernames = []
-            names = []
-            url_main = []
-            url_user = []
-            exists = []
-            http_status = []
-            response_time_s = []
+                        response_time_s.append("")
+                    else:
+                        response_time_s.append(results[site]["status"].query_time)
+                    usernames.append(username)
+                    names.append(site)
+                    url_main.append(results[site]["url_main"])
+                    url_user.append(results[site]["url_user"])
+                    exists.append(str(results[site]["status"].status))
+                    http_status.append(results[site]["http_status"])
 
-            for site in results:
-                if (
-                    args.print_found
-                    and not args.print_all
-                    and results[site]["status"].status != QueryStatus.CLAIMED
-                ):
-                    continue
+                DataFrame = pd.DataFrame(
+                    {
+                        "username": usernames,
+                        "name": names,
+                        "url_main": [f'=HYPERLINK(\"{u}\")' for u in url_main],
+                        "url_user": [f'=HYPERLINK(\"{u}\")' for u in url_user],
+                        "exists": exists,
+                        "http_status": http_status,
+                        "response_time_s": response_time_s,
+                    }
+                )
+                DataFrame.to_excel(f"{username}.xlsx", sheet_name="sheet1", index=False)
 
-                if response_time_s is None:
-                    response_time_s.append("")
-                else:
-                    response_time_s.append(results[site]["status"].query_time)
-                usernames.append(username)
-                names.append(site)
-                url_main.append(results[site]["url_main"])
-                url_user.append(results[site]["url_user"])
-                exists.append(str(results[site]["status"].status))
-                http_status.append(results[site]["http_status"])
-
-            DataFrame = pd.DataFrame(
-                {
-                    "username": usernames,
-                    "name": names,
-                    "url_main": [f'=HYPERLINK(\"{u}\")' for u in url_main],
-                    "url_user": [f'=HYPERLINK(\"{u}\")' for u in url_user],
-                    "exists": exists,
-                    "http_status": http_status,
-                    "response_time_s": response_time_s,
-                }
-            )
-            DataFrame.to_excel(f"{username}.xlsx", sheet_name="sheet1", index=False)
-
-        print()
-    query_notify.finish()
+            print()
+    except KeyboardInterrupt:
+        print("\nSearch interrupted by user.")
+        sys.exit(130)
+    else:
+        query_notify.finish()
 
 
 if __name__ == "__main__":

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,7 +1,11 @@
 """Tests for handling usernames with special/unicode characters."""
 
 from concurrent.futures import Future
+import time
 
+import pytest
+
+from sherlock_project import sherlock
 from sherlock_project.sherlock import get_response
 
 
@@ -45,3 +49,72 @@ def test_get_response_handles_unicode_encode_error():
     assert response is None
     assert error_context == "Encoding Error"
     assert "ascii" in exception_text
+
+
+class SlowFuture:
+    def __init__(self):
+        self.calls = 0
+
+    def result(self, timeout=None):
+        self.calls += 1
+        raise sherlock.FutureTimeoutError()
+
+
+
+def test_get_response_propagates_keyboard_interrupt_from_polling(monkeypatch):
+    future = SlowFuture()
+    original_handler = sherlock.handler
+
+    def fake_handler(signal_received, frame):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(sherlock, "handler", fake_handler)
+
+    def interrupting_result(timeout=None):
+        future.calls += 1
+        if future.calls >= 2:
+            raise KeyboardInterrupt
+        raise sherlock.FutureTimeoutError()
+
+    future.result = interrupting_result
+
+    with pytest.raises(KeyboardInterrupt):
+        get_response(
+            request_future=future,
+            error_type=["status_code"],
+            social_network="TestSite",
+        )
+
+
+
+def test_shutdown_request_session_cancels_futures_and_closes_sessions():
+    cancelled = []
+    shutdown_calls = []
+    closed = []
+
+    class FakeFuture:
+        def cancel(self):
+            cancelled.append(True)
+
+    class FakeExecutor:
+        def shutdown(self, wait=True, cancel_futures=False):
+            shutdown_calls.append((wait, cancel_futures))
+
+    class FakeSession:
+        executor = FakeExecutor()
+
+    class FakeUnderlyingSession:
+        def close(self):
+            closed.append(True)
+
+    site_data = {
+        "SiteA": {"request_future": FakeFuture()},
+        "SiteB": {"request_future": FakeFuture()},
+        "SiteC": {},
+    }
+
+    sherlock.shutdown_request_session(FakeSession(), FakeUnderlyingSession(), site_data)
+
+    assert len(cancelled) == 2
+    assert shutdown_calls == [(False, True)]
+    assert closed == [True]

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from sherlock_project import sherlock
 from sherlock_interactives import Interactives
@@ -41,3 +43,80 @@ def test_wildcard_username_expansion():
 def test_no_usernames_provided(cliargs):
     with pytest.raises(InteractivesSubprocessError, match=r"error: the following arguments are required: USERNAMES"):
         Interactives.run_cli(cliargs)
+
+
+
+def test_handler_raises_keyboard_interrupt():
+    with pytest.raises(KeyboardInterrupt):
+        sherlock.handler(None, None)
+
+
+
+def test_main_exits_cleanly_on_keyboard_interrupt(monkeypatch, capsys):
+    args = SimpleNamespace(
+        proxy=None,
+        no_color=True,
+        output=None,
+        folderoutput=None,
+        username=["jackson"],
+        local=True,
+        json_file=None,
+        ignore_exclusions=False,
+        site_list=[],
+        nsfw=True,
+        verbose=False,
+        print_all=False,
+        print_found=True,
+        browse=False,
+        dump_response=False,
+        timeout=1,
+        output_txt=False,
+        csv=False,
+        xlsx=False,
+    )
+
+    monkeypatch.setattr(sherlock.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.setattr(sherlock.signal, "signal", lambda *args, **kwargs: None)
+    monkeypatch.setattr(sherlock, "init", lambda *args, **kwargs: None)
+
+    class FakeReleaseResponse:
+        text = '{"tag_name": "v' + sherlock.__version__ + '", "html_url": "https://example.com"}'
+
+    monkeypatch.setattr(sherlock.requests, "get", lambda *args, **kwargs: FakeReleaseResponse())
+
+    class FakeSitesInformation:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def remove_nsfw_sites(self, do_not_remove=None):
+            return None
+
+        def __iter__(self):
+            return iter([])
+
+    monkeypatch.setattr(sherlock, "SitesInformation", FakeSitesInformation)
+
+    finish_called = []
+
+    class FakeQueryNotifyPrint:
+        def __init__(self, result=None, verbose=False, print_all=False, browse=False):
+            self.result = result
+
+        def start(self, message=None):
+            return None
+
+        def update(self, result):
+            return None
+
+        def finish(self, message="The processing has been finished."):
+            finish_called.append(message)
+
+    monkeypatch.setattr(sherlock, "QueryNotifyPrint", FakeQueryNotifyPrint)
+    monkeypatch.setattr(sherlock, "sherlock", lambda *args, **kwargs: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+    with pytest.raises(SystemExit) as exit_info:
+        sherlock.main()
+
+    assert exit_info.value.code == 130
+    assert finish_called == []
+    assert "Search interrupted by user." in capsys.readouterr().out


### PR DESCRIPTION
### Summary
This PR improves how Sherlock responds to Ctrl+C during active username checks.

Previously, Sherlock could remain blocked while waiting for a single future to finish, which made interruption feel delayed during long-running searches. This change makes future polling more interruptible and adds cleanup for pending work when a keyboard interrupt occurs.

### What changed
- Changed future result handling in **[get_response()](vscode-webview://1ti846r0c0ujc5vcd751u45ikd20gi83nek1f7789u81tph2gfu6/sherlock_project/sherlock.py:114)** to use short-interval polling via **[request_future.result(timeout=0.1)](vscode-webview://1ti846r0c0ujc5vcd751u45ikd20gi83nek1f7789u81tph2gfu6/sherlock_project/sherlock.py:123)** instead of waiting indefinitely for a single future.

- Preserved **[KeyboardInterrupt](vscode-webview://1ti846r0c0ujc5vcd751u45ikd20gi83nek1f7789u81tph2gfu6/sherlock_project/sherlock.py:131)** so user interruption is propagated instead of being absorbed into ordinary request error handling.
- Added **[shutdown_request_session()](vscode-webview://1ti846r0c0ujc5vcd751u45ikd20gi83nek1f7789u81tph2gfu6/sherlock_project/sherlock.py:156)** to:
cancel not-yet-started futures when possible,
shut down the executor,
close the underlying requests session.
- Updated the query flow in **[sherlock()](vscode-webview://1ti846r0c0ujc5vcd751u45ikd20gi83nek1f7789u81tph2gfu6/sherlock_project/sherlock.py:193)** so interruptions trigger cleanup before bubbling back to the main CLI flow.
Kept the main interrupt path centered around **[handler()](vscode-webview://1ti846r0c0ujc5vcd751u45ikd20gi83nek1f7789u81tph2gfu6/sherlock_project/sherlock.py:558)** and the CLI flow in **[main()](vscode-webview://1ti846r0c0ujc5vcd751u45ikd20gi83nek1f7789u81tph2gfu6/sherlock_project/sherlock.py:566)**, so users still receive a clear interruption message and exit path.
### Why this matters
It improves interactive behavior during concurrent site checks by reducing the amount of time Sherlock can remain stuck waiting on a single future before reacting to Ctrl+C.

It does not forcibly terminate already-running worker threads, but it does:

reduce time spent blocking on one future,
make interruption more responsive,
and clean up pending work more reliably.
### Testing
Added/used targeted tests covering:

[KeyboardInterrupt](vscode-webview://1ti846r0c0ujc5vcd751u45ikd20gi83nek1f7789u81tph2gfu6/sherlock_project/sherlock.py:131) propagation during future polling,
cancellation/cleanup logic in [shutdown_request_session()](vscode-webview://1ti846r0c0ujc5vcd751u45ikd20gi83nek1f7789u81tph2gfu6/sherlock_project/sherlock.py:156),
main CLI interruption behavior through the updated Ctrl+C path.
Targeted test result:

6 passed, 7 deselected