### PR TITLE
Re-enable Scribd after validation

### DIFF
--- a/false_positive_exclusions.txt
+++ b/false_positive_exclusions.txt
@@ -26,7 +26,6 @@ Reddit
 Replit.com
 ReverbNation
 RocketTube
-Scribd
 Shelf
 SlideShare
 Splice


### PR DESCRIPTION
## Summary

Removes Scribd from false_positive_exclusions.txt so the site is checked again during searches.

## Validation

Scribd detection verified with --ignore-exclusions.

Fixes #2547