### PR TITLE
fix: URL-encode username to prevent invalid URLs from trailing dots

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -246,7 +246,7 @@ def sherlock(
             headers.update(net_info["headers"])
 
         # URL of user on site (if it exists)
-        url = interpolate_string(net_info["url"], username.replace(' ', '%20'))
+        url = interpolate_string(net_info["url"], __import__('urllib.parse').parse.quote(username, safe=''))
 
         # Don't make request if username is invalid for the site
         regex_check = net_info.get("regexCheck")


### PR DESCRIPTION
Fixes #2970: usernames ending with a period created malformed URLs.
Now properly URL-encodes the username before substituting into URLs.