### PR TITLE
Remove stray errorUrl from Pinterest (fails data.schema.json)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -3168,7 +3168,6 @@
   },
   "Pinterest": {
     "errorType": "status_code",
-    "errorUrl": "https://www.pinterest.com/",
     "url": "https://www.pinterest.com/{}/",
     "urlProbe": "https://www.pinterest.com/oembed.json?url=https://www.pinterest.com/{}/",
     "urlMain": "https://www.pinterest.com/",


### PR DESCRIPTION
## What

Removes the `errorUrl` field from the `Pinterest` entry in `data.json`.

## Why

`Pinterest` uses `errorType: status_code`, but also carries an `errorUrl` — a field
that is only meaningful for `response_url` detection. Because of this, the entry fails
the repository's **own** `data.schema.json`: the `status_code` branch of the schema's
`oneOf` does not permit `errorUrl`.

Reproduction (before this change):

```python
import json, jsonschema
d = json.load(open("sherlock_project/resources/data.json"))
s = json.load(open("sherlock_project/resources/data.schema.json"))
jsonschema.validate(d, s)
# -> ValidationError: 'response_url' was expected ... on instance['Pinterest']['errorType']
```

After this change, `jsonschema.validate(...)` passes.

## Behavior impact

None. `errorUrl` is not read by `sherlock.py` for `status_code` sites (it is only used
by `response_url` detection, which this site does not use). Pinterest detection is
unchanged; the manifest simply becomes schema-valid again.