### PR TITLE
fix: wrap float() in timeout_check with try/except for clean argparse error

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -520,7 +520,12 @@ def timeout_check(value):
     NOTE:  Will raise an exception if the timeout in invalid.
     """
 
-    float_value = float(value)
+    try:
+        float_value = float(value)
+    except ValueError:
+        raise ArgumentTypeError(
+            f"Invalid timeout value: {value}. Timeout must be a positive number."
+        )
 
     if float_value <= 0:
         raise ArgumentTypeError(

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -41,3 +41,17 @@ def test_wildcard_username_expansion():
 def test_no_usernames_provided(cliargs):
     with pytest.raises(InteractivesSubprocessError, match=r"error: the following arguments are required: USERNAMES"):
         Interactives.run_cli(cliargs)
+
+
+@pytest.mark.parametrize('timeout_val', ['abc', 'xyz', '1.2.3', '', 'None'])
+def test_invalid_timeout_raises_argparse_error(timeout_val):
+    """Non-numeric --timeout values should raise a clean argparse error, not a raw ValueError."""
+    with pytest.raises(InteractivesSubprocessError, match=r"error: argument --timeout: invalid"):
+        Interactives.run_cli(f'--timeout {timeout_val} someuser')
+
+
+@pytest.mark.parametrize('timeout_val', ['-1', '0', '-0.5'])
+def test_non_positive_timeout_raises_argparse_error(timeout_val):
+    """Zero or negative --timeout values should raise a clean argparse error."""
+    with pytest.raises(InteractivesSubprocessError, match=r"error: argument --timeout: invalid"):
+        Interactives.run_cli(f'--timeout {timeout_val} someuser')


### PR DESCRIPTION
## Summary

Fixes #2866

Passing a non-numeric value to `--timeout` (e.g. `sherlock --timeout abc user`) currently raises a raw `ValueError` from `float(value)` before argparse can intercept it, producing an ugly unformatted traceback.

## Root cause

```python
# Before — raw ValueError escapes argparse
def timeout_check(value):
    float_value = float(value)   # raises ValueError for non-numeric input
    if float_value <= 0:
        raise ArgumentTypeError(...)
    return float_value
```

## Fix

```python
# After — non-numeric input caught and re-raised as ArgumentTypeError
def timeout_check(value):
    try:
        float_value = float(value)
    except ValueError:
        raise ArgumentTypeError(
            f"Invalid timeout value: {value}. Timeout must be a positive number."
        )
    if float_value <= 0:
        raise ArgumentTypeError(
            f"Invalid timeout value: {value}. Timeout must be a positive number."
        )
    return float_value
```

Argparse then formats this consistently as:
```
error: argument --timeout: invalid timeout_check value: 'abc'
```

## Tests added

Two parametrized regression tests in `test_ux.py`:
- `test_invalid_timeout_raises_argparse_error` — covers non-numeric strings (`abc`, `xyz`, `1.2.3`, `None`)
- `test_non_positive_timeout_raises_argparse_error` — covers zero and negative values (pre-existing bug, now also tested)

## Test plan
- [ ] `sherlock --timeout abc user` → clean argparse error message
- [ ] `sherlock --timeout -1 user` → clean argparse error message  
- [ ] `sherlock --timeout 5 user` → works normally
- [ ] New tests pass