### PR TITLE
Fix dailykos false positives via status_code detection

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -2888,11 +2888,9 @@
     "username_claimed": "blue"
   },
   "dailykos": {
-    "errorMsg": "{\"result\":true,\"message\":null}",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://www.dailykos.com/user/{}",
     "urlMain": "https://www.dailykos.com",
-    "urlProbe": "https://www.dailykos.com/signup/check_nickname?nickname={}",
     "username_claimed": "blue"
   },
   "datingRU": {


### PR DESCRIPTION
## Summary

`dailykos` is on the false-positive exclusions list. Its entry probed the signup
endpoint (`/signup/check_nickname?nickname={}`) and matched the message
`{"result":true,"message":null}`. That inverted-logic check is fragile: when the
endpoint drifts it stops returning the message and every username reads as taken,
producing false positives.

The profile page itself is a clean, stable signal:
`https://www.dailykos.com/user/{}` returns **HTTP 200** for an existing user and
**404** for a missing one. This switches `dailykos` to `status_code` detection on
that URL and drops the now-unneeded `errorMsg` and `urlProbe`.

## Validation

Per the false-positive remediation guide, validated against the live site with
`--local` (no false positive and no false negative):

- false negative: `username_claimed` `blue` -> **Found** (200)
- false positive: random usernames (e.g. `xkq7mztab9`, `zzqwx88notreal`) -> **Not Found** (404)
- `pytest tests/test_validate_targets.py --chunked-sites=dailykos -m online` -> **2 passed**

No dailykos-specific false-positive issue exists, so `Fixes:` is omitted per the guide.
