### PR TITLE
fix(cli): honor --folderoutput for xlsx output

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -924,7 +924,14 @@ def main():
                     "response_time_s": response_time_s,
                 }
             )
-            DataFrame.to_excel(f"{username}.xlsx", sheet_name="sheet1", index=False)
+            result_file = f"{username}.xlsx"
+            if args.folderoutput:
+                # The usernames results should be stored in a targeted folder.
+                # If the folder doesn't exist, create it first
+                os.makedirs(args.folderoutput, exist_ok=True)
+                result_file = os.path.join(args.folderoutput, result_file)
+
+            DataFrame.to_excel(result_file, sheet_name="sheet1", index=False)
 
         print()
     query_notify.finish()

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -1,5 +1,8 @@
+import os
+
 import pytest
 from sherlock_project import sherlock
+from sherlock_project.result import QueryResult, QueryStatus
 from sherlock_interactives import Interactives
 from sherlock_interactives import InteractivesSubprocessError
 
@@ -41,3 +44,34 @@ def test_wildcard_username_expansion():
 def test_no_usernames_provided(cliargs):
     with pytest.raises(InteractivesSubprocessError, match=r"error: the following arguments are required: USERNAMES"):
         Interactives.run_cli(cliargs)
+
+
+def test_xlsx_honors_folderoutput(tmp_path, monkeypatch):
+    def fake(username, site_data, query_notify, **kw):
+        return {'Example': {
+            'url_main': 'https://example.com',
+            'url_user': f'https://example.com/{username}',
+            'status': QueryResult(username, 'Example', f'https://example.com/{username}', QueryStatus.CLAIMED),
+            'http_status': 200,
+            'response_text': b'',
+        }}
+
+    captured = {}
+
+    def spy_to_excel(self, path, *args, **kwargs):
+        captured['path'] = path
+
+    out_dir = tmp_path / 'sub'
+    monkeypatch.setattr(sherlock, 'sherlock', fake)
+    monkeypatch.setattr(sherlock.requests, 'get', lambda *a, **kw: (_ for _ in ()).throw(RuntimeError('offline')))
+    monkeypatch.setattr(sherlock.pd.DataFrame, 'to_excel', spy_to_excel)
+    monkeypatch.setattr('sys.argv', [
+        'sherlock',
+        '--local',
+        '--xlsx',
+        '--folderoutput', str(out_dir),
+        'user_folderoutput',
+    ])
+    sherlock.main()
+    assert out_dir.is_dir()
+    assert captured['path'] == os.path.join(str(out_dir), 'user_folderoutput.xlsx')


### PR DESCRIPTION
Fixes #3115

## Problem

`--folderoutput` is honored by the `--txt` and `--csv` branches, but the `--xlsx` branch hardcodes `DataFrame.to_excel(f"{username}.xlsx", ...)` and always writes to the current working directory, silently ignoring `--folderoutput`.

## Fix

Mirror the csv branch's path handling verbatim in the xlsx branch: `os.makedirs(folderoutput, exist_ok=True)` + `os.path.join(folderoutput, f"{username}.xlsx")`. No changes to txt/csv branches, `--output` handling, or the `response_time_s` logic (#2891/#3077 territory — intentionally untouched).

## Testing

- Regression test `test_xlsx_honors_folderoutput` (offline, spies on `pd.DataFrame.to_excel` to capture the resolved path):
  - fails on `master` (CWD-relative path)
  - passes on this branch (path inside `--folderoutput`)
- Real-write check: nonexistent/nested dir with spaces → auto-created, xlsx lands inside
- Full offline suite: `pytest tests -m "not online" -q` → 15 passed
- `ruff check`: zero new findings vs master

## Verification

Independently re-verified on a fresh checkout: diff touches only the xlsx call site (+8/-1) and tests; csv mirror fidelity confirmed side-by-side; no-`--folderoutput` behavior byte-identical to master.
