### PR TITLE
Remove decommissioned mastodon.cloud (false positive #3095)

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -3050,12 +3050,6 @@
     "urlMain": "https://www.livelib.ru/",
     "username_claimed": "blue"
   },
-  "mastodon.cloud": {
-    "errorType": "status_code",
-    "url": "https://mastodon.cloud/@{}",
-    "urlMain": "https://mastodon.cloud/",
-    "username_claimed": "TheAdmin"
-  },
   "mastodon.social": {
     "errorType": "status_code",
     "url": "https://mastodon.social/@{}",


### PR DESCRIPTION
mastodon.cloud was decommissioned (redirects to a hosting shutdown notice), so it returns 'Found' for every username — 100% false positive. Removing the entry from data.json. Closes #3095.