### PR TITLE
Fix Python 3.9 compatibility for PEP 604 union annotations

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -7,6 +7,8 @@ This module contains the main logic to search for usernames at social
 networks.
 """
 
+from __future__ import annotations
+
 import sys
 
 try:

--- a/sherlock_project/sites.py
+++ b/sherlock_project/sites.py
@@ -3,6 +3,8 @@
 This module supports storing information about websites.
 This is the raw data that will be used to search for usernames.
 """
+from __future__ import annotations
+
 import json
 import requests
 import secrets


### PR DESCRIPTION
## Summary

`pyproject.toml` declares `python = "^3.9"` and ships a `Programming Language :: Python :: 3` classifier, but the package currently **fails to import on Python 3.9**. Two modules use [PEP 604](https://peps.python.org/pep-0604/) union syntax in annotations that are evaluated at runtime:

- `sherlock_project/sites.py` — `data_file_path: str|None = None` (function default annotation, evaluated at definition)
- `sherlock_project/sherlock.py` — `-> dict[str, dict[str, str | QueryResult]]` (return annotation, evaluated at definition)

On Python 3.9 this raises:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

so `sherlock --version` (and any invocation) crashes on a stock 3.9 interpreter.

## Fix

Add `from __future__ import annotations` ([PEP 563](https://peps.python.org/pep-0563/)) to both affected modules. This makes annotations lazy strings that are never evaluated at runtime, so the modern union syntax keeps working while 3.9 support is restored. No annotation rewrites, no behavioral change.

## Verification

On a stock **Python 3.9.6**:

- `sherlock --version` → `Sherlock v0.16.1`
- Live search (`sherlock --site GitHub --site Reddit octocat`) returns results
- Full default test suite: **27 passed**

Also confirmed working on Python 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)