### PR TITLE
fix(ColourLovers): switch to message errorType to prevent false positives

### DIFF
--- a/sherlock_project/resources/data.json
+++ b/sherlock_project/resources/data.json
@@ -576,7 +576,11 @@
     "username_claimed": "blue"
   },
   "ColourLovers": {
-    "errorType": "status_code",
+    "errorMsg": [
+      "Lover not found",
+      "Nothing here by that name"
+    ],
+    "errorType": "message",
     "url": "https://www.colourlovers.com/lover/{}",
     "urlMain": "https://www.colourlovers.com/",
     "username_claimed": "blue"


### PR DESCRIPTION
## Description
ColourLovers returns an HTTP 200 OK status code even when a requested username does not exist, displaying "Lover not found · COLOURlovers" in the page title and body (soft 404). Because ColourLovers was previously configured with `errorType: status_code`, Sherlock reported all nonexistent usernames as found (false positive).

This PR updates `ColourLovers` in `sherlock_project/resources/data.json`:
- Changes `errorType` from `status_code` to `message`
- Adds `errorMsg` containing `["Lover not found", "Nothing here by that name"]`

Verified against local and remote schema tests (`test_manifest.py`), as well as live query verification of both claimed (`blue`) and nonexistent usernames.

Fixes #3126
