### PR TITLE
Re-enable Bandcamp, Giphy, and Trovo after validation

### DIFF
--- a/false_positive_exclusions.txt
+++ b/false_positive_exclusions.txt
@@ -3,14 +3,12 @@ Airliners
 Apple Developer
 Apple Discussions
 Archive.org
-Bandcamp
 Codolio
 DeviantArt
 Discord.bio
 Envato Forum
 Flipboard
 GeeksforGeeks
-Giphy
 Hashnode
 Hubski
 LessWrong
@@ -28,7 +26,6 @@ Slack
 SlideShare
 Splice
 Spotify
-Trovo
 TryHackMe
 Weblate
 YandexMusic


### PR DESCRIPTION
## Summary

Re-opens the work from #3032 (closed after a branch rewrite).

Removes Bandcamp, Giphy, and Trovo from `false_positive_exclusions.txt` after re-validation so those sites are checked again.

Base: `exclusions`

## Test plan

- [x] Diff is only those three removals from `false_positive_exclusions.txt`
- [ ] Maintainer confirmation that Bandcamp / Giphy / Trovo no longer false-positive