### PR TITLE
chore: improve sherlock maintenance path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def fetch_local_manifest(honor_exclusions: bool = True) -> dict[str, dict[str, s
     return sites_iterable
 
 @pytest.fixture()
-def sites_obj():
+def sites_obj() -> SitesInformation:
     sites_obj = SitesInformation(data_file_path=os.path.join(os.path.dirname(__file__), "../sherlock_project/resources/data.json"))
     yield sites_obj
 

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -30,7 +30,10 @@ def test_wildcard_username_expansion():
     assert sherlock.check_for_parameter('testtest') is False
     assert sherlock.check_for_parameter('test{?test') is False
     assert sherlock.check_for_parameter('test?}test') is False
-    assert sherlock.multiple_usernames('test{?}test') == ["test_test" , "test-test" , "test.test"]
+    assert sherlock.check_for_parameter('') is False
+    assert sherlock.multiple_usernames('test{?}test') == ["test_test", "test-test", "test.test"]
+    assert sherlock.multiple_usernames('testtest') == ["testtest", "testtest", "testtest"]
+    assert sherlock.multiple_usernames('{?}a{?}') == ["_a_", "-a-", ".a."]
 
 
 @pytest.mark.parametrize('cliargs', [


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/test_ux.py, tests/conftest.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.