### PR TITLE
percent-encode the username when building probe URLs

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -25,6 +25,7 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from json import loads as json_loads
 from time import monotonic
 from typing import Optional
+from urllib.parse import quote
 
 import requests
 from requests_futures.sessions import FuturesSession
@@ -167,6 +168,26 @@ def multiple_usernames(username):
     return allUsernames
 
 
+def encode_username_for_url(username):
+    """Percent-encode a username for safe inclusion in a URL path or query.
+
+    Replaces the previous ad-hoc ``username.replace(' ', '%20')`` which only
+    handled spaces and left characters like ``?``, ``#``, ``&``, ``+``,
+    ``/``, ``%`` and any non-ASCII bytes raw. A username containing one of
+    those characters would corrupt the resulting URL: ``#`` would be
+    interpreted as a fragment delimiter by the server, ``?`` as a query
+    string, ``+`` as a space by form-decoders, ``/`` as an extra path
+    segment, ``%`` as a start of a percent-escape, and a raw non-ASCII byte
+    (e.g. ``é``, emoji) would force the path to be re-encoded by the HTTP
+    library and could land at a different route than intended.
+
+    ``urllib.parse.quote`` with the default ``safe=''`` encodes every
+    character except the unreserved set (letters, digits, ``-._~``) and
+    matches the form the receiving site is expected to URL-decode.
+    """
+    return quote(username, safe="")
+
+
 def sherlock(
     username: str,
     site_data: dict[str, dict[str, str]],
@@ -243,7 +264,7 @@ def sherlock(
             headers.update(net_info["headers"])
 
         # URL of user on site (if it exists)
-        url = interpolate_string(net_info["url"], username.replace(' ', '%20'))
+        url = interpolate_string(net_info["url"], encode_username_for_url(username))
 
         # Don't make request if username is invalid for the site
         regex_check = net_info.get("regexCheck")
@@ -285,7 +306,7 @@ def sherlock(
             else:
                 # There is a special URL for probing existence separate
                 # from where the user profile normally can be found.
-                url_probe = interpolate_string(url_probe, username)
+                url_probe = interpolate_string(url_probe, encode_username_for_url(username))
 
             if request is None:
                 if net_info["errorType"] == "status_code":

--- a/tests/test_url_encode.py
+++ b/tests/test_url_encode.py
@@ -1,0 +1,76 @@
+"""Regression tests for URL-safe username encoding in sherlock.
+
+The per-site URL is built by interpolating the username into a format
+string (e.g. ``https://example.com/users/{}``). The previous code
+percent-encoded only spaces (``username.replace(' ', '%20')``) and let
+every other URL-special character through raw, which broke usernames
+containing ``?``, ``#``, ``&``, ``+``, ``/``, ``%``, or any non-ASCII
+byte. The fix routes the username through ``encode_username_for_url``,
+which uses ``urllib.parse.quote`` with ``safe=''`` and matches the form
+the receiving site is expected to URL-decode.
+"""
+
+import pytest
+
+from sherlock_project.sherlock import encode_username_for_url
+
+
+class TestEncodeUsernameForUrl:
+    """Pure-function coverage: no sherlock() call required."""
+
+    def test_plain_username_passes_through(self):
+        assert encode_username_for_url("alice") == "alice"
+
+    def test_underscore_dot_dash_tilde_are_unreserved(self):
+        assert encode_username_for_url("a.b_c-d~e") == "a.b_c-d~e"
+
+    def test_space_is_encoded_as_percent_20(self):
+        assert encode_username_for_url("alice bob") == "alice%20bob"
+
+    def test_question_mark_is_encoded(self):
+        # ?  would otherwise start a query string
+        assert encode_username_for_url("a?b") == "a%3Fb"
+
+    def test_hash_is_encoded(self):
+        # # would otherwise start a fragment
+        assert encode_username_for_url("a#b") == "a%23b"
+
+    def test_ampersand_is_encoded(self):
+        assert encode_username_for_url("a&b") == "a%26b"
+
+    def test_plus_is_encoded(self):
+        # + would otherwise decode to space in form-encoded bodies
+        assert encode_username_for_url("a+b") == "a%2Bb"
+
+    def test_percent_is_encoded(self):
+        # % must itself be escaped or the next two chars are read as a hex escape
+        assert encode_username_for_url("a%b") == "a%25b"
+
+    def test_slash_is_encoded(self):
+        # / would otherwise insert an extra path segment
+        assert encode_username_for_url("a/b") == "a%2Fb"
+
+    def test_non_ascii_latin_is_encoded(self):
+        assert encode_username_for_url("é") == "%C3%A9"
+
+    def test_emoji_is_encoded(self):
+        # astral codepoint: é would be broken if any other encoding were used
+        result = encode_username_for_url("🦊")
+        assert "%" in result
+        # the four-byte UTF-8 of the fox emoji
+        assert result == "%F0%9F%A6%8A"
+
+    def test_empty_username_encodes_to_empty(self):
+        assert encode_username_for_url("") == ""
+
+    def test_digits_only_unchanged(self):
+        assert encode_username_for_url("12345") == "12345"
+
+    def test_mixed_path_unsafe_characters(self):
+        # the kind of username that actually triggers the bug
+        # — combination of space, query, fragment, and percent
+        assert encode_username_for_url("a b?c#d%e") == "a%20b%3Fc%23d%25e"
+
+    def test_all_unreserved_passes_through_unchanged(self):
+        # RFC 3986 unreserved set: ALPHA / DIGIT / "-" / "." / "_" / "~"
+        assert encode_username_for_url("ABCabc0123-._~") == "ABCabc0123-._~"


### PR DESCRIPTION
The only call sites built the per-site URL with
`username.replace(' ', '%20')` and passed the result into
`interpolate_string`. That replaced spaces and nothing else: a username
containing `?`, `#`, `&`, `+`, `/`, `%`, or any non-ASCII byte (e.g.
`é`, emoji) was spliced into the URL raw, which corrupts the request —
`?` becomes a query-string delimiter, `#` a fragment, `+` a space
once form-decoded, `/` an extra path segment, and a raw non-ASCII byte
forces the HTTP library to re-encode the path and can land the request
on a different route than intended.

`urllib.parse.quote(username, safe='')` encodes everything outside the
unreserved set (letters, digits, `-._~`) and is what the receiving
site is expected to URL-dec
