### PR TITLE
xlsx export: emit empty string instead of NaN for sites missing query_time

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -900,10 +900,11 @@ def main():
                 ):
                     continue
 
-                if response_time_s is None:
+                query_time = results[site]["status"].query_time
+                if query_time is None:
                     response_time_s.append("")
                 else:
-                    response_time_s.append(results[site]["status"].query_time)
+                    response_time_s.append(query_time)
                 usernames.append(username)
                 names.append(site)
                 url_main.append(results[site]["url_main"])


### PR DESCRIPTION
The xlsx branch of `main()` has a dead `if response_time_s is None` check. `response_time_s` is initialized as a list 4 lines earlier, so it is never `None` and the `else` branch always runs — appending `status.query_time` directly. When a site has `query_time = None` (the documented default for an unread result), the appended `None` is written into a pandas column that gets cast to a numeric type by `to_excel`, producing `NaN` in the cell instead of the empty string the CSV branch emits for the same case.

**Fix:** Read `status.query_time` into a local `query_time`, then check `if query_time is None` and append `""` in the None case, mirroring the existing CSV branch.

**Verified:** Simulated with a list of mixed `[0.123, None, 0.456, None]` query_times. Before: `[0.123, NaN, 0.456, NaN]`. After: `[0.123, '', 0.456, '']` — matching the CSV branch's output for the same input.