### PR TITLE
fix(cli): enforce --output single-username guard after wildcard expansion

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -812,6 +812,12 @@ def main():
                 all_usernames.append(name)
         else:
             all_usernames.append(username)
+
+    # Check validity for single username output after wildcard expansion.
+    if args.output is not None and len(all_usernames) != 1:
+        print("You can only use --output with a single username")
+        sys.exit(1)
+
     for username in all_usernames:
         results = sherlock(
             username,

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -1,5 +1,6 @@
 import pytest
 from sherlock_project import sherlock
+from sherlock_project.result import QueryResult, QueryStatus
 from sherlock_interactives import Interactives
 from sherlock_interactives import InteractivesSubprocessError
 
@@ -41,3 +42,34 @@ def test_wildcard_username_expansion():
 def test_no_usernames_provided(cliargs):
     with pytest.raises(InteractivesSubprocessError, match=r"error: the following arguments are required: USERNAMES"):
         Interactives.run_cli(cliargs)
+
+
+@pytest.fixture()
+def offline_sherlock_main(monkeypatch):
+    """Stub out sherlock() and all network access so main() runs fully offline"""
+    def fake(username, site_data, query_notify, **kw):
+        return {'Example': {
+            'url_main': 'https://example.com',
+            'url_user': f'https://example.com/{username}',
+            'status': QueryResult(username, 'Example', f'https://example.com/{username}', QueryStatus.CLAIMED),
+            'http_status': 200,
+            'response_text': b'',
+        }}
+
+    monkeypatch.setattr(sherlock, 'sherlock', fake)
+    monkeypatch.setattr(sherlock.requests, 'get', lambda *a, **kw: (_ for _ in ()).throw(RuntimeError('offline')))
+
+
+def test_output_single_username_enforced_after_wildcard_expansion(tmp_path, monkeypatch, offline_sherlock_main):
+    output_file = tmp_path / 'results.txt'
+    monkeypatch.setattr('sys.argv', [
+        'sherlock',
+        '--local',
+        '--txt',
+        '--output', str(output_file),
+        'user{?}',
+    ])
+    with pytest.raises(SystemExit) as excinfo:
+        sherlock.main()
+    assert excinfo.value.code == 1
+    assert not output_file.exists()


### PR DESCRIPTION
Fixes #3114

## Problem

`--output FILE` is guarded to single-username use, but the guard counts raw CLI args. A `{?}` wildcard username passes as 1 arg, then expands into 3 usernames (`user_`, `user-`, `user.`). The output file is reopened with mode `"w"` on every loop iteration, so each variant's results overwrite the previous — silent data loss with no warning.

## Fix

Enforce the existing design intent **after** expansion: if `--output` is set and the expanded username count is not exactly 1, exit 1 with the same error message the existing pre-expansion guard uses (`You can only use --output with a single username`). No new error path — it reuses the existing guard's message and exit code; the pre-expansion fast-path guard is preserved.

## Testing

- Regression test `test_output_single_username_enforced_after_wildcard_expansion` (offline, drives `main()` with stubbed `sherlock()`/`requests.get`):
  - fails on `master` (file was written 3x, no exit)
  - passes on this branch (exit 1, no file written)
- Full offline suite: `pytest tests -m "not online" -q` → 15 passed
- `ruff check`: zero new findings vs master (byte-identical findings on touched files)
- Adversarial checks: double wildcard, multiple wildcards, duplicate usernames, flag combinations (`--print-found`/`--print-all`) all exit 1 correctly; `{?}` always expands to exactly 3 variants so the guard cannot be bypassed

## Verification

Independently re-verified on a fresh checkout: multi-raw-username behavior unchanged; single-username `--output --txt` still writes normally.
