### PR TITLE
Fix LeetCode detection via GraphQL API

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -1437,9 +1437,18 @@
     "username_claimed": "blue"
   },
   "LeetCode": {
-    "errorType": "status_code",
-    "url": "https://leetcode.com/{}",
+    "errorMsg": "That user does not exist.",
+    "errorType": "message",
+    "request_method": "POST",
+    "request_payload": {
+      "query": "query getUserProfile($username: String!) { matchedUser(username: $username) { username } }",
+      "variables": {
+        "username": "{}"
+      }
+    },
+    "url": "https://leetcode.com/u/{}/",
     "urlMain": "https://leetcode.com/",
+    "urlProbe": "https://leetcode.com/graphql",
     "username_claimed": "blue"
   },
   "LemmyWorld": {


### PR DESCRIPTION
## Problem

LeetCode is currently reported as **not found** for every username. Two things changed on LeetCode's side:

1. Profiles moved from `https://leetcode.com/{}` to `https://leetcode.com/u/{}/`.
2. Direct profile requests now return **HTTP 403** for everyone (bot protection), so `status_code` detection can never succeed.

## Fix

Switch LeetCode to its public GraphQL API (`matchedUser` query) and detect the `"That user does not exist."` error message returned for missing users. This mirrors the existing **Anilist** entry, which already uses a `POST` + GraphQL `urlProbe` + `request_payload` pattern. The display `url` is also updated to the new `/u/{}/` path.

```json
"LeetCode": {
  "errorMsg": "That user does not exist.",
  "errorType": "message",
  "request_method": "POST",
  "request_payload": {
    "query": "query getUserProfile($username: String!) { matchedUser(username: $username) { username } }",
    "variables": { "username": "{}" }
  },
  "url": "https://leetcode.com/u/{}/",
  "urlMain": "https://leetcode.com/",
  "urlProbe": "https://leetcode.com/graphql",
  "username_claimed": "blue"
}
```

## Testing

- `test_manifest.py` schema validation — passes
- `test_validate_targets.py` false-negative (LeetCode) — passes (known user → Claimed)
- `test_validate_targets.py` false-positive (LeetCode) — passes (random users → Available)

Verified manually:
- `sherlock siddharthaasal --site LeetCode` → found
- random/nonexistent username → not found