### PR TITLE
Add PhoneInfoga compose setup and optional .env.local loading

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+NUMVERIFY_API_KEY="value"
+GOOGLECSE_CX="value"
+GOOGLE_API_KEY="value"

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ tests/.excluded_sites
 
 # Vim swap files
 *.swp
+
+# Local environment overrides
+.env.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+
+services:
+  phoneinfoga:
+    container_name: phoneinfoga
+    restart: on-failure
+    image: sundowndev/phoneinfoga:latest
+    command:
+      - "serve"
+    ports:
+      - "80:5000"

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,23 @@ options:
   --ignore-exclusions   Ignore upstream exclusions (may return more false positives)
 ```
 
+## Optional local API key configuration
+
+If you run Sherlock from the repository root, it can read optional API keys from a local `.env.local` file.
+Use `.env.local.example` as a starting point:
+
+```bash
+cp .env.local.example .env.local
+```
+
+The following keys are supported:
+
+- `NUMVERIFY_API_KEY`
+- `GOOGLECSE_CX`
+- `GOOGLE_API_KEY`
+
+Use `--verbose` to see whether these variables were loaded and whether any are missing.
+
 ## Credits
 
 Thank you to everyone who has contributed to Sherlock! ❤️

--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -20,6 +20,7 @@ import csv
 import signal
 import pandas as pd
 import os
+import pathlib
 import re
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from json import loads as json_loads
@@ -43,6 +44,42 @@ from sherlock_project.notify import QueryNotifyPrint
 from sherlock_project.sites import SitesInformation
 from colorama import init
 from argparse import ArgumentTypeError
+
+
+PHONE_LOOKUP_ENV_VARS = ("NUMVERIFY_API_KEY", "GOOGLECSE_CX", "GOOGLE_API_KEY")
+
+
+def load_environment_file(env_path: pathlib.Path) -> None:
+    with env_path.open(encoding="utf-8") as env_file:
+        for line_number, raw_line in enumerate(env_file, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            if "=" not in line:
+                raise ValueError(
+                    f"{env_path}:{line_number} must be in KEY=VALUE format."
+                )
+
+            key, value = line.split("=", 1)
+            key = key.strip()
+            if not key:
+                raise ValueError(f"{env_path}:{line_number} is missing the key name.")
+
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                value = value[1:-1]
+
+            os.environ.setdefault(key, value)
+
+
+def load_local_environment() -> Optional[pathlib.Path]:
+    env_path = pathlib.Path.cwd() / ".env.local"
+    if not env_path.is_file():
+        return None
+
+    load_environment_file(env_path)
+    return env_path
 
 
 class SherlockFuturesSession(FuturesSession):
@@ -695,6 +732,26 @@ def main():
     )
 
     args = parser.parse_args()
+
+    try:
+        loaded_environment = load_local_environment()
+    except ValueError as error:
+        print(f"Invalid .env.local file: {error}")
+        sys.exit(1)
+
+    if args.verbose:
+        if loaded_environment is not None:
+            print(f"Loaded environment from {loaded_environment}.")
+        missing_phone_lookup_env = [
+            key for key in PHONE_LOOKUP_ENV_VARS if not os.environ.get(key)
+        ]
+        if missing_phone_lookup_env:
+            print(
+                "Missing phone lookup environment variables: "
+                + ", ".join(missing_phone_lookup_env)
+            )
+        else:
+            print("Phone lookup environment variables are configured.")
 
     # If the user presses CTRL-C, exit gracefully without throwing errors
     signal.signal(signal.SIGINT, handler)

--- a/tests/test_env_local.py
+++ b/tests/test_env_local.py
@@ -1,0 +1,57 @@
+import os
+
+from sherlock_project import sherlock
+
+
+def test_load_local_environment_file(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env.local"
+    env_file.write_text(
+        '\n'.join(
+            [
+                'NUMVERIFY_API_KEY="numverify"',
+                "GOOGLECSE_CX=custom-search-engine",
+                "GOOGLE_API_KEY='google-api-key'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("NUMVERIFY_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLECSE_CX", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    loaded_path = sherlock.load_local_environment()
+
+    assert loaded_path == env_file
+    assert os.environ["NUMVERIFY_API_KEY"] == "numverify"
+    assert os.environ["GOOGLECSE_CX"] == "custom-search-engine"
+    assert os.environ["GOOGLE_API_KEY"] == "google-api-key"
+
+
+def test_load_local_environment_respects_existing_value(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env.local"
+    env_file.write_text('NUMVERIFY_API_KEY="from-file"', encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NUMVERIFY_API_KEY", "pre-existing")
+
+    sherlock.load_local_environment()
+
+    assert os.environ["NUMVERIFY_API_KEY"] == "pre-existing"
+
+
+def test_load_local_environment_skips_when_file_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert sherlock.load_local_environment() is None
+
+
+def test_load_environment_file_raises_for_invalid_line(tmp_path):
+    env_file = tmp_path / ".env.local"
+    env_file.write_text("NOT_VALID", encoding="utf-8")
+
+    try:
+        sherlock.load_environment_file(env_file)
+        assert False, "Expected load_environment_file to raise ValueError."
+    except ValueError as error:
+        assert "KEY=VALUE" in str(error)


### PR DESCRIPTION
This change packages two setup improvements so local usage is easier: a ready-to-run PhoneInfoga compose service, and optional `.env.local` loading for API keys used in phone lookup workflows.

## What changed
- Added `docker-compose.yml` with a `phoneinfoga` service (`sundowndev/phoneinfoga:latest`, `serve`, port `80:5000`).
- Added optional `.env.local` support in `sherlock_project/sherlock.py`:
  - Loads `.env.local` from repository root when present.
  - Parses `KEY=VALUE` lines (including quoted values), ignores blank/comment lines, and preserves pre-existing environment variables.
  - Surfaces invalid format errors clearly.
  - In `--verbose` mode, reports load status and whether `NUMVERIFY_API_KEY`, `GOOGLECSE_CX`, and `GOOGLE_API_KEY` are configured.
- Added `.env.local` to `.gitignore` and added `.env.local.example` with the supported keys.
- Documented local API key configuration in `docs/README.md`.
- Added tests in `tests/test_env_local.py` covering load success, missing file behavior, existing env precedence, and invalid line handling.

## Notes for reviewers
- `.env.local` remains local-only and is not committed.
- Env loading is opt-in by file presence and non-disruptive to existing CLI behavior.