### PR TITLE
Fix crash when usernames end with period

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -808,6 +808,7 @@ def main():
     # Run report on all specified users.
     all_usernames = []
     for username in args.username:
+        username = username.rstrip(".")
         if check_for_parameter(username):
             for name in multiple_usernames(username):
                 all_usernames.append(name)


### PR DESCRIPTION
Fixes #2970

Strip trailing periods from usernames during input sanitization to prevent URL parsing errors.