### PR TITLE
Fix site metadata defaults and XLSX export

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -903,10 +903,8 @@ def main():
                 ):
                     continue
 
-                if response_time_s is None:
-                    response_time_s.append("")
-                else:
-                    response_time_s.append(results[site]["status"].query_time)
+                response_time = results[site]["status"].query_time
+                response_time_s.append("" if response_time is None else response_time)
                 usernames.append(username)
                 names.append(site)
                 url_main.append(results[site]["url_main"])

--- a/sherlock_project/sites.py
+++ b/sherlock_project/sites.py
@@ -13,7 +13,7 @@ EXCLUSIONS_URL = "https://raw.githubusercontent.com/sherlock-project/sherlock/re
 
 class SiteInformation:
     def __init__(self, name, url_home, url_username_format, username_claimed,
-                information, is_nsfw, username_unclaimed=secrets.token_urlsafe(10)):
+                information, is_nsfw, username_unclaimed=None):
         """Create Site Information Object.
 
         Contains information about a specific website.
@@ -56,9 +56,11 @@ class SiteInformation:
         self.url_username_format = url_username_format
 
         self.username_claimed = username_claimed
-        self.username_unclaimed = secrets.token_urlsafe(32)
+        self.username_unclaimed = (
+            username_unclaimed if username_unclaimed is not None else secrets.token_urlsafe(32)
+        )
         self.information = information
-        self.is_nsfw  = is_nsfw
+        self.is_nsfw = is_nsfw
 
         return
 
@@ -80,7 +82,7 @@ class SitesInformation:
             self,
             data_file_path: str|None = None,
             honor_exclusions: bool = True,
-            do_not_exclude: list[str] = [],
+            do_not_exclude: list[str] | None = None,
         ):
         """Create Sites Information Object.
 
@@ -114,6 +116,9 @@ class SitesInformation:
         Return Value:
         Nothing.
         """
+
+        if do_not_exclude is None:
+            do_not_exclude = []
 
         if not data_file_path:
             # The default data file is the live data.json which is in the GitHub repo. The reason why we are using
@@ -205,7 +210,7 @@ class SitesInformation:
 
         return
 
-    def remove_nsfw_sites(self, do_not_remove: list = []):
+    def remove_nsfw_sites(self, do_not_remove: list | None = None):
         """
         Remove NSFW sites from the sites, if isNSFW flag is true for site
 
@@ -216,6 +221,8 @@ class SitesInformation:
         None
         """
         sites = {}
+        if do_not_remove is None:
+            do_not_remove = []
         do_not_remove = [site.casefold() for site in do_not_remove]
         for site in self.sites:
             if self.sites[site].is_nsfw and site.casefold() not in do_not_remove:

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -1,5 +1,6 @@
 import pytest
 from sherlock_project import sherlock
+from sherlock_project.sites import SiteInformation
 from sherlock_interactives import Interactives
 from sherlock_interactives import InteractivesSubprocessError
 
@@ -31,6 +32,20 @@ def test_wildcard_username_expansion():
     assert sherlock.check_for_parameter('test{?test') is False
     assert sherlock.check_for_parameter('test?}test') is False
     assert sherlock.multiple_usernames('test{?}test') == ["test_test" , "test-test" , "test.test"]
+
+
+def test_site_information_preserves_explicit_unclaimed_username():
+    site = SiteInformation(
+        "Example",
+        "https://example.com",
+        "https://example.com/{}",
+        "claimed-user",
+        {"urlMain": "https://example.com"},
+        False,
+        username_unclaimed="available-user",
+    )
+
+    assert site.username_unclaimed == "available-user"
 
 
 @pytest.mark.parametrize('cliargs', [


### PR DESCRIPTION
This fixes two edge-case bugs in Sherlock's site metadata and export flow.

The metadata loader was overwriting explicit `username_unclaimed` values and reusing mutable default collections across site objects, which could leak state between runs. The XLSX output path also appended the response-time list incorrectly when a value was missing, which could break `--xlsx` exports.

The change keeps the metadata behavior stable while preserving the explicit unclaimed username and avoids shared mutable defaults. It also adds a regression test covering the metadata case and keeps the export logic consistent when no response time exists.

Validation:
- `python -m pytest -q`