### PR TITLE
fix: prevent crash on malformed FQDNs by handling LocationParseError (fixes #2970)

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -27,6 +27,7 @@ from time import monotonic
 from typing import Optional
 
 import requests
+import urllib3
 from requests_futures.sessions import FuturesSession
 
 from sherlock_project.__init__ import (
@@ -121,6 +122,12 @@ def get_response(request_future, error_type, social_network):
         if response.status_code:
             # Status code exists in response object
             error_context = None
+    except urllib3.exceptions.LocationParseError as errl:
+        error_context = "Illegal URL"
+        exception_text = str(errl)
+    except requests.exceptions.InvalidURL as erriu:
+        error_context = "Invalid URL"
+        exception_text = str(erriu)
     except requests.exceptions.HTTPError as errh:
         error_context = "HTTP Error"
         exception_text = str(errh)


### PR DESCRIPTION
### Description

This PR fixes the fatal crash reported in #2970 when searching for usernames ending in a period (e.g., `alice.`).

**The Root Cause:**
When a username ending in a period is interpolated into a subdomain-based target (like `https://{}.empretienda.com.ar`), it generates a malformed FQDN containing consecutive dots (`alice..empretienda.com.ar`). When `requests_futures` attempts to resolve this, the underlying `urllib3` library raises a `LocationParseError`. Because this specific exception does not inherit from `requests.exceptions.RequestException`, it bypassed the existing error handling in `get_response`, crashing the entire application.

**The Solution:**
Instead of playing whack-a-mole by adding regex filters to individual targets in `data.json` (which breaks CI target validation as seen in PR #2971 and doesn't scale for future target additions), this PR implements a robust architectural fix at the network layer.

By catching `urllib3.exceptions.LocationParseError` and `requests.exceptions.InvalidURL` directly in the asynchronous future resolution block (`sherlock_project/sherlock.py`), the application now gracefully handles any malformed URL generation, marks the specific target as failed ("Illegal URL"), and continues execution without crashing.

### Steps to Test

1. Run `python3 -m sherlock_project alice.`
2. Prior to this PR, the application would fatal crash immediately on `alice..empretienda.com.ar`.
3. With this PR, the error is caught, handled gracefully, and the scan finishes successfully.

### Checklist:

- [x] I have tested this code.
- [x] I have updated the documentation (if necessary).
- [x] This is not a target addition/modification (no `data.json` changes).