### PR TITLE
ci: skip modified target validation when no targets changed

### DIFF
--- a/.github/workflows/validate_modified_targets.yml
+++ b/.github/workflows/validate_modified_targets.yml
@@ -91,6 +91,7 @@ jobs:
       # --- The rest of the steps below are unchanged ---
 
       - name: Validate modified targets
+        if: steps.discover-modified.outputs.changed_targets != ''
         env:
           CHANGED_TARGETS: ${{ steps.discover-modified.outputs.changed_targets }}
         run: |


### PR DESCRIPTION
## Summary

- Add the missing guard to the `Validate modified targets` step so deletion-only manifest changes do not run the full live target validation suite with an empty `--chunked-sites` value.
- Keep the change limited to `.github/workflows/validate_modified_targets.yml`.

## Why

The workflow already discovers changed targets and skips manifest validation, summary generation, and commenting when `changed_targets` is empty. The pytest step was the only step without the same guard, so deletion-only changes produced an empty `CHANGED_TARGETS` value and accidentally ran validation against the entire target catalog.

## Proof

- `PATH=.venv/bin:$PATH .venv/bin/python -m pytest -q --tb=short -m 'not online and not validate_targets'` -> 14 passed, 975 deselected
- `PATH=.venv/bin:$PATH .venv/bin/python -m pytest -q tests/test_manifest.py::test_validate_manifest_against_local_schema tests/test_ux.py tests/test_unicode.py` -> 10 passed
- `.venv/bin/python -m ruff check` -> All checks passed
- `git diff --check upstream/master` -> passed
- Parsed `.github/workflows/validate_modified_targets.yml` with PyYAML -> passed
- Local simulation of the deletion-only case confirmed `changed_targets` is empty for removed targets `GNOME VCS,Patched`, so the guarded validation step is skipped.

---
Restored after an accidental fork deletion. Same commits as #3002.