### PR TITLE
fix: check query_time instead of response_time_s list in xlsx output

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -903,7 +903,7 @@ def main():
                 ):
                     continue
 
-                if response_time_s is None:
+                if results[site]["status"].query_time is None:
                     response_time_s.append("")
                 else:
                     response_time_s.append(results[site]["status"].query_time)


### PR DESCRIPTION
## Summary

Fixes #2891

The condition on line 906 checks `if response_time_s is None`, but `response_time_s` is initialised as an empty list (`[]`) on line 896 of the same block — so this check is **always `False`** and the empty-string fallback is never reached.

As a result, when a site's `query_time` is `None` (timeout or error), the raw `None` gets appended to the list. Pandas then writes `None` into the Excel cell instead of a blank string, which breaks downstream xlsx processing.

## Root cause

```python
# Before (line 906) — condition always False, None leaks into the list
if response_time_s is None:
    response_time_s.append("")
else:
    response_time_s.append(results[site]["status"].query_time)  # appends None
```

## Fix

```python
# After — checks the actual value, mirrors the CSV path (lines 875-877)
if results[site]["status"].query_time is None:
    response_time_s.append("")
else:
    response_time_s.append(results[site]["status"].query_time)
```

This mirrors the pattern already used correctly in the CSV output block (lines ~875–877).

## Test plan

- [ ] Run `sherlock --xlsx <username>` — sites that time out now produce blank cells instead of `None`
- [ ] Existing tests pass