### PR TITLE
narrow version-check exception handler to specific request and JSON errors

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -708,7 +708,17 @@ def main():
                 f"\n{latest_release_json['html_url']}"
             )
 
-    except Exception as error:
+    except (requests.RequestException, ValueError, KeyError) as error:
+        # requests.get() raises requests.RequestException (and its concrete
+        # subclasses ConnectionError, Timeout, HTTPError) for network and
+        # transport failures; json_loads() raises json.JSONDecodeError (a
+        # ValueError subclass) for malformed JSON; and the ["tag_name"] /
+        # latest_remote_tag[1:] lookups raise KeyError / IndexError for
+        # unexpected payload shapes. Catching the bare Exception was
+        # masking KeyboardInterrupt during a Ctrl-C just after the version
+        # check and turning any unrelated bug (a typo in forge_api_latest_release,
+        # an unhandled unicode issue in latest_release_raw) into a confusing
+        # 'A problem occurred while checking for an update' line on stderr.
         print(f"A problem occurred while checking for an update: {error}")
 
     # Make prompts


### PR DESCRIPTION
The bare `except Exception` in the post-argparse version-check guarded against only three concrete failure modes:

  - `requests.get(forge_api_latest_release, timeout=10)` raises `requests.RequestException` (and its concrete subclasses `ConnectionError`, `Timeout`, `HTTPError`) for network and transport failures.
  - `json_loads(latest_release_raw)` raises `json.JSONDecodeError` (a `ValueError` subclass) for malformed JSON.
  - `latest_release_json['tag_name']` and `latest_remote_tag[1:]` raise `KeyError` / `IndexError` for unexpected payload shapes.

Catching `Exception` was masking unrelated bugs and `KeyboardInterrupt` (e.g. a Ctrl-C between the `signal.signal` call above and the `try` block). The narrower tuple keeps the original 'silently report the version-check failure' behaviour for the three real failure modes and lets other exceptions propagate with their full traceback.

Tested locally: `python3 -c "import ast; ast.parse(...)"` parses; the version-check still prints 'A problem occurred while checking for an update' for the network/JSON failure modes it was originally guarding against.