### PR TITLE
Remove mastodon.cloud site entry

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -3050,12 +3050,6 @@
     "urlMain": "https://www.livelib.ru/",
     "username_claimed": "blue"
   },
-  "mastodon.cloud": {
-    "errorType": "status_code",
-    "url": "https://mastodon.cloud/@{}",
-    "urlMain": "https://mastodon.cloud/",
-    "username_claimed": "TheAdmin"
-  },
   "mastodon.social": {
     "errorType": "status_code",
     "url": "https://mastodon.social/@{}",


### PR DESCRIPTION
The mastodon.cloud instance appears to be shut down - it now redirects to a hosting provider's generic 'service unavailable' page for every username, including ones that don't exist. This made Sherlock report a false 'Found' result 100% of the time for this site.

Fixes: #3095