### PR TITLE
fix: detect TikTok SlardarWAF to prevent false positives

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -389,7 +389,8 @@ def sherlock(
             r'.loading-spinner{visibility:hidden}body.no-js .challenge-running{display:none}body.dark{background-color:#222;color:#d9d9d9}body.dark a{color:#fff}body.dark a:hover{color:#ee730a;text-decoration:underline}body.dark .lds-ring div{border-color:#999 transparent transparent}body.dark .font-red{color:#b20f03}body.dark', # 2024-05-13 Cloudflare
             r'<span id="challenge-error-text">', # 2024-11-11 Cloudflare error page
             r'AwsWafIntegration.forceRefreshToken', # 2024-11-11 Cloudfront (AWS)
-            r'{return l.onPageView}}),Object.defineProperty(r,"perimeterxIdentifiers",{enumerable:' # 2024-04-09 PerimeterX / Human Security
+            r'{return l.onPageView}}),Object.defineProperty(r,"perimeterxIdentifiers",{enumerable:', # 2024-04-09 PerimeterX / Human Security
+            r'SlardarWAF', # 2025-05-17 TikTok SlardarWAF (ByteDance)
         ]
 
         if error_text is not None:


### PR DESCRIPTION
## Summary

- TikTok now responds to Python `requests` (HTTP/1.1) with a **SlardarWAF** bot-challenge page for all profile requests, regardless of whether the account actually exists
- The challenge page returns HTTP 200 with ~1428 bytes but contains no `statusCode:10221`, so Sherlock incorrectly marks every TikTok query as **CLAIMED** (false positive)
- Adding `SlardarWAF` to `WAFHitMsgs` correctly classifies these responses as `QueryStatus.WAF` instead

## Root cause

TikTok performs TLS/HTTP fingerprinting and serves a ByteDance SlardarWAF challenge to non-browser clients. `curl` (HTTP/2) bypasses it and returns the correct `statusCode` in the JSON payload; Python `requests` (HTTP/1.1) does not.

Verified with:
```
# curl → statusCode:0 (exists) / statusCode:10221 (not found) ✓
# Python requests → SlardarWAF challenge page (HTTP 200, no statusCode) for both ✗
```

## Test plan

- [ ] Run `sherlock <nonexistent_tiktok_username> --site TikTok` → should show `WAF` (not `CLAIMED`)
- [ ] Run `sherlock <existing_tiktok_username> --site TikTok` → should show `WAF` (bot detection active for all requests)