### PR TITLE
fix: move result counter from module global to instance variable

### DIFF
--- a/sherlock_project/notify.py
+++ b/sherlock_project/notify.py
@@ -7,9 +7,6 @@ from sherlock_project.result import QueryStatus
 from colorama import Fore, Style
 import webbrowser
 
-# Global variable to count the number of results.
-globvar = 0
-
 
 class QueryNotify:
     """Query Notify Object.
@@ -132,6 +129,7 @@ class QueryNotifyPrint(QueryNotify):
         self.verbose = verbose
         self.print_all = print_all
         self.browse = browse
+        self._result_count = 0
 
 
     def start(self, message):
@@ -169,9 +167,8 @@ class QueryNotifyPrint(QueryNotify):
         Return Value:
         The number of results by the time we call the function.
         """
-        global globvar
-        globvar += 1
-        return globvar
+        self._result_count += 1
+        return self._result_count
 
     def update(self, result):
         """Notify Update.
@@ -258,7 +255,7 @@ class QueryNotifyPrint(QueryNotify):
         Return Value:
         Nothing.
         """
-        NumberOfResults = self.countResults() - 1
+        NumberOfResults = self._result_count
 
         print(Style.BRIGHT + Fore.GREEN + "[" +
               Fore.YELLOW + "*" +

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,53 @@
+"""Tests for QueryNotifyPrint result counter behaviour."""
+import pytest
+from sherlock_project.notify import QueryNotifyPrint
+from sherlock_project.result import QueryResult, QueryStatus
+
+
+def _make_result(status):
+    return QueryResult(
+        username="testuser",
+        site_name="TestSite",
+        site_url_user="https://testsite.com/testuser",
+        status=status,
+    )
+
+
+class TestResultCounter:
+    def test_count_starts_at_zero(self):
+        notify = QueryNotifyPrint()
+        assert notify._result_count == 0
+
+    def test_count_increments_on_claimed(self):
+        notify = QueryNotifyPrint()
+        notify.update(_make_result(QueryStatus.CLAIMED))
+        notify.update(_make_result(QueryStatus.CLAIMED))
+        assert notify._result_count == 2
+
+    def test_count_does_not_increment_on_available(self):
+        notify = QueryNotifyPrint()
+        notify.update(_make_result(QueryStatus.AVAILABLE))
+        assert notify._result_count == 0
+
+    def test_independent_instances_do_not_share_count(self):
+        """Two QueryNotifyPrint objects must not share a global counter."""
+        n1 = QueryNotifyPrint()
+        n2 = QueryNotifyPrint()
+        n1.update(_make_result(QueryStatus.CLAIMED))
+        n1.update(_make_result(QueryStatus.CLAIMED))
+        n1.update(_make_result(QueryStatus.CLAIMED))
+        # n2 was never updated — its count must still be 0
+        assert n2._result_count == 0
+
+    def test_second_username_count_is_not_cumulative(self):
+        """Simulates two separate username scans using separate notify objects."""
+        notify1 = QueryNotifyPrint()
+        notify1.update(_make_result(QueryStatus.CLAIMED))
+        notify1.update(_make_result(QueryStatus.CLAIMED))
+
+        notify2 = QueryNotifyPrint()
+        notify2.update(_make_result(QueryStatus.CLAIMED))
+
+        # Each object tracks its own scan independently
+        assert notify1._result_count == 2
+        assert notify2._result_count == 1


### PR DESCRIPTION
## Summary

Fixes #2990

`QueryNotifyPrint` used a module-level `globvar = 0` as its result counter. Because the global was never reset, scanning multiple usernames in one invocation (`sherlock user1 user2`) caused `finish()` to print a cumulative total across all usernames rather than a per-username count.

`finish()` also called `self.countResults() - 1` — which incremented the counter one extra time before subtracting 1 — a fragile off-by-one workaround that breaks completely across multiple scans.

## Changes

- `sherlock_project/notify.py`: remove module-level `globvar`; add `self._result_count = 0` in `QueryNotifyPrint.__init__`; `countResults()` now increments the instance variable; `finish()` reads `self._result_count` directly (no spurious extra increment)
- `tests/test_notify.py`: new test file verifying counter starts at zero, increments only on `CLAIMED`, and that two independent instances never share state

## Test plan

- [ ] `pytest tests/test_notify.py` — all new tests pass
- [ ] `pytest` — full suite green
- [ ] `sherlock user1 user2` — each username shows its own independent count