### PR TITLE
fix: reset result counter per username scan (#2990)

### DIFF
--- a/sherlock_project/notify.py
+++ b/sherlock_project/notify.py
@@ -7,9 +7,6 @@ from sherlock_project.result import QueryStatus
 from colorama import Fore, Style
 import webbrowser
 
-# Global variable to count the number of results.
-globvar = 0
-
 
 class QueryNotify:
     """Query Notify Object.
@@ -132,6 +129,7 @@ class QueryNotifyPrint(QueryNotify):
         self.verbose = verbose
         self.print_all = print_all
         self.browse = browse
+        self._count = 0
 
 
     def start(self, message):
@@ -147,7 +145,7 @@ class QueryNotifyPrint(QueryNotify):
         Return Value:
         Nothing.
         """
-
+        self._count = 0
         title = "Checking username"
 
         print(Style.BRIGHT + Fore.GREEN + "[" +
@@ -169,9 +167,8 @@ class QueryNotifyPrint(QueryNotify):
         Return Value:
         The number of results by the time we call the function.
         """
-        global globvar
-        globvar += 1
-        return globvar
+        self._count += 1
+        return self._count
 
     def update(self, result):
         """Notify Update.
@@ -258,7 +255,7 @@ class QueryNotifyPrint(QueryNotify):
         Return Value:
         Nothing.
         """
-        NumberOfResults = self.countResults() - 1
+        NumberOfResults = self._count
 
         print(Style.BRIGHT + Fore.GREEN + "[" +
               Fore.YELLOW + "*" +


### PR DESCRIPTION
﻿Closes #2990

**Problem:** `notify.py` used a module-level `globvar = 0` to count claimed results. The single `QueryNotifyPrint` instance persists across all username scans, and the global was never reset, so the "Search completed with X results" line showed a cumulative total when scanning multiple usernames.

**Fix:**
- Replaced the module global with an instance attribute `self._count`, initialized in `__init__`.
- Reset `self._count = 0` in `start()` (called once per username scan in `sherlock()`).
- `countResults()` now increments `self._count` instead of the global.
- `finish()` reads `self._count` directly instead of doing the fragile `countResults() - 1` increment-then-compensate dance.

Behavior is unchanged for single-username scans and correct per-username for multi-username scans.
