### PR TITLE
Add FACEIT

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -3304,5 +3304,13 @@
     "errorType": "status_code",
     "errorCode": 404,
     "username_claimed": "blue"
+  },
+    "FACEIT": {
+    "errorType": "message",
+    "errorMsg": "user not found",
+    "url": "https://www.faceit.com/en/players/{}",
+    "urlMain": "https://www.faceit.com/",
+    "urlProbe": "https://www.faceit.com/api/users/v1/nicknames/{}",
+    "username_claimed": "s1mple-"
   }
 }


### PR DESCRIPTION
## Purpose

This PR adds support for FACEIT, a leading competitive gaming platform used by Counter-Strike players and esports teams.

The initial implementation relied on profile page detection using `response_url`, but GitHub Actions runners consistently encountered FACEIT's anti-bot protection, causing validation to return `WAF` instead of deterministic account status.

To address this, the implementation now uses FACEIT's public nickname API endpoint as a probe URL.

## Implementation

The FACEIT entry uses:

* `url`: Public player profile URL
* `urlProbe`: Public nickname lookup API
* `errorType`: `message`
* `errorMsg`: `user not found`

The API endpoint returns structured JSON and does not require authentication:

### Existing user

Returns:

```json
{
  "result": "OK",
  "payload": {
    ...
  }
}
```

### Non-existing user

Returns:

```json
{
  "errors": [
    {
      "code": "err_nf0",
      "message": "user not found"
    }
  ]
}
```

This provides deterministic account detection without relying on profile page scraping or redirects.

## Testing

Validated against:

* Existing user: `s1mple-`
* Random non-existent username

Confirmed that the API returns distinct responses for claimed and unclaimed usernames and avoids the WAF issues encountered when probing profile pages directly.
