### PR TITLE
fix: don't crash the scan on a location parse error (trailing-dot usernames)

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -27,6 +27,7 @@ from time import monotonic
 from typing import Optional
 
 import requests
+import urllib3
 from requests_futures.sessions import FuturesSession
 
 from sherlock_project.__init__ import (
@@ -138,6 +139,13 @@ def get_response(request_future, error_type, social_network):
         exception_text = str(err)
     except UnicodeError as err:
         error_context = "Encoding Error"
+        exception_text = str(err)
+    except urllib3.exceptions.LocationParseError as err:
+        # Raised when a site embeds the username in the hostname and the
+        # resulting address has an empty label (e.g. a trailing period makes
+        # "alice." -> "alice..example.com"). Treat it as a per-site error
+        # instead of crashing the entire scan.
+        error_context = "Error Parsing URL"
         exception_text = str(err)
 
     return response, error_context, exception_text

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -103,3 +103,21 @@ def test_username_illegal_regex(sites_info):
     assert pattern.match(invalid_handle) is None
     assert simple_query(sites_info=sites_info, site=site, username=invalid_handle) is QueryStatus.ILLEGAL
 
+
+def test_trailing_period_does_not_crash_hostname_site(sites_info):
+    # Regression test for #2970. A username ending in a period, when embedded in
+    # a site whose URL places the username in the hostname (e.g. "Empretienda AR"
+    # -> "https://{}.empretienda.com.ar"), produces an empty DNS label
+    # ("alice..empretienda.com.ar"). urllib3 raises LocationParseError for this;
+    # sherlock must surface it as a per-site error, not crash the whole scan.
+    site: str = 'Empretienda AR'
+    trailing_dot_handle: str = 'sherlockfix.'
+    query_notify = QueryNotify()
+    result = sherlock(
+        username=trailing_dot_handle,
+        site_data={site: sites_info[site]},
+        query_notify=query_notify,
+    )
+    status = result[site]['status']
+    assert status.status is QueryStatus.UNKNOWN
+


### PR DESCRIPTION
Closes #2970

## Problem

When a username ends in a period (e.g. `alice.`), sites whose URL embeds the username in the hostname produce an empty DNS label (`alice..empretienda.com.ar`). `urllib3` then raises `urllib3.exceptions.LocationParseError`, which is **not** caught by `get_response()` and propagates through the request future, crashing the entire scan.

## Root cause

`get_response()` in `sherlock_project/sherlock.py` handles `requests.exceptions.*` and `UnicodeError` but not `urllib3.exceptions.LocationParseError`. Because `LocationParseError` is raised during URL/host parsing and isn't wrapped into a `requests.exceptions.RequestException`, it escapes the worker future uncaught.

## Fix

Register a `urllib3.exceptions.LocationParseError` handler in `get_response()` so the malformed-hostname site is recorded as a per-site error (`QueryStatus.UNKNOWN`) instead of aborting the whole run.

## Test

Added `test_trailing_period_does_not_crash_hostname_site` to `tests/test_probes.py`. Verified the test crashes with the exact `LocationParseError` from the issue before the fix and passes after.