### PR TITLE
Fix #3011: Narrow overly broad except Exception blocks

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -370,11 +370,11 @@ def sherlock(
         # Attempt to get request information
         try:
             http_status = r.status_code
-        except Exception:
+        except AttributeError:
             http_status = "?"
         try:
             response_text = r.text.encode(r.encoding or "UTF-8")
-        except Exception:
+        except (AttributeError, TypeError, ValueError):
             response_text = ""
 
         query_status = QueryStatus.UNKNOWN
@@ -466,7 +466,7 @@ def sherlock(
             print("Results...")
             try:
                 print(f"RESPONSE CODE : {r.status_code}")
-            except Exception:
+            except AttributeError:
                 pass
             try:
                 print(f"ERROR TEXT    : {net_info['errorMsg']}")
@@ -475,7 +475,7 @@ def sherlock(
             print(">>>>> BEGIN RESPONSE TEXT")
             try:
                 print(r.text)
-            except Exception:
+            except AttributeError:
                 pass
             print("<<<<< END RESPONSE TEXT")
             print("VERDICT       : " + str(query_status))
@@ -711,7 +711,7 @@ def main():
                 f"\n{latest_release_json['html_url']}"
             )
 
-    except Exception as error:
+    except (requests.exceptions.RequestException, ValueError, KeyError, TypeError, TimeoutError) as error:
         print(f"A problem occurred while checking for an update: {error}")
 
     # Make prompts
@@ -765,7 +765,7 @@ def main():
                 honor_exclusions=not args.ignore_exclusions,
                 do_not_exclude=args.site_list,
             )
-    except Exception as error:
+    except (requests.exceptions.RequestException, ValueError, FileNotFoundError, KeyError, TypeError) as error:
         print(f"ERROR:  {error}")
         sys.exit(1)
 

--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -24,7 +24,7 @@ import re
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from json import loads as json_loads
 from time import monotonic
-from typing import Optional
+from typing import Optional, Union
 
 import requests
 from requests_futures.sessions import FuturesSession
@@ -177,7 +177,7 @@ def sherlock(
     dump_response: bool = False,
     proxy: Optional[str] = None,
     timeout: int = 60,
-) -> dict[str, dict[str, str | QueryResult]]:
+) -> dict[str, dict[str, Union[str, QueryResult]]]:
     """Run Sherlock Analysis.
 
     Checks for existence of username on various social media sites.

--- a/sherlock_project/sites.py
+++ b/sherlock_project/sites.py
@@ -125,7 +125,7 @@ class SitesInformation:
             # Reference is to a URL.
             try:
                 response = requests.get(url=data_file_path, timeout=30)
-            except Exception as error:
+            except requests.exceptions.RequestException as error:
                 raise FileNotFoundError(
                     f"Problem while attempting to access data file URL '{data_file_path}':  {error}"
                 )
@@ -136,7 +136,7 @@ class SitesInformation:
                                         )
             try:
                 site_data = response.json()
-            except Exception as error:
+            except ValueError as error:
                 raise ValueError(
                     f"Problem parsing json contents at '{data_file_path}':  {error}."
                 )
@@ -147,7 +147,7 @@ class SitesInformation:
                 with open(data_file_path, "r", encoding="utf-8") as file:
                     try:
                         site_data = json.load(file)
-                    except Exception as error:
+                    except ValueError as error:
                         raise ValueError(
                             f"Problem parsing json contents at '{data_file_path}':  {error}."
                         )
@@ -176,7 +176,7 @@ class SitesInformation:
                         except KeyError:
                             pass
 
-            except Exception:
+            except requests.exceptions.RequestException:
                 # If there was any problem loading the exclusions, just continue without them
                 print("Warning: Could not load exclusions, continuing without them.")
                 honor_exclusions = False

--- a/sherlock_project/sites.py
+++ b/sherlock_project/sites.py
@@ -6,6 +6,7 @@ This is the raw data that will be used to search for usernames.
 import json
 import requests
 import secrets
+from typing import Optional
 
 
 MANIFEST_URL = "https://data.sherlockproject.xyz"
@@ -78,9 +79,9 @@ class SiteInformation:
 class SitesInformation:
     def __init__(
             self,
-            data_file_path: str|None = None,
+            data_file_path: Optional[str] = None,
             honor_exclusions: bool = True,
-            do_not_exclude: list[str] = [],
+            do_not_exclude: list = [],
         ):
         """Create Sites Information Object.
 


### PR DESCRIPTION
This PR refactors `except Exception:` and `except:` blocks in `sherlock.py` and `sites.py` to catch more specific exceptions as per issue #3011.