### PR TITLE
Fix --output flag silently ignored unless --txt is also passed

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -833,7 +833,7 @@ def main():
         else:
             result_file = f"{username}.txt"
 
-        if args.output_txt:
+        if args.output_txt or args.output:
             with open(result_file, "w", encoding="utf-8") as file:
                 exists_counter = 0
                 for website_name in results:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,45 @@
+import sys
+
+from sherlock_project import sherlock
+from sherlock_project.result import QueryResult, QueryStatus
+
+
+def test_output_option_writes_text_file_without_txt(monkeypatch, tmp_path):
+    output_file = tmp_path / 'results.txt'
+    result = QueryResult(
+        username='example',
+        site_name='Example',
+        site_url_user='https://example.com/example',
+        status=QueryStatus.CLAIMED,
+    )
+
+    def offline(*args, **kwargs):
+        raise OSError('offline')
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['sherlock', '--local', '--output', str(output_file), 'example'],
+    )
+    monkeypatch.setattr(
+        sherlock.requests,
+        'get',
+        offline,
+    )
+    monkeypatch.setattr(
+        sherlock,
+        'sherlock',
+        lambda *args, **kwargs: {
+            'Example': {
+                'status': result,
+                'url_user': result.site_url_user,
+            }
+        },
+    )
+
+    sherlock.main()
+
+    assert output_file.read_text() == (
+        'https://example.com/example\n'
+        'Total Websites Username Detected On : 1\n'
+    )


### PR DESCRIPTION
Fixes #2992

## Problem

Passing `--output results.txt` without `--txt` computes the requested filename but never writes it because the write block is guarded only by `args.output_txt`.

## Change

Write the text report when either `--txt` or an explicit `--output` path is provided.

## Regression test

The new end-to-end test invokes `main` with `--output` but without `--txt`, stubs network/search work, and verifies that the requested file contains the claimed URL and total.

Local result: `1 passed`.
