### PR TITLE
fix: use status_code for four sites with stale message rules

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -440,6 +440,7 @@
   "Chatujme.cz": {
     "errorType": "status_code",
     "regexCheck": "^[a-zA-Z][a-zA-Z1-9_-]*$",
+    "request_method": "GET",
     "url": "https://profil.chatujme.cz/{}",
     "urlMain": "https://chatujme.cz/",
     "username_claimed": "david"
@@ -2991,6 +2992,7 @@
   },
   "interpals": {
     "errorType": "status_code",
+    "request_method": "GET",
     "url": "https://www.interpals.net/{}",
     "urlMain": "https://www.interpals.net/",
     "username_claimed": "blue"

--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -438,8 +438,7 @@
     "username_claimed": "ordnung"
   },
   "Chatujme.cz": {
-    "errorMsg": "Neexistujic\u00ed profil",
-    "errorType": "message",
+    "errorType": "status_code",
     "regexCheck": "^[a-zA-Z][a-zA-Z1-9_-]*$",
     "url": "https://profil.chatujme.cz/{}",
     "urlMain": "https://chatujme.cz/",
@@ -735,8 +734,7 @@
     "username_claimed": "blue"
   },
   "Discord.bio": {
-    "errorType": "message",
-    "errorMsg": "<title>Server Error (500)</title>",
+    "errorType": "status_code",
     "url": "https://discords.com/api-v2/bio/details/{}",
     "urlMain": "https://discord.bio/",
     "username_claimed": "robert"
@@ -2101,8 +2099,7 @@
     "username_claimed": "John_Smith"
   },
   "ReverbNation": {
-    "errorMsg": "Sorry, we couldn't find that page",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://www.reverbnation.com/{}",
     "urlMain": "https://www.reverbnation.com/",
     "username_claimed": "blue"
@@ -2993,8 +2990,7 @@
     "username_claimed": "blue"
   },
   "interpals": {
-    "errorMsg": "The requested user does not exist or is inactive",
-    "errorType": "message",
+    "errorType": "status_code",
     "url": "https://www.interpals.net/{}",
     "urlMain": "https://www.interpals.net/",
     "username_claimed": "blue"


### PR DESCRIPTION
Chatujme.cz, Discord.bio, ReverbNation and interpals return 404 for missing users, so status_code is both correct and fail-closed.

Their configured errorMsg strings no longer appear on the page, and a message rule infers "account exists" from the absence of that string — so all four currently report a hit for every username.