### PR TITLE
fix: --output flag writes the file without requiring --txt (#2992)

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -833,7 +833,7 @@ def main():
         else:
             result_file = f"{username}.txt"
 
-        if args.output_txt:
+        if args.output_txt or args.output:
             with open(result_file, "w", encoding="utf-8") as file:
                 exists_counter = 0
                 for website_name in results:


### PR DESCRIPTION
﻿Closes #2992

`--output myfile.txt` without `--txt` silently created no file. The help text promises the file is written when `--output` is used, but the write block was guarded exclusively by `args.output_txt`.

Minimal fix: the txt write block now also runs when `--output` is given (`if args.output_txt or args.output:`). `result_file` was already computed correctly for the `--output` case, so the existing `open(result_file, "w")` writes to the requested path. `--folderoutput` behavior and the `--csv` path are untouched; the `--output` single-username guard (line ~734) already rejects multi-username usage, so the file can never be clobbered across usernames.
