### PR TITLE
Re-enable DeviantArt after validation

### DIFF
--- a/false_positive_exclusions.txt
+++ b/false_positive_exclusions.txt
@@ -5,7 +5,6 @@ Apple Discussions
 Archive.org
 Bandcamp
 Codolio
-DeviantArt
 Discord.bio
 Envato Forum
 Flipboard


### PR DESCRIPTION
## Summary

Re-opens the work from #3033 (closed after a branch rewrite).

Removes DeviantArt from `false_positive_exclusions.txt` after re-validation so the site is checked again.

Base: `exclusions`

## Test plan

- [x] Diff is only the DeviantArt removal from `false_positive_exclusions.txt`
- [ ] Maintainer confirmation that DeviantArt no longer false-positives