### PR TITLE
fix: prevent crash on non-requests exceptions in get_response

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -139,6 +139,13 @@ def get_response(request_future, error_type, social_network):
     except UnicodeError as err:
         error_context = "Encoding Error"
         exception_text = str(err)
+    except Exception as err:
+        # Catch-all for errors raised outside of the `requests` exception
+        # hierarchy (e.g. urllib3.exceptions.LocationParseError for
+        # malformed hosts produced by usernames such as "alice."), so a
+        # single bad site/username combination cannot crash the whole run.
+        error_context = "Unknown Error"
+        exception_text = str(err)
 
     return response, error_context, exception_text
 

--- a/tests/test_get_response.py
+++ b/tests/test_get_response.py
@@ -1,0 +1,42 @@
+import requests
+from urllib3.exceptions import LocationParseError
+
+from sherlock_project.sherlock import get_response
+
+
+class _FailingFuture:
+    """Minimal stand-in for a requests_futures Future whose result() raises."""
+
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    def result(self):
+        raise self._exc
+
+
+def test_get_response_handles_known_requests_exceptions():
+    response, error_context, exception_text = get_response(
+        request_future=_FailingFuture(requests.exceptions.ConnectionError("boom")),
+        error_type="status_code",
+        social_network="ExampleSite",
+    )
+    assert response is None
+    assert error_context == "Error Connecting"
+    assert "boom" in exception_text
+
+
+def test_get_response_handles_non_requests_exceptions():
+    # Regression test for https://github.com/sherlock-project/sherlock/issues/2970
+    # A username ending in "." combined with a subdomain-based site URL (e.g.
+    # "alice." -> "alice..example.com") produces a malformed host. urllib3
+    # raises LocationParseError, which is *not* a requests.exceptions.RequestException
+    # subclass, so it previously propagated uncaught and crashed the whole run.
+    exc = LocationParseError("'alice..example.com', label empty or too long")
+    response, error_context, exception_text = get_response(
+        request_future=_FailingFuture(exc),
+        error_type="status_code",
+        social_network="ExampleSite",
+    )
+    assert response is None
+    assert error_context == "Unknown Error"
+    assert "label empty or too long" in exception_text


### PR DESCRIPTION
## Summary
- Usernames ending in a period (e.g. `alice.`) combined with a subdomain-interpolated site URL (e.g. `https://{}.empretienda.com.ar`) can produce a malformed host such as `alice..empretienda.com.ar`.
- `urllib3` raises `LocationParseError` for this, which is **not** a `requests.exceptions.RequestException` subclass, so it was previously uncaught in `get_response` and crashed the entire run instead of just failing that one site.
- Added a catch-all `Exception` handler in `get_response` so any such error is reported as an `Unknown` status for that site only, consistent with how other connection failures (`ConnectionError`, `Timeout`, etc.) are already handled.

Fixes #2970

## Test plan
- [x] Added `tests/test_get_response.py`: unit tests for `get_response` covering a known `requests` exception (existing behavior) and a non-`requests` exception (`LocationParseError`, the regression case).
- [x] Reproduced the original crash end-to-end using the actual site from the reported traceback (`Empretienda AR`, which has no `regexCheck`) with username `alice.` — confirmed it now reports `Unknown` instead of crashing.
- [x] Full offline test suite passes (`pytest -m "not online"`).