### PR TITLE
fix: treat status_code == 0 as a successfully-received response (#3027)

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -118,7 +118,7 @@ def get_response(request_future, error_type, social_network):
     exception_text = None
     try:
         response = request_future.result()
-        if response.status_code:
+        if response is not None and response.status_code is not None:
             # Status code exists in response object
             error_context = None
     except requests.exceptions.HTTPError as errh:


### PR DESCRIPTION
﻿Closes #3027

`get_response` used `if response.status_code:` to detect a successfully-received response. The truthiness test silently treats `status_code == 0` as a failure (impossible for real HTTP, but the response object could report it), and a future `Response` reporting `status_code` as `None` would crash the comparison.

Replaced with an explicit `response is not None and response.status_code is not None` check so any integer status code is treated as a received response, and the actual status semantics (200/300/400 handling) are decided downstream by the site's error metadata, unchanged.
