### PR TITLE
reject usernames that contain dots at the Empretienda AR probe

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -788,6 +788,7 @@
   "Empretienda AR": {
     "__comment__": "Note that Error Connecting responses may be indicative of unclaimed handles",
     "errorType": "status_code",
+    "regexCheck": "^[\\w@-]+?$",
     "url": "https://{}.empretienda.com.ar",
     "urlMain": "https://empretienda.com",
     "username_claimed": "camalote"


### PR DESCRIPTION
Closes #2970.

The url pattern for Empretienda AR embeds the username as a subdomain of empretienda.com.ar (`https://{}.empretienda.com.ar`). A username that contains a period, e.g. `alice.`, is interpolated into the host of the request, producing a URL like

```
https://alice..empretienda.com.ar
```

The intermediate double dot is not a valid DNS label separator, so urllib3 raises `LocationParseError` from the adapter and the whole `sherlock` run aborts with a traceback pointing at `create_connection` instead of skipping the broken site.

Fix: add a `regexCheck` that matches the same character class as the other subdomain-style entries already in the manifest (`booth.pm`, `blogspot.com`, `carbonmade.com`, `crevado.com`, `exposure.co`, etc.), namely `^[\\w@-]+?$`. That accepts the usernames Empretienda actually issues (letters, digits, underscores, hyphens, at-signs) and rejects any with dots or other characters that would corrupt the host part of the interpolated URL. The skip path is `QueryStatus.ILLEGAL`, the same as the other sites that use this regex, and the run continues past the problematic username.

Verified locally that `test_validate_manifest_against_local_schema` still passes; the rest of the regex behaviour can be exercised against any of the existing `test_username_illegal_regex`-style probes.