### PR TITLE
fix(minds): tighten detection to avoid false positives on 5xx (#2950)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -3082,7 +3082,10 @@
   },
   "minds": {
     "errorMsg": "\"valid\":true",
-    "errorType": "message",
+    "errorType": [
+      "message",
+      "status_code"
+    ],
     "url": "https://www.minds.com/{}/",
     "urlMain": "https://www.minds.com",
     "urlProbe": "https://www.minds.com/api/v3/register/validate?username={}",


### PR DESCRIPTION
## Pull Request Type

- [ ] This pull request adds or modifies **code**
- [x] This pull request adds or modifies the **manifest** (`data.json`)
- [ ] This pull request adds or modifies **documentation**

## Description

Closes #2950.

The `minds` entry probes:

```
GET https://www.minds.com/api/v3/register/validate?username={}
```

and uses `errorType: "message"` with `errorMsg: "\"valid\":true"` to mean "user not found". When the upstream API intermittently returns a 5xx, the configured `errorMsg` is absent from the body, the message-match branch falls through to `CLAIMED`, and Sherlock prints `[+] minds: https://www.minds.com/<username>/` for accounts that do not exist.

### Fix

Switch `errorType` from the bare string `"message"` to the list `["message", "status_code"]`. The detection loop in `sherlock_project/sherlock.py` (L432-L443) already supports this shape:

```python
if "status_code" in error_type and query_status is not QueryStatus.AVAILABLE:
    error_codes = net_info.get("errorCode")
    query_status = QueryStatus.CLAIMED
    if isinstance(error_codes, int):
        error_codes = [error_codes]
    if error_codes is not None and r.status_code in error_codes:
        query_status = QueryStatus.AVAILABLE
    elif r.status_code >= 300 or r.status_code < 200:
        query_status = QueryStatus.AVAILABLE
```

When the message-match arm sets `CLAIMED`, the `status_code` arm runs next and downgrades any non-2xx response to `AVAILABLE`. When the message-match arm sets `AVAILABLE`, the `status_code` arm is skipped (it only runs while `query_status is not AVAILABLE`), so the 200 success paths are unchanged.

### Behavior matrix

Verified against the manifest's detection logic:

| status | body                              | before                  | after          |
|--------|-----------------------------------|-------------------------|----------------|
| 200    | `{"status":"success","valid":false}` | CLAIMED (correct)       | CLAIMED        |
| 200    | `{"status":"success","valid":true}`  | AVAILABLE (correct)     | AVAILABLE      |
| 502    | `Bad Gateway`                     | **CLAIMED (false pos.)** | AVAILABLE      |
| 502    | `<html>nginx error</html>`        | **CLAIMED (false pos.)** | AVAILABLE      |
| 500    | `{"error":"internal"}`            | **CLAIMED (false pos.)** | AVAILABLE      |

### Verification

- `tests/test_manifest.py` passes (schema validation covers both bare-string and array `errorType` per `data.schema.json`).
- Live API check, current behavior preserved:
  - `python -m sherlock_project nonsense_uname_xyzzy_9988 --site minds` → `Not Found`
  - `python -m sherlock_project john --site minds` → `https://www.minds.com/john/`

### Scope

Per-site only. The broader class issue (any `errorType: "message"` site can false-positive on 5xx) noted in #2950 would need an engine change; this PR keeps the change minimal and focused on `minds`.

## Pull Request Checklist

- [x] I've checked for similar pull requests
- [x] I've verified my changes locally
- [x] I've signed off my commits (DCO)