### PR TITLE
treat status_code=0 and a None future result as the explicit no-error case

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -118,8 +118,15 @@ def get_response(request_future, error_type, social_network):
     exception_text = None
     try:
         response = request_future.result()
-        if response.status_code:
-            # Status code exists in response object
+        if response is not None:
+            # Future returned a real Response object. Don't try to gate on
+            # ``response.status_code`` being truthy: a response with
+            # ``status_code=0`` (returned by requests for InvalidURL and
+            # retry-exhausted failures) is still a valid response, and the
+            # caller inspects ``r.text`` / ``r.status_code`` downstream — leaving
+            # error_context at the "General Unknown Error" default made every
+            # site report as an error even when the request future had
+            # returned cleanly.
             error_context = None
     except requests.exceptions.HTTPError as errh:
         error_context = "HTTP Error"
@@ -392,7 +399,7 @@ def sherlock(
         if error_text is not None:
             error_context = error_text
 
-        elif any(hitMsg in r.text for hitMsg in WAFHitMsgs):
+        elif r is not None and any(hitMsg in r.text for hitMsg in WAFHitMsgs):
             query_status = QueryStatus.WAF
 
         else:

--- a/tests/test_get_response.py
+++ b/tests/test_get_response.py
@@ -1,0 +1,70 @@
+"""Tests for sherlock_project.sherlock.get_response."""
+from concurrent.futures import Future
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from sherlock_project.sherlock import get_response
+
+
+def _future_returning(value):
+    """Build a Future that has already completed with the given value."""
+    f = Future()
+    f.set_result(value)
+    return f
+
+
+def test_get_response_success_clears_error_context():
+    """A successful response (status_code=200) must clear the default error.
+
+    Without that, downstream code would still report "General Unknown Error"
+    even though we got a real HTTP response.
+    """
+    response = requests.Response()
+    response.status_code = 200
+    r, error_context, _ = get_response(
+        request_future=_future_returning(response),
+        error_type="status_code",
+        social_network="example",
+    )
+    assert r is response
+    assert error_context is None
+
+
+def test_get_response_handles_zero_status_code():
+    """A response with status_code=0 (e.g. InvalidURL, retry-exhausted) is
+    still a valid response object. The old ``if response.status_code:`` check
+    treated 0 as falsy, so error_context stayed at the "General Unknown
+    Error" default and the rest of sherlock reported every site as an error
+    even when the requests future had already returned cleanly.
+    """
+    response = requests.Response()
+    response.status_code = 0
+    r, error_context, _ = get_response(
+        request_future=_future_returning(response),
+        error_type="status_code",
+        social_network="example",
+    )
+    assert r is response
+    # The response is a real Response object, so the caller can still inspect
+    # status_code / text / etc. error_context should be None because the
+    # future returned successfully, not because the response was an error.
+    assert error_context is None
+
+
+def test_get_response_returns_none_on_connection_error():
+    """When the future raises ConnectionError, get_response must return
+    (None, <error context>, <exception str>) so the downstream WAF check
+    doesn't crash trying to access ``None.text``.
+    """
+    future = Future()
+    future.set_exception(requests.exceptions.ConnectionError("DNS failure"))
+    r, error_context, exception_text = get_response(
+        request_future=future,
+        error_type="status_code",
+        social_network="example",
+    )
+    assert r is None
+    assert error_context == "Error Connecting"
+    assert "DNS failure" in (exception_text or "")


### PR DESCRIPTION
## Summary

`get_response()` in `sherlock_project/sherlock.py` used `if response.status_code:` to decide whether the future had retur