### PR TITLE
Fix local manifest filenames beginning with http

### DIFF
--- a/sherlock_project/sites.py
+++ b/sherlock_project/sites.py
@@ -121,7 +121,7 @@ class SitesInformation:
             # users from creating issue about false positives which has already been fixed or having outdated data
             data_file_path = MANIFEST_URL
 
-        if data_file_path.lower().startswith("http"):
+        if data_file_path.lower().startswith(("http://", "https://")):
             # Reference is to a URL.
             try:
                 response = requests.get(url=data_file_path, timeout=30)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,7 +1,50 @@
 import os
 import json
+from unittest.mock import Mock
+
 import pytest
 from jsonschema import validate
+
+from sherlock_project.sites import SitesInformation
+
+
+@pytest.mark.parametrize("manifest_name", ["http-manifest.json", "https-manifest.json"])
+def test_local_manifest_filename_starting_with_http(manifest_name, tmp_path, monkeypatch):
+    manifest = tmp_path / manifest_name
+    manifest.write_text(
+        json.dumps(
+            {
+                "Example": {
+                    "urlMain": "https://example.com",
+                    "url": "https://example.com/{}",
+                    "username_claimed": "taken",
+                    "errorType": "status_code",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    sites = SitesInformation(manifest.name, honor_exclusions=False)
+
+    assert sites.site_name_list() == ["Example"]
+
+
+@pytest.mark.parametrize("manifest_url", [
+    "http://example.com/manifest.json",
+    "https://example.com/manifest.json",
+])
+def test_manifest_http_url_is_fetched(manifest_url, monkeypatch):
+    response = Mock(status_code=200)
+    response.json.return_value = {}
+    get = Mock(return_value=response)
+    monkeypatch.setattr("sherlock_project.sites.requests.get", get)
+
+    sites = SitesInformation(manifest_url, honor_exclusions=False)
+
+    assert sites.site_name_list() == []
+    get.assert_called_once_with(url=manifest_url, timeout=30)
 
 def test_validate_manifest_against_local_schema():
     """Ensures that the manifest matches the local schema, for situations where the schema is being changed."""


### PR DESCRIPTION
## What this fixes

Sherlock lets users replace its default site list by passing a local JSON file to `--json`. A user can reasonably name that file `http-manifest.json` or `https-sites.json` and expect Sherlock to load it from the current directory. Today, the broad prefix check mistakes either filename for a web address, so Requests rejects it for having no URL scheme and Sherlock stops before checking any accounts. This patch recognizes only actual `http://` and `https://` addresses as remote, while preserving both local-file loading and remote manifest fetching.

## Reproduction

1. Create a valid local manifest named `http-manifest.json`.
2. Run `sherlock testuser --json http-manifest.json --ignore-exclusions`.
3. Sherlock exits while loading the manifest with `Invalid URL 'http-manifest.json': No scheme supplied`.

The same problem affects relative filenames beginning with `https`, such as `https-sites.json`.

## Root cause

`SitesInformation` classified any path whose text began with `http` as a URL. That includes ordinary relative filenames, even though they contain no URL scheme.

## What changed

- Treat only paths beginning with `http://` or `https://`, case-insensitively, as remote manifests.
- Add regression coverage for local filenames beginning with `http` and `https`.
- Confirm that real HTTP and HTTPS manifest URLs continue to use Requests.

## Validation

- `pytest tests/test_manifest.py -q`: 8 passed
- Full `pytest`: 31 passed, 962 deselected by the repository configuration
- `tox -e py313`: passed
- `tox -e lint`: passed

`tox -e offline` currently stops during collection because that environment does not install `rstr`, which `tests/test_validate_targets.py` imports. The failure is unchanged and outside this patch.
