### PR TITLE
fix(cli): reject non-finite --timeout values

### DIFF
--- a/sherlock_project/sherlock.py
+++ b/sherlock_project/sherlock.py
@@ -17,6 +17,7 @@ except ImportError:
     sys.exit(1)
 
 import csv
+import math
 import signal
 import pandas as pd
 import os
@@ -507,7 +508,8 @@ def sherlock(
 def timeout_check(value):
     """Check Timeout Argument.
 
-    Checks timeout for validity.
+    Checks timeout for validity. The timeout must be a finite, positive
+    number.
 
     Keyword Arguments:
     value                  -- Time in seconds to wait before timing out request.
@@ -521,9 +523,9 @@ def timeout_check(value):
 
     float_value = float(value)
 
-    if float_value <= 0:
+    if not math.isfinite(float_value) or float_value <= 0:
         raise ArgumentTypeError(
-            f"Invalid timeout value: {value}. Timeout must be a positive number."
+            f"Invalid timeout value: {value}. Timeout must be a finite, positive number."
         )
 
     return float_value

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -1,3 +1,5 @@
+from argparse import ArgumentTypeError
+
 import pytest
 from sherlock_project import sherlock
 from sherlock_interactives import Interactives
@@ -41,3 +43,14 @@ def test_wildcard_username_expansion():
 def test_no_usernames_provided(cliargs):
     with pytest.raises(InteractivesSubprocessError, match=r"error: the following arguments are required: USERNAMES"):
         Interactives.run_cli(cliargs)
+
+
+def test_timeout_check_rejects_nonfinite_values():
+    with pytest.raises(ArgumentTypeError):
+        sherlock.timeout_check('inf')
+    with pytest.raises(ArgumentTypeError):
+        sherlock.timeout_check('nan')
+
+
+def test_timeout_check_accepts_finite_positive_values():
+    assert sherlock.timeout_check('1e5') == 100000.0


### PR DESCRIPTION
Part of #3120.

## Problem

`timeout_check` only rejects values `<= 0`. `--timeout inf` and `--timeout nan` pass validation and crash the entire run with unhandled exceptions from the socket layer (`OverflowError: timestamp out of range for platform time_t` / `ValueError: Invalid value NaN`), escaping `get_response`'s `except` clauses. Huge finite values like `--timeout 1e5` are accepted (user's explicit choice, intentionally not capped here).

## Fix

```python
if not math.isfinite(float_value) or float_value <= 0:
    raise ArgumentTypeError(...)
```

`nan` previously slipped even the `<= 0` check (`nan <= 0` is `False`). Large finite values remain accepted; only non-finite values are rejected. The "huge finite values block indefinitely" half of #3120's title stays out of scope: capping large finite values would override the user's explicit choice, so the issue stays open for it.

## Relation to open PRs #2876 / #2867 / #2955

All three address #2866 (non-numeric input) and keep `if float_value <= 0` unchanged, so `inf`/`nan` pass through all of them. This is complementary; no conflict.

## Testing

- New test `test_timeout_check_rejects_nonfinite_values`: fails on `master` (`DID NOT RAISE`), passes here; `'1e5'` acceptance pinned as a regression guard.
- End-to-end (offline, stubbed network): `--timeout 1e5` → 100000.0 reaches the query layer; `inf`/`nan`/`-5` → clean `SystemExit(2)` instead of a crash.
- Full offline suite: `pytest tests -m "not online" -q` → 16 passed
- `ruff`: findings identical to master (single-line insertion shift only)

## Verification

Independently re-verified on fresh checkout: condition reviewed line-by-line, test proven to bite on master, success paths unchanged end-to-end, `' 1.5 '` whitespace behavior unchanged.
