### PR TITLE
notify: per-username result counts (fixes #2990)

### DIFF
--- a/sherlock_project/notify.py
+++ b/sherlock_project/notify.py
@@ -7,9 +7,6 @@ from sherlock_project.result import QueryStatus
 from colorama import Fore, Style
 import webbrowser
 
-# Global variable to count the number of results.
-globvar = 0
-
 
 class QueryNotify:
     """Query Notify Object.
@@ -132,6 +129,7 @@ class QueryNotifyPrint(QueryNotify):
         self.verbose = verbose
         self.print_all = print_all
         self.browse = browse
+        self._result_count = 0
 
 
     def start(self, message):
@@ -169,9 +167,8 @@ class QueryNotifyPrint(QueryNotify):
         Return Value:
         The number of results by the time we call the function.
         """
-        global globvar
-        globvar += 1
-        return globvar
+        self._result_count += 1
+        return self._result_count
 
     def update(self, result):
         """Notify Update.
@@ -258,7 +255,9 @@ class QueryNotifyPrint(QueryNotify):
         Return Value:
         Nothing.
         """
-        NumberOfResults = self.countResults() - 1
+        NumberOfResults = self._result_count
+        # The instance is shared across username scans, so reset the count for the next scan.
+        self._result_count = 0
 
         print(Style.BRIGHT + Fore.GREEN + "[" +
               Fore.YELLOW + "*" +

--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -928,7 +928,7 @@ def main():
             DataFrame.to_excel(f"{username}.xlsx", sheet_name="sheet1", index=False)
 
         print()
-    query_notify.finish()
+        query_notify.finish()
 
 
 if __name__ == "__main__":

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,48 @@
+import re
+from sherlock_project.notify import QueryNotifyPrint
+from sherlock_project.result import QueryResult, QueryStatus
+
+
+def make_result(username, site):
+    return QueryResult(
+        username=username,
+        site_name=site,
+        site_url_user=f"https://example.com/{username}",
+        status=QueryStatus.CLAIMED,
+        query_time=None,
+        context=None,
+    )
+
+
+def completed_count(out) -> str:
+    match = re.search(r"completed with\x1b\[37m (\d+)", out)
+    assert match is not None, f"no 'Search completed with N results' line in: {out!r}"
+    return match.group(1)
+
+
+def test_count_is_per_instance(capsys):
+    qn_a = QueryNotifyPrint()
+    qn_b = QueryNotifyPrint()
+
+    qn_a.update(make_result("user1", "github"))
+    qn_a.update(make_result("user1", "twitter"))
+    qn_b.update(make_result("user2", "github"))
+
+    qn_a.finish()
+    assert completed_count(capsys.readouterr().out) == "2"
+
+    qn_b.finish()
+    assert completed_count(capsys.readouterr().out) == "1"
+
+
+def test_count_resets_between_username_scans(capsys):
+    qn = QueryNotifyPrint()
+
+    qn.update(make_result("user1", "github"))
+    qn.update(make_result("user1", "twitter"))
+    qn.finish()
+    assert completed_count(capsys.readouterr().out) == "2"
+
+    qn.update(make_result("user2", "github"))
+    qn.finish()
+    assert completed_count(capsys.readouterr().out) == "1"


### PR DESCRIPTION
## Summary

Fixes #2990 — the "Search completed with X results" line showed a **cumulative** total across all usernames (and relied on a fragile `countResults() - 1` off-by-one compensation).

### Root cause

`sherlock_project/notify.py` used a module-level `globvar` that is never reset. A single `QueryNotifyPrint` instance is created once in `main()` (`sherlock.py:812`) and shared across every username scan, so the counter accumulated across scans.

### Changes

- `sherlock_project/notify.py`
  - Remove the module-level `globvar`.
  - Track the count on the instance (`self._result_count`, initialised in `__init__`).
  - `finish()` reads `self._result_count` directly (no extra increment + `- 1`) and resets it so the next username scan starts from zero.
- `sherlock_project/sherlock.py`
  - Call `query_notify.finish()` inside the per-username loop so each scan prints its own "Search completed with X results" line.
- `tests/test_notify.py` — new offline unit tests covering per-instance counts and reset between scans.

### Verification

- Reproduced before: two scans (2 claimed, then 1 claimed) printed `2 results` then `4 results`. After the fix: `2 results` then `1 results`.
- `pytest tests/test_notify.py` passes (2 passed).
- Full offline suite remains green (the only pre-existing failures are environment-related `py -m` subprocess tests that also fail on `master`).