### PR TITLE
Fix Discord.bio and interpals false positives

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -735,8 +735,8 @@
     "username_claimed": "blue"
   },
   "Discord.bio": {
-    "errorType": "message",
-    "errorMsg": "<title>Server Error (500)</title>",
+    "errorCode": 404,
+    "errorType": "status_code",
     "url": "https://discords.com/api-v2/bio/details/{}",
     "urlMain": "https://discord.bio/",
     "username_claimed": "robert"
@@ -2993,8 +2993,9 @@
     "username_claimed": "blue"
   },
   "interpals": {
-    "errorMsg": "The requested user does not exist or is inactive",
-    "errorType": "message",
+    "errorCode": 404,
+    "errorType": "status_code",
+    "request_method": "GET",
     "url": "https://www.interpals.net/{}",
     "urlMain": "https://www.interpals.net/",
     "username_claimed": "blue"


### PR DESCRIPTION
References: #2547

## Changes

Two excluded sites now return clean, detectable responses:

- **Discord.bio** — the API returns 404 with a JSON body for missing users (the old Server Error (500) page is gone). Switched to status_code detection with errorCode: 404.
- **interpals** — missing users return 404, but the page body is empty so the message-based check no longer matches. Switched to status_code detection, forcing GET since the site loops redirects on HEAD.

## Verification

- Fake usernames: both sites now report not-found (no false positive)
- Claimed username obert/lue: both still reported as found
- 	ests/test_manifest.py passes