### PR TITLE
Add Frontend Mentor

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -929,8 +929,7 @@
     "errorType": "status_code",
     "url": "https://www.frontendmentor.io/profile/{}",
     "urlMain": "https://www.frontendmentor.io/",
-    "username_claimed": "artimys",
-    "username_unclaimed": "noonewouldeverusethis123456789"
+    "username_claimed": "artimys"
   },
   "Freesound": {
     "errorType": "status_code",

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -925,6 +925,13 @@
     "urlProbe": "https://www.freelancer.com/api/users/0.1/users?usernames%5B%5D={}&compact=true",
     "username_claimed": "red0xff"
   },
+  "Frontend Mentor": {
+    "errorType": "status_code",
+    "url": "https://www.frontendmentor.io/profile/{}",
+    "urlMain": "https://www.frontendmentor.io/",
+    "username_claimed": "artimys",
+    "username_unclaimed": "noonewouldeverusethis123456789"
+  },
   "Freesound": {
     "errorType": "status_code",
     "url": "https://freesound.org/people/{}/",


### PR DESCRIPTION
Added Frontend Mentor support.

Detection method: status_code

Claimed username:
artimys

Claimed profile:
https://www.frontendmentor.io/profile/artimys

Unclaimed username:
noonewouldeverusethis123456789

Verification:
- Claimed profile returns HTTP 200
- Unclaimed profile returns HTTP 404