### PR TITLE
fix: strip trailing periods from usernames to prevent DNS errors

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -809,10 +809,10 @@ def main():
     all_usernames = []
     for username in args.username:
         if check_for_parameter(username):
-            for name in multiple_usernames(username):
-                all_usernames.append(name)
+            for raw_name in multiple_usernames(username):
+                all_usernames.append(raw_name.rstrip("."))
         else:
-            all_usernames.append(username)
+            all_usernames.append(username.rstrip("."))
     for username in all_usernames:
         results = sherlock(
             username,


### PR DESCRIPTION
Usernames ending in a period cause URL templates like `https://{}.example.com` to produce `https://alice..example.com`, which urllib3 rejects with "label empty or too long".

Strip trailing periods from all usernames before processing.

Fixes #2970