### PR TITLE
fix: bound quantifiers without rewriting character classes

### DIFF
--- a/tests/test_validate_targets.py
+++ b/tests/test_validate_targets.py
@@ -1,4 +1,5 @@
 import pytest
+import random
 import re
 import rstr
 
@@ -12,19 +13,67 @@ FALSE_POSITIVE_QUANTIFIER_UPPER_BOUND: int = 15  # If a pattern uses quantifiers
 FALSE_POSITIVE_DEFAULT_PATTERN: str = r'^[a-zA-Z0-9]{7,20}$'  # Used in absence of a regexCheck entry
 
 
+OPEN_ENDED_REPETITION: re.Pattern = re.compile(r'\{(\d+),\}')  # {n,}
+
+
 def set_pattern_upper_bound(pattern: str, upper_bound: int = FALSE_POSITIVE_QUANTIFIER_UPPER_BOUND) -> str:
-    """Set upper bound for regex patterns that use quantifiers such as `+` `*` or `{n,}`."""
-    def replace_upper_bound(match: re.Match) -> str: # type: ignore
-        lower_bound: int = int(match.group(1)) if match.group(1) else 0 # type: ignore
-        nonlocal upper_bound
-        upper_bound = upper_bound if lower_bound < upper_bound else lower_bound # type: ignore  # noqa: F823
-        return f'{{{lower_bound},{upper_bound}}}'
+    """Set upper bound for regex patterns that use quantifiers such as `+` `*` or `{n,}`.
 
-    pattern = re.sub(r'(?<!\\)\{(\d+),\}', replace_upper_bound, pattern) # {n,} # type: ignore
-    pattern = re.sub(r'(?<!\\)\+', f'{{1,{upper_bound}}}', pattern) # +
-    pattern = re.sub(r'(?<!\\)\*', f'{{0,{upper_bound}}}', pattern) # *
+    Only quantifiers are rewritten. Inside a character class `+` and `*` are ordinary
+    members, so rewriting them there would alter which characters the pattern accepts
+    and produce handles the target itself rejects.
+    """
+    def bounded(lower_bound: int) -> str:
+        return f'{{{lower_bound},{max(lower_bound, upper_bound)}}}'
 
-    return pattern
+    bounded_pattern: list[str] = []
+    index: int = 0
+    within_class: bool = False
+
+    while index < len(pattern):
+        char: str = pattern[index]
+
+        # An escaped character is a literal, never a quantifier
+        if char == '\\':
+            bounded_pattern.append(pattern[index:index + 2])
+            index += 2
+            continue
+
+        if within_class:
+            within_class = char != ']'
+            bounded_pattern.append(char)
+            index += 1
+            continue
+
+        if char == '[':
+            bounded_pattern.append(char)
+            index += 1
+            within_class = True
+            # A leading `^` negates the class, and a `]` in first position is a
+            # literal member rather than the end of the class
+            if pattern[index:index + 1] == '^':
+                bounded_pattern.append('^')
+                index += 1
+            if pattern[index:index + 1] == ']':
+                bounded_pattern.append(']')
+                index += 1
+            continue
+
+        if char in '+*':
+            bounded_pattern.append(bounded(1 if char == '+' else 0))
+            index += 1
+            continue
+
+        open_ended: re.Match | None = OPEN_ENDED_REPETITION.match(pattern, index)
+        if open_ended:
+            bounded_pattern.append(bounded(int(open_ended.group(1))))
+            index = open_ended.end()
+            continue
+
+        bounded_pattern.append(char)
+        index += 1
+
+    return ''.join(bounded_pattern)
 
 def false_positive_check(sites_info: dict[str, dict[str, str]], site: str, pattern: str) -> QueryStatus:
     """Check if a site is likely to produce false positives."""
@@ -97,4 +146,51 @@ class Test_All_Targets:
         for site in chunked_sites:
             result: QueryStatus = false_negative_check(chunked_sites, site)
             assert result is QueryStatus.CLAIMED, f"{site} produced false negative, result was {result}"
+
+
+@pytest.mark.parametrize('pattern,expected', [
+    # Quantifiers are bounded
+    (r'^[a-z]+$', r'^[a-z]{1,15}$'),
+    (r'^[a-z]*$', r'^[a-z]{0,15}$'),
+    (r'^[a-z]{3,}$', r'^[a-z]{3,15}$'),
+    (r'^(ab)+$', r'^(ab){1,15}$'),
+    # Closed ranges and escaped literals are not quantifiers to bound
+    (r'^[a-z]{3,10}$', r'^[a-z]{3,10}$'),
+    (r'^a\+b$', r'^a\+b$'),
+    (r'^a\*b$', r'^a\*b$'),
+    # An escaped backslash is a literal, so the quantifier after it still applies
+    (r'^a\\+$', r'^a\\{1,15}$'),
+    # `+` and `*` inside a character class are members rather than quantifiers
+    (r'^[a-zA-Z0-9_.+-]{1,40}$', r'^[a-zA-Z0-9_.+-]{1,40}$'),    # Wordnik
+    (r'^[^\/:*?"<>|@]{3,50}$', r'^[^\/:*?"<>|@]{3,50}$'),        # CyberDefenders
+    (r'^[]+]$', r'^[]+]$'),                                      # leading `]` is a member
+    # A lower bound above the cap lifts the bound for that quantifier alone
+    (r'^[a-z]{20,}x[0-9]+$', r'^[a-z]{20,20}x[0-9]{1,15}$'),
+])
+def test_set_pattern_upper_bound(pattern: str, expected: str):
+    """Bounding should constrain quantifiers without rewriting anything else."""
+    assert set_pattern_upper_bound(pattern) == expected
+
+
+def test_bounded_manifest_patterns_generate_legal_usernames(sites_info):
+    """Every regexCheck must still accept the usernames generated from its bounded form.
+
+    A bound that alters the pattern yields usernames the target itself rejects, which
+    reports as a false positive against an otherwise healthy target.
+    """
+    lookaround: re.Pattern = re.compile(r'\(\?[=!<]')
+    random.seed(0)
+
+    for site, site_info in sites_info.items():
+        pattern: str | None = site_info.get('regexCheck')
+        # rstr cannot honor lookarounds, so those patterns may generate a rejected
+        # username no matter how they are bounded
+        if not pattern or lookaround.search(pattern):
+            continue
+
+        bounded: str = set_pattern_upper_bound(pattern)
+        for _ in range(20):
+            username: str = rstr.xeger(bounded)
+            assert re.search(pattern, username), \
+                f"{site}: bounded pattern {bounded} generated '{username}', which its own regexCheck {pattern} rejects"
 


### PR DESCRIPTION
`set_pattern_upper_bound` rewrites every unescaped `+` and `*` in a `regexCheck` before the false positive fuzzer generates a handle. Inside a character class those are ordinary members, not quantifiers, so the substitution changes which characters the class accepts.

Two targets in the manifest are affected today:

```
Wordnik          ^[a-zA-Z0-9_.+-]{1,40}$   ->  ^[a-zA-Z0-9_.{1,15}-]{1,40}$
CyberDefenders   ^[^\/:*?"<>|@]{3,50}$     ->  ^[^\/:{0,15}?"<>|@]{3,50}$
```

Wordnik loses `+` and gains `{`, `,`, `}`. CyberDefenders stops excluding `*` and starts excluding digits. Sampling 20k handles from each rewritten pattern, 54% and 26% of them fail the site's real `regexCheck`, so sherlock returns Illegal and the check reports a false positive against a healthy target:

```
AssertionError: Wordnik produced false positive with pattern ^[a-zA-Z0-9_.{1,15}-]{1,40}$, result was Illegal
```

Running `-m validate_targets_fp --chunked-sites "Wordnik,CyberDefenders"` 15 times: 7 of 15 runs fail on master, 0 of 15 after this change. That job gates every data.json PR and also runs nightly over the full manifest in the exclusions updater, so the noise is recurring rather than one-off.

The fix walks the pattern and applies bounds only where a quantifier can appear. Escaped literals are skipped, which also fixes `\+`, where the `+` is a real quantifier that the old lookbehind declined to bound. A lower bound above the cap now lifts the bound for that one quantifier instead of leaking into the rest of the pattern, which is what the `nonlocal` in the previous version did.

Behaviour outside character classes is unchanged: `+`, `*` and `{n,}` still collapse to the same bounds, and generated handles are still capped at 15 characters.

Tests cover the quantifier cases, the escaping rules, both manifest patterns above, and a sweep asserting that every `regexCheck` in the manifest still accepts what its bounded form generates. Six of them fail against the current implementation. Patterns using lookarounds are skipped in the sweep, since rstr cannot honour those and they fail independently of bounding.